### PR TITLE
feat(fw-toggle): adding support for showicon and keyboard navigation

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -550,15 +550,27 @@ export namespace Components {
         /**
           * Sets the selected state as the default state. If the attribute’s value is undefined, the value is set to false.
          */
+        "active": boolean;
+        /**
+          * @deprecated use active instead. Sets the selected state as the default state. If the attribute’s value is undefined, the value is set to false.
+         */
         "checked": boolean;
         /**
           * Specifies whether to disable the control on the interface. If the attribute’s value is undefined, the value is set to false.
          */
         "disabled": boolean;
         /**
+          * Label for the component, that can be used by screen readers.
+         */
+        "label": string;
+        /**
           * Name of the component, saved as part of the form data.
          */
         "name": string;
+        /**
+          * Specifies whether to show the check and cancel icons on toggle button. If the attribute’s value is undefined, the value is set to false.
+         */
+        "showicon": boolean;
         /**
           * Size of the input control.
          */
@@ -1375,11 +1387,19 @@ declare namespace LocalJSX {
         /**
           * Sets the selected state as the default state. If the attribute’s value is undefined, the value is set to false.
          */
+        "active"?: boolean;
+        /**
+          * @deprecated use active instead. Sets the selected state as the default state. If the attribute’s value is undefined, the value is set to false.
+         */
         "checked"?: boolean;
         /**
           * Specifies whether to disable the control on the interface. If the attribute’s value is undefined, the value is set to false.
          */
         "disabled"?: boolean;
+        /**
+          * Label for the component, that can be used by screen readers.
+         */
+        "label"?: string;
         /**
           * Name of the component, saved as part of the form data.
          */
@@ -1388,6 +1408,10 @@ declare namespace LocalJSX {
           * Triggered when the input control is selected or deselected.
          */
         "onFwChange"?: (event: CustomEvent<any>) => void;
+        /**
+          * Specifies whether to show the check and cancel icons on toggle button. If the attribute’s value is undefined, the value is set to false.
+         */
+        "showicon"?: boolean;
         /**
           * Size of the input control.
          */

--- a/packages/crayons-core/src/components/toggle/readme.md
+++ b/packages/crayons-core/src/components/toggle/readme.md
@@ -14,12 +14,13 @@ fw-toggle displays an input control that enables modifying an element’s state 
 
 ## Properties
 
-| Property   | Attribute  | Description                                                                                                                  | Type                             | Default    |
-| ---------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ---------- |
-| `checked`  | `checked`  | Sets the selected state as the default state. If the attribute’s value is undefined, the value is set to false.              | `boolean`                        | `false`    |
-| `disabled` | `disabled` | Specifies whether to disable the control on the interface. If the attribute’s value is undefined, the value is set to false. | `boolean`                        | `false`    |
-| `name`     | `name`     | Name of the component, saved as part of the form data.                                                                       | `string`                         | `''`       |
-| `size`     | `size`     | Size of the input control.                                                                                                   | `"large" \| "medium" \| "small"` | `'medium'` |
+| Property   | Attribute  | Description                                                                                                                                                                                   | Type                             | Default    |
+| ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ---------- |
+| `active`   | `active`   | Sets the selected state as the default state. If the attribute’s value is undefined, the value is set to false.                                                                               | `boolean`                        | `false`    |
+| `checked`  | `checked`  | <span style="color:red">**[DEPRECATED]**</span> use active instead. Sets the selected state as the default state. If the attribute’s value is undefined, the value is set to false.<br/><br/> | `boolean`                        | `false`    |
+| `disabled` | `disabled` | Specifies whether to disable the control on the interface. If the attribute’s value is undefined, the value is set to false.                                                                  | `boolean`                        | `false`    |
+| `name`     | `name`     | Name of the component, saved as part of the form data.                                                                                                                                        | `string`                         | `''`       |
+| `size`     | `size`     | Size of the input control.                                                                                                                                                                    | `"large" \| "medium" \| "small"` | `'medium'` |
 
 
 ## Events

--- a/packages/crayons-core/src/components/toggle/toggle.e2e.ts
+++ b/packages/crayons-core/src/components/toggle/toggle.e2e.ts
@@ -12,10 +12,10 @@ describe('fw-toggle', () => {
   it('it renders with check', async () => {
     const page = await newE2EPage();
 
-    await page.setContent('<fw-toggle checked></fw-toggle>');
+    await page.setContent('<fw-toggle active></fw-toggle>');
     const element = await page.find('fw-toggle');
-    const isChecked = await element.getProperty('checked');
-    expect(isChecked).toBe(true);
+    const isActive = await element.getProperty('active');
+    expect(isActive).toBe(true);
   });
 
   it('it emits fwChange when clicked', async () => {
@@ -25,7 +25,17 @@ describe('fw-toggle', () => {
     const element = await page.find('fw-toggle');
     const fwChange = await page.spyOnEvent('fwChange');
     await element.click();
-    expect(fwChange).toHaveReceivedEventDetail({ checked: true });
+    expect(fwChange).toHaveReceivedEventDetail({ active: true });
+  });
+
+  it('it emits fwChange when enter/space key is pressed', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<fw-toggle></fw-toggle>');
+    const element = await page.find('fw-toggle');
+    const fwChange = await page.spyOnEvent('fwChange');
+    await element.press('Space')
+    expect(fwChange).toHaveReceivedEventDetail({ active: true });
   });
 
   it('it should not emit fwChange when disabled', async () => {
@@ -37,4 +47,5 @@ describe('fw-toggle', () => {
     await element.click();
     expect(fwChange.events).toEqual([]);
   });
+
 });

--- a/packages/crayons-core/src/components/toggle/toggle.scss
+++ b/packages/crayons-core/src/components/toggle/toggle.scss
@@ -1,5 +1,38 @@
 $toggle-on-bg: #2c5cc5;
 
+:host {
+  --checkIcon: url('data:image/svg+xml;utf8,\
+  <svg width="8px" height="6px" viewBox="0 0 8 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">\
+    <style>\
+      svg{color: rgb(44, 92, 197) }\
+    </style>\
+    <g id="Icons-✅" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">\
+      <g id="Icons" transform="translate(-494.000000, -2525.000000)" fill="currentColor">\
+        <g id="icon/check" transform="translate(494.000000, 2525.000000)">\
+          <g id="check">\
+            <path d="M3,5.87 C2.81333186,5.87267463 2.63332891,5.80067345 2.5,5.67 L0.21,3.41 C0.031367205,3.23136721 -0.0383968428,2.97100423 0.0269872981,2.7269873 C0.092371439,2.48297036 0.282970362,2.29237144 0.526987298,2.2269873 C0.771004234,2.16160316 1.03136721,2.23136721 1.21,2.41 L3,4.18 L6.8,0.33 C7.07679776,0.0554444353 7.52320224,0.0554444353 7.8,0.33 C7.93696438,0.460253055 8.01450026,0.640989153 8.01450026,0.83 C8.01450026,1.01901085 7.93696438,1.19974694 7.8,1.33 L3.45,5.67 C3.32917466,5.78896945 3.16927265,5.86003701 3,5.87 Z" id="Path"></path>\
+          </g>\
+        </g>\
+      </g>\
+    </g>\
+  </svg>');
+  --cancelIcon: url('data:image/svg+xml;utf8,\
+  <svg width="6px" height="6px" viewBox="0 0 6 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">\
+    <style>\
+      svg{color: rgb(100,122,142) }\
+    </style>\
+    <g id="Icons-✅" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"> \
+      <g id="Icons" transform="translate(-495.000000, -2261.000000)" fill="currentColor"> \
+        <g id="icon/cross" transform="translate(495.000000, 2261.000000)"> \
+          <g id="cross" transform="translate(-1.000000, -1.000000)"> \
+            <path d="M3.00678571,3.985 L1.18,2.17 C0.903857625,1.89385763 0.903857625,1.44614237 1.18,1.17 C1.45614237,0.893857625 1.90385763,0.893857625 2.18,1.17 L4.00411003,2.99411003 L5.83,1.18 C6.10614237,0.903857625 6.55385763,0.903857625 6.83,1.18 C7.10614237,1.45614237 7.10614237,1.90385763 6.83,2.18 L5.00608602,3.99608602 L6.83,5.82 C7.02335713,6.02244677 7.0797026,6.31961464 6.97387278,6.57878972 C6.86804295,6.8379648 6.61979681,7.01075775 6.34,7.02 L6.33,7 C6.14188674,7.00002687 5.96167928,6.92433974 5.83,6.79 L4.01309415,4.98481612 L2.17,6.82 C2.03347281,6.94339035 1.85384766,7.0080554 1.67,7 C1.39020319,6.99075775 1.14195705,6.8179648 1.03612722,6.55878972 C0.930297399,6.29961464 0.986642873,6.00244677 1.18,5.8 L3.00678571,3.985 Z" id="Combined-Shape"></path> \
+          </g> \
+        </g> \
+      </g> \
+    </g> \
+  </svg>');
+}
+
 *,
 ::after,
 ::before {
@@ -62,6 +95,9 @@ $toggle-on-bg: #2c5cc5;
     background-color: $app-secondary-btn;
     -webkit-transition: 0.2s;
     transition: 0.2s;
+    background-image: var(--bg-img);
+    background-repeat: no-repeat;
+    background-position: center;
   }
 
   .slider.small {
@@ -74,6 +110,7 @@ $toggle-on-bg: #2c5cc5;
       left: 0;
       bottom: -2px;
       border: solid 1px #647a8e;
+      background-size: 6px 6px;
     }
 
     &:hover::before,
@@ -92,6 +129,7 @@ $toggle-on-bg: #2c5cc5;
       left: 0;
       bottom: -2px;
       border: solid 1px #647a8e;
+      background-size: 8px 8px;
     }
 
     &:hover::before,
@@ -110,6 +148,7 @@ $toggle-on-bg: #2c5cc5;
       left: 0;
       bottom: -2px;
       border: solid 1px #647a8e;
+      background-size: 10px 10px;
     }
 
     &:hover::before,

--- a/packages/crayons-core/src/components/toggle/toggle.tsx
+++ b/packages/crayons-core/src/components/toggle/toggle.tsx
@@ -1,4 +1,4 @@
-import { Component, Event, EventEmitter, Prop, Watch, h } from '@stencil/core';
+import { Component, Event, Element, EventEmitter, Prop, Watch, h, Host } from '@stencil/core';
 
 import { handleKeyDown } from '../../utils/utils';
 @Component({
@@ -7,7 +7,13 @@ import { handleKeyDown } from '../../utils/utils';
   shadow: true,
 })
 export class Toggle {
+  @Element() host!: HTMLElement;
   /**
+   * Sets the selected state as the default state. If the attribute’s value is undefined, the value is set to false.
+   */
+   @Prop() active = false;
+  /**
+   * @deprecated use active instead.
    * Sets the selected state as the default state. If the attribute’s value is undefined, the value is set to false.
    */
   @Prop({ mutable: true }) checked = false;
@@ -24,47 +30,85 @@ export class Toggle {
    */
   @Prop() disabled = false;
   /**
+   * Specifies whether to show the check and cancel icons on toggle button. If the attribute’s value is undefined, the value is set to false.
+   */
+  @Prop() showicon = false;
+  /**
+   * Label for the component, that can be used by screen readers.
+   */
+  @Prop() label = '';
+  /**
    * Triggered when the input control is selected or deselected.
    */
   @Event() fwChange: EventEmitter;
 
-  @Watch('checked')
+  connectedCallback() {
+    if(this.showicon) {
+      if(this.active) {
+        this.host.style.setProperty('--bg-img', 'var(--checkIcon)');
+      } else {
+        this.host.style.setProperty('--bg-img', 'var(--cancelIcon)');
+      }
+    }
+  }
+
+  handleKeyDown(ev: KeyboardEvent) {
+    if(ev.code === 'Space' || ev.code === 'Enter') {
+      ev.preventDefault();
+      this.toggle();
+    }
+  }
+
+  @Watch('active')
   watchHandler(newValue: boolean) {
-    this.fwChange.emit({ checked: newValue });
+    if(this.showicon) {
+      if(this.active) {
+        this.host.style.setProperty('--bg-img', 'var(--checkIcon)');
+      } else {
+        this.host.style.setProperty('--bg-img', 'var(--cancelIcon)');
+      }
+    }
+    this.fwChange.emit({ active: newValue });
   }
 
   private toggle = (): void => {
     if (!this.disabled) {
-      this.checked = !this.checked;
+      this.active = !this.active;
     }
   };
 
   render() {
     return (
-      <div
-        role='button'
-        tabindex='0'
+      <Host
+      onClick={() => this.toggle()}
+      onKeyDown={(ev) => this.handleKeyDown(ev)}
+      tabindex="0" 
+      role="switch"
+      aria-disabled={this.disabled ? 'true' : 'false'}
+      aria-checked={`${this.active}`}
+      aria-label={`${this.label}`}
+      >
+        <div
         class={{
           'toggle-switch': true,
           [this.size]: true,
         }}
-        onClick={() => this.toggle()}
-        onKeyDown={handleKeyDown(this.toggle)}
-      >
-        <input
-          name={this.name}
-          type='checkbox'
-          disabled={this.disabled}
-          checked={this.checked}
-          class='checkboxClass'
-        />
-        <span
-          class={{
-            slider: true,
-            [this.size]: true,
-          }}
-        ></span>
-      </div>
+        >
+          <input
+            name={this.name}
+            type='checkbox'
+            disabled={this.disabled}
+            checked={this.active}
+            class='checkboxClass'
+          />
+          <span
+            class={{
+              slider: true,
+              [this.size]: true,
+            }}
+          ></span>
+        </div>
+      </Host>
     );
   }
 }


### PR DESCRIPTION
Adding capability to show icon based on flag and fix a11y issues and add support for keyboard
navigation


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
