### PR TITLE
fix(fw-button): fixes CSS issues with external CSS

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -23,6 +23,8 @@
   --btn-link-bg: var(--color-smoke-50);
 
   --active-box-shadow: inset 0 0 4px 0 rgba(0, 0, 0, 0.25);
+
+  display: inline-block;
   //=== Button Style===//
 }
 


### PR DESCRIPTION
On setting a margin on the component from outside, it was not getting applied. This fix adds
`display:inline-block` to make the component respect the margin.

fix #134


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested locally on storybook
