### PR TITLE
feat(component): adding DataGrid component

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -5,6 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
+import { Column, Row, } from "./components/data-grid/types";
 export namespace Components {
     interface FwButton {
         /**
@@ -53,6 +54,24 @@ export namespace Components {
           * Identifier corresponding to the component, that is saved when the form data is saved.
          */
         "value": string;
+    }
+    interface FwDataGrid {
+        /**
+          * Columns Array of objects that provides information regarding the columns in the table.
+         */
+        "columns": Column[];
+        /**
+          * isSelectable Boolean based on which selectable options appears for rows in the table.
+         */
+        "isSelectable": boolean;
+        /**
+          * Label attribute is not visible on screen. There for accessibility purposes.
+         */
+        "label": string;
+        /**
+          * Rows Array of objects to be displayed in the table.
+         */
+        "rows": Row[];
     }
     interface FwDatepicker {
         /**
@@ -587,6 +606,12 @@ declare global {
         prototype: HTMLFwCheckboxElement;
         new (): HTMLFwCheckboxElement;
     };
+    interface HTMLFwDataGridElement extends Components.FwDataGrid, HTMLStencilElement {
+    }
+    var HTMLFwDataGridElement: {
+        prototype: HTMLFwDataGridElement;
+        new (): HTMLFwDataGridElement;
+    };
     interface HTMLFwDatepickerElement extends Components.FwDatepicker, HTMLStencilElement {
     }
     var HTMLFwDatepickerElement: {
@@ -698,6 +723,7 @@ declare global {
     interface HTMLElementTagNameMap {
         "fw-button": HTMLFwButtonElement;
         "fw-checkbox": HTMLFwCheckboxElement;
+        "fw-data-grid": HTMLFwDataGridElement;
         "fw-datepicker": HTMLFwDatepickerElement;
         "fw-dropdown-button": HTMLFwDropdownButtonElement;
         "fw-icon": HTMLFwIconElement;
@@ -790,6 +816,28 @@ declare namespace LocalJSX {
           * Identifier corresponding to the component, that is saved when the form data is saved.
          */
         "value"?: string;
+    }
+    interface FwDataGrid {
+        /**
+          * Columns Array of objects that provides information regarding the columns in the table.
+         */
+        "columns"?: Column[];
+        /**
+          * isSelectable Boolean based on which selectable options appears for rows in the table.
+         */
+        "isSelectable"?: boolean;
+        /**
+          * Label attribute is not visible on screen. There for accessibility purposes.
+         */
+        "label"?: string;
+        /**
+          * fwSelectionChange Emits this event when row is selected/unselected.
+         */
+        "onFwSelectionChange"?: (event: CustomEvent<any>) => void;
+        /**
+          * Rows Array of objects to be displayed in the table.
+         */
+        "rows"?: Row[];
     }
     interface FwDatepicker {
         /**
@@ -1414,6 +1462,7 @@ declare namespace LocalJSX {
     interface IntrinsicElements {
         "fw-button": FwButton;
         "fw-checkbox": FwCheckbox;
+        "fw-data-grid": FwDataGrid;
         "fw-datepicker": FwDatepicker;
         "fw-dropdown-button": FwDropdownButton;
         "fw-icon": FwIcon;
@@ -1440,6 +1489,7 @@ declare module "@stencil/core" {
         interface IntrinsicElements {
             "fw-button": LocalJSX.FwButton & JSXBase.HTMLAttributes<HTMLFwButtonElement>;
             "fw-checkbox": LocalJSX.FwCheckbox & JSXBase.HTMLAttributes<HTMLFwCheckboxElement>;
+            "fw-data-grid": LocalJSX.FwDataGrid & JSXBase.HTMLAttributes<HTMLFwDataGridElement>;
             "fw-datepicker": LocalJSX.FwDatepicker & JSXBase.HTMLAttributes<HTMLFwDatepickerElement>;
             "fw-dropdown-button": LocalJSX.FwDropdownButton & JSXBase.HTMLAttributes<HTMLFwDropdownButtonElement>;
             "fw-icon": LocalJSX.FwIcon & JSXBase.HTMLAttributes<HTMLFwIconElement>;

--- a/src/components/checkbox/readme.md
+++ b/src/components/checkbox/readme.md
@@ -35,11 +35,13 @@ fw-checkbox displays a check box on the user interface and enables assigning a s
 
 ### Used by
 
+ - [fw-data-grid](../data-grid)
  - [fw-dropdown-button](../dropdown-button)
 
 ### Graph
 ```mermaid
 graph TD;
+  fw-data-grid --> fw-checkbox
   fw-dropdown-button --> fw-checkbox
   style fw-checkbox fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/components/data-grid/data-grid.e2e.ts
+++ b/src/components/data-grid/data-grid.e2e.ts
@@ -1,0 +1,95 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('fw-data-grid', () => {
+  let page: any;
+  const data: any = {
+    rows: [{
+      'id': '1234',
+      'name': 'Alexander Goodman',
+    }],
+    columns: [{
+      'key': 'name',
+      'text': 'Name',
+      'orderIndex': 1,
+    }],
+  };
+
+  const loadDataIntoGrid = async (gridData: any) => {
+    await page.$eval(
+      'fw-data-grid',
+      (elm: any, data: any) => {
+        Object.assign(elm, data);
+      },
+      gridData
+    );
+  };
+
+  beforeEach(async () => {
+    page = await newE2EPage();
+    await page.setContent('<fw-data-grid></fw-data-grid>');
+    await page.waitForChanges();
+  });
+
+  it('renders', async () => {
+    const element = await page.find('fw-data-grid');
+    expect(element).toHaveClass('hydrated');
+  });
+
+  it('should render rows when table has data', async () => {
+    await loadDataIntoGrid(data);
+    await page.waitForChanges();
+    const row = await page.find('fw-data-grid >>> tbody > tr');
+    expect(row).toBeTruthy();
+  });
+
+  it('should show checkbox when passing isSelectable option', async () => {
+    const currentData = { ...data, isSelectable: true };
+    await loadDataIntoGrid(currentData);
+    await page.waitForChanges();
+    const checkbox = await page.find('fw-data-grid >>> tbody > tr:first-child > td:first-child > fw-checkbox');
+    expect(checkbox).toBeTruthy();
+  });
+
+  it('should trigger fwSelectionChange event when checkbox is checked in a row', async () => {
+    const currentData = { ...data, isSelectable: true };
+    await loadDataIntoGrid(currentData);
+    await page.waitForChanges();
+    const checkbox = await page.find('fw-data-grid >>> tbody > tr:first-child > td:first-child > fw-checkbox');
+    const changedEvent = await page.spyOnEvent('fwSelectionChange');
+    checkbox.click();
+    await page.waitForChanges();
+    const selectedRow = await page.find('fw-data-grid >>> tbody > tr:first-child.active');
+    expect(changedEvent).toHaveReceivedEventTimes(1);
+    expect(selectedRow).toBeTruthy();
+  });
+
+  it('should render in the right column order', async () => {
+    const data = {
+      rows: [
+        {
+          'id': '1234',
+          'name': 'Alexander Goodman',
+          'job': 'Lead designer',
+        },
+      ],
+      columns: [
+        {
+          'key': 'name',
+          'text': 'Name',
+          'orderIndex': 2,
+        },
+        {
+          'key': 'job',
+          'text': 'Job',
+          'orderIndex': 1,
+        },
+      ],
+    };
+    await loadDataIntoGrid(data);
+    await page.waitForChanges();
+    const firstColumn = await page.find('fw-data-grid >>> thead > tr > th:nth-child(1)');
+    const secondColumn = await page.find('fw-data-grid >>> thead > tr > th:nth-child(2)');
+    expect(firstColumn.innerText).toEqual('Job');
+    expect(secondColumn.innerText).toEqual('Name');
+  });
+});

--- a/src/components/data-grid/data-grid.scss
+++ b/src/components/data-grid/data-grid.scss
@@ -1,0 +1,126 @@
+@import "../../styles/freshworks";
+
+:host {
+  --grid-header-bg: var(--color-smoke-10);
+  --grid-body-bg: var(--color-milk);
+  --grid-row-active: var(--color-azure-50);
+  --grid-row-border: var(--color-smoke-50);
+
+  --grid-header-txt-color: var(--color-smoke-700);
+  --grid-row-txt-color: var(--color-elephant-900);
+
+  --grid-header-txt-size: var(--font-size-12);
+  --grid-row-txt-size: var(--font-size-14);
+  --grid-line-height: var(--font-size-20);
+
+  --grid-density-sm: 4px 8px;
+  --grid-density-md: 12px 8px;
+  --grid-density-lg: 16px 8px;
+
+
+  display: inline-block;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+}
+
+table.fw-data-grid {
+  table-layout: fixed;
+  border-collapse: collapse;
+  box-sizing: border-box;
+  min-width: 100%;
+  width: max-content;
+
+  thead {
+    position: sticky;
+    top: 0;
+    background: var(--grid-header-bg);
+    width: 100%;
+    border-radius: 4px;
+
+    tr th {
+      color: var(--grid-header-txt-color);
+      font-size: var(--grid-header-txt-size);
+      line-height: var(--grid-line-height);
+      padding: var(--grid-density-md);
+      font-weight: 600;
+      letter-spacing: 0.2px;
+      text-overflow: ellipsis;
+      text-align: left;
+      z-index: 1;
+
+      &.data-grid-sm {
+        padding: var(--grid-density-sm);
+      }
+
+      &.data-grid-md {
+        padding: var(--grid-density-md);
+      }
+
+      &.data-grid-lg {
+        padding: var(--grid-density-lg);
+      }
+
+      &:first-child {
+        padding-left: 16px;
+      }
+
+      &:last-child {
+        padding-right: 16px;
+      }
+    }
+  }
+
+  tbody {
+    width: 100%;
+    background: var(--grid-body-bg);
+
+    tr {
+      width: 100%;
+      border-bottom: 1px solid var(--grid-row-border);
+
+      &:hover {
+        background: var(--grid-header-bg);
+        cursor: pointer;
+      }
+
+      &.active {
+        background: var(--grid-row-active);
+      }
+
+      td {
+        color: var(--grid-row-txt-color);
+        font-size: var(--grid-row-txt-size);
+        line-height: var(--grid-line-height);
+        padding: var(--grid-density-md);
+        text-overflow: ellipsis;
+        z-index: 0;
+
+        &.data-grid-checkbox {
+          text-align: center;
+          width: 20px;
+        }
+
+        &.data-grid-sm {
+          padding: var(--grid-density-sm);
+        }
+
+        &.data-grid-md {
+          padding: var(--grid-density-md);
+        }
+
+        &.data-grid-lg {
+          padding: var(--grid-density-lg);
+        }
+
+        &:first-child {
+          padding-left: 16px;
+        }
+
+        &:last-child {
+          padding-right: 16px;
+        }
+      }
+    }
+  }
+}

--- a/src/components/data-grid/data-grid.stories.mdx
+++ b/src/components/data-grid/data-grid.stories.mdx
@@ -1,0 +1,136 @@
+import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import { html } from 'lit-html';
+
+export const Template = (args) => (
+  html`
+    <!-- 
+      We cannot pass objects to props in HTML. So, initially load the template empty and then load the props later like in example below,
+      var cmp = document.querySelector('my-comp');
+      cmp.data = arr; // arr is the array you are want to pass
+      (or)
+      React: <fw-data-grid {...args}></fw-data-grid>
+      Vue: <fw-data-grid v-bind="args"></fw-data-grid>
+      Lit: Template below is compiled using lit-html. No spread operator available for passing complex args.
+    -->
+    <fw-data-grid .rows=${args.rows} .columns=${args.columns} is-selectable=${args.isSelectable}></fw-data-grid>
+  `
+);
+
+export const args = {
+  rows: [{
+    "id": "1234",
+    "name": "Alexander Goodman", 
+    "role": "Administrator", 
+    "group": "L1 Support"
+  }, {
+    "id": "2345",
+    "name": "Ambrose Wayne", 
+    "role": "Supervisor", 
+    "group": "L1 Support"
+  }, {
+    "id": "3456",
+    "name": "August hines",
+    "role": "Agent",
+    "group": "L1 support"
+  }],
+  columns: [{
+    "key": "name",
+    "text": "Name",
+    "orderIndex": 1
+  }, {
+    "key": "group",
+    "text": "Group",
+    "orderIndex": 3
+  }, {
+    "key": "role",
+    "text": "Role",
+    "orderIndex": 2
+  }],
+  isSelectable: false
+};
+
+export const argsWithSelect = Object.assign({}, args, { isSelectable: true });
+
+export const argsWithStickyHeader = Object.assign({}, args, { 
+  rows: [{
+    "id": "1234",
+    "name": "Alexander Goodman", 
+    "role": "Administrator", 
+    "group": "L1 Support"
+  }, {
+    "id": "2345",
+    "name": "Ambrose Wayne", 
+    "role": "Supervisor", 
+    "group": "L1 Support"
+  }, {
+    "id": "3456",
+    "name": "August hines",
+    "role": "Agent",
+    "group": "L1 support"
+  }, {
+    "id": "4567",
+    "name": "Jack Newman", 
+    "role": "Administrator", 
+    "group": "L1 Support"
+  }, {
+    "id": "5678",
+    "name": "Rose Pointing", 
+    "role": "Agent", 
+    "group": "L1 Support"
+  }, {
+    "id": "6789",
+    "name": "John Pollock", 
+    "role": "Supervisor", 
+    "group": "L1 Support"
+  }] 
+});
+
+# DataGrid
+
+<Meta
+  title='DataGrid'
+  component='fw-data-grid'
+/>
+
+## Props 
+
+<Props of="fw-data-grid"/>
+
+## Usage
+
+### Default 
+<Preview>
+  <Story 
+    name='Default'
+    args={args}
+  >
+    {Template.bind({})}
+  </Story>
+</Preview>
+
+## with select option
+<Preview>
+  <Story 
+    name='Selectable'
+    args={argsWithSelect}
+  >
+    {Template.bind({})}
+  </Story>
+</Preview>
+
+## Sticky Header
+<Preview>
+  <Story 
+    name='Sticky header'
+    args={argsWithStickyHeader}
+    decorators={[
+      (Story) => {
+        const story = Story();
+        console.log(story);
+        return html`<div style="width: 100%; height: 270px;">${story}</div>`;
+      }
+    ]}
+  >
+    {Template.bind({})}
+  </Story>
+</Preview>

--- a/src/components/data-grid/data-grid.tsx
+++ b/src/components/data-grid/data-grid.tsx
@@ -1,0 +1,175 @@
+import { Component, Event, EventEmitter, Host, Listen, Prop, State, Watch, h } from '@stencil/core';
+
+import { Column, Row } from './types';
+
+@Component({
+  tag: 'fw-data-grid',
+  styleUrl: 'data-grid.scss',
+  shadow: true,
+})
+export class DataGrid {
+
+  /**
+   * Label attribute is not visible on screen. There for accessibility purposes.
+   */
+  @Prop({ mutable: true, reflect: false }) label = '';
+
+  /**
+   * Rows Array of objects to be displayed in the table.
+   */
+  @Prop({ mutable: true, reflect: false }) rows: Row[] = [];
+
+  /**
+   * Columns Array of objects that provides information regarding the columns in the table.
+   */
+  @Prop({ mutable: true, reflect: false }) columns: Column[] = [];
+
+  /**
+   * isSelectable Boolean based on which selectable options appears for rows in the table.
+   */
+  @Prop() isSelectable = false;
+
+  /**
+   * orderedColumns Maintains a collection of ordered columns.
+   */
+  @State() orderedColumns: Column[] = [];
+
+  /**
+   * selected Array of selected row id.
+   */
+  @State() selected: string[] = [];
+
+  /**
+   * fwSelectionChange Emits this event when row is selected/unselected.
+   */
+  @Event() fwSelectionChange: EventEmitter;
+
+  /**
+   * fwChangeHandler
+   */
+  @Listen('fwChange')
+  fwChangeHandler(event) {
+    if (event.detail) {
+      if (event.detail.checked) {
+        this.selected.push(event.detail.value);
+        event.path[0].closest('tr').classList.add('active');
+      } else {
+        this.selected.splice(this.selected.indexOf(event.detail.value), 1);
+        event.path[0].closest('tr').classList.remove('active');
+      }
+      this.fwSelectionChange.emit({
+        rowId: event.detail.value,
+        checked: event.detail.checked,
+        selected: this.selected,
+      });
+    }
+  }
+
+  @Listen('keydown')
+  handleKeyDown(event) {
+    const currentElement: HTMLElement = (event.path[0].nodeName === 'TD') ? event.path[0] : event.path[0].closest('td');
+    const currentRowIndex: number = +currentElement.parentElement.getAttribute('aria-rowIndex');
+    const currentColIndex: number = +currentElement.getAttribute('aria-colIndex');
+    let nextRowIndex: number;
+    let nextColIndex: number;
+    const columnLength: number = (this.isSelectable) ? (this.orderedColumns.length + 1) : this.orderedColumns.length;
+    switch (event.key) {
+      case 'ArrowDown':
+        nextRowIndex = currentRowIndex + 1;
+        nextColIndex = currentColIndex;
+        break;
+      case 'ArrowUp':
+        nextRowIndex = currentRowIndex - 1;
+        nextColIndex = currentColIndex;
+        break;
+      case 'ArrowRight':
+        if (currentColIndex !== columnLength) {
+          nextRowIndex = currentRowIndex;
+          nextColIndex = currentColIndex + 1;
+        } else {
+          nextRowIndex = currentRowIndex + 1;
+          nextColIndex = 1;
+        }
+        break;
+        case 'ArrowLeft':
+        if (currentColIndex !== 1) {
+          nextRowIndex = currentRowIndex;
+          nextColIndex = currentColIndex - 1;
+        } else {
+          nextRowIndex = currentRowIndex - 1;
+          nextColIndex = columnLength;
+        }
+        break;
+      default:
+        break;
+    }
+    const nextCell = event.currentTarget.shadowRoot.querySelector(`[aria-rowIndex="${nextRowIndex}"] > [aria-colIndex="${nextColIndex}"]`);
+    if (nextCell) {
+      const nextFocusCell = (nextCell.dataset.hasComponent) ? nextCell.firstChild : nextCell;
+      currentElement.setAttribute('tabIndex', '-1');
+      nextCell.setAttribute('tabIndex', '0');
+      nextFocusCell.focus();
+    }
+  }
+
+  /**
+   * connectedCallback
+   */
+  connectedCallback() {
+    this.orderedColumns = this.columns.sort((a, b) => {
+      return (a.orderIndex - b.orderIndex);
+    });
+  }
+
+  @Watch('columns')
+  onColumnsChanged(newValue: Column[]) {
+    this.orderedColumns = newValue.sort((a, b) => {
+      return (a.orderIndex - b.orderIndex);
+    });
+  }
+
+  render() {
+    return (
+      <Host>
+        <table class="fw-data-grid" role="grid" aria-colcount={this.orderedColumns.length} aria-label={this.label}>
+          <thead>
+            <tr role="row">
+              { this.orderedColumns.length && this.isSelectable && <th key="isSelectable" aria-colindex={1}></th> }
+              {
+                this.orderedColumns.map((column, columnIndex) =>
+                  <th role="columnheader" key={column.key} aria-colindex={ (this.isSelectable) ? (columnIndex + 2) : (columnIndex + 1) }>
+                    {column.text}
+                  </th>
+                )
+              }
+            </tr>
+          </thead>
+          <tbody>
+            {
+              this.rows.map((row, rowIndex) =>
+                <tr role="row" aria-rowindex={rowIndex + 1}>
+                  {
+                    this.orderedColumns.length && this.isSelectable && <td class="data-grid-checkbox" aria-colindex={1} data-has-component="true">
+                      <fw-checkbox label="" value={ (row.id) ? row.id : '' }></fw-checkbox>
+                    </td>
+                  }
+                  {
+                    this.orderedColumns.map((orderedColumn, columnIndex) =>
+                      <td role="gridcell"
+                        tabindex={ (!this.isSelectable && (rowIndex === 0) && (columnIndex === 0)) ? '0' : '-1' }
+                        aria-colindex={ (this.isSelectable) ? (columnIndex + 2) : (columnIndex + 1) }
+                      >
+                        { row[orderedColumn.key] }
+                      </td>
+                    )
+                  }
+                </tr>
+              )
+            }
+          </tbody>
+        </table>
+      </Host>
+    );
+  }
+
+}

--- a/src/components/data-grid/readme.md
+++ b/src/components/data-grid/readme.md
@@ -1,0 +1,99 @@
+# DataGrid (fw-data-grid)
+fw-data-grid are used for data visualization.
+
+## Usage
+
+```html live
+<template>
+  <!-- 
+    In HTML we cannot pass objects as attributes to custom elements. 
+    So, here vue template is used to load data into datagrid for demo purposes. 
+    You must use fw-data-grid like in example below incase of React/Stencil projects:
+    <fw-data-grid columns={headers} rows={persons} isSelectable></fw-data-grid>
+  -->
+  <fw-data-grid ref="datagrid"></fw-data-grid>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      headers: [{
+        "key": "name",
+        "text": "Name",
+        "orderIndex": 1
+      }, {
+        "key": "group",
+        "text": "Group",
+        "orderIndex": 3
+      }, {
+        "key": "role",
+        "text": "Role",
+        "orderIndex": 2
+      }],
+      persons: [{
+        "id": 1234,
+        "name": "Alexander Goodman", 
+        "role": "Administrator", 
+        "group": "L1 Support"
+      }, {
+        "id": 2345,
+        "name": "Ambrose Wayne", 
+        "role": "Supervisor", 
+        "group": "L1 Support"
+      }, {
+        "id": 3456,
+        "name": "August hines",
+        "role": "Agent",
+        "group": "L1 support"
+      }],
+      isSelectable: true,
+      label: "Hello world"
+    }
+  },
+  mounted() {
+    this.$refs.datagrid.columns = this.headers;
+    this.$refs.datagrid.rows = this.persons;
+    this.$refs.datagrid.isSelectable = this.isSelectable;
+    this.$refs.datagrid.label = this.label;
+  }
+};
+</script>
+```
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property       | Attribute       | Description                                                                            | Type       | Default |
+| -------------- | --------------- | -------------------------------------------------------------------------------------- | ---------- | ------- |
+| `columns`      | --              | Columns Array of objects that provides information regarding the columns in the table. | `Column[]` | `[]`    |
+| `isSelectable` | `is-selectable` | isSelectable Boolean based on which selectable options appears for rows in the table.  | `boolean`  | `false` |
+| `label`        | `label`         | Label attribute is not visible on screen. There for accessibility purposes.            | `string`   | `''`    |
+| `rows`         | --              | Rows Array of objects to be displayed in the table.                                    | `Row[]`    | `[]`    |
+
+
+## Events
+
+| Event               | Description                                                         | Type               |
+| ------------------- | ------------------------------------------------------------------- | ------------------ |
+| `fwSelectionChange` | fwSelectionChange Emits this event when row is selected/unselected. | `CustomEvent<any>` |
+
+
+## Dependencies
+
+### Depends on
+
+- [fw-checkbox](../checkbox)
+
+### Graph
+```mermaid
+graph TD;
+  fw-data-grid --> fw-checkbox
+  style fw-data-grid fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+Built with ❤ at Freshworks

--- a/src/components/data-grid/types.ts
+++ b/src/components/data-grid/types.ts
@@ -1,0 +1,12 @@
+interface Column {
+  key: string,
+  text: string,
+  orderIndex: number
+}
+
+interface Row {
+  id: string;
+  [prop: string]: any;
+}
+
+export { Column, Row };

--- a/src/styles/variables/_colors.scss
+++ b/src/styles/variables/_colors.scss
@@ -12,6 +12,7 @@
   --color-smoke-100: #cfd7df;
   --color-smoke-50: #ebeff3;
   --color-smoke-25: #f3f5f7;
+  --color-smoke-10: #f5f7f9;
 
   --color-jungle-800: #00795b;
   --color-jungle-500: #00a886;


### PR DESCRIPTION
DataGrid component is used for data visualization.

DataGrid is a component used for data visualization. To try the component, use the `npm run build` command. Build storybook from the 'storybook-dist' folder. To open the Vuepress documentation use the 'docs-dist' folder.
Passing objects to custom elements as props is not allowed in HTML, in places where we are showing code in documentation, tried to show how we can add datatables in various framework's templates.

NOTES:

- Using Table and related tags for creating the layout of the component.
  -  Table element seems to have better browser support. When trying to replicate table component with div tags, faced a couple of issues. Like CSS grid layout having only partial support(older version of specification) in IE. Some important aria tags that are necessary also don't seem to have good browser support. Trying to replicate what table or css grid does through JS would cost us too much later.  Most libraries have gone ahead with using table tags for the same reasons. 
  - https://caniuse.com/css-grid
  - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Gridcell_role#best_practices
  - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Gridcell_role#accessibility_concerns
- Not introducing Table headers/rows as a separate component. Using props to populate children in this component.
  - Table tags don't seem to support Shadow DOM as per specs.
  - https://dom.spec.whatwg.org/#dom-element-attachshadow
  - Table specs have limited permitted content. Don't seem to appreciate non-semantic elements in between table components. 
  - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table
  - All components in Crayons seem to be using ShadowDOM. So didnt want to create components that break the general rule.
  - Table row component might not be used anywhere else outside a table/grid. Components that looks similar are usually  list elements.
- Unlike row and header choice, planning to create pagination as a separate component in crayons. That will be consumed in data-grid.



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Manually verified variations in Storybook and Vuepress docs. Added tests for the component.
