### PR TITLE
feat(custom-react-wrapper): use Custom React Wrapper instead of Stencil's react wrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38856,6 +38856,15 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "dev": true
     },
+    "node_modules/react-output-target": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/react-output-target/-/react-output-target-0.0.8.tgz",
+      "integrity": "sha512-s8jD1KY8qJUgBjBfKosN4T+Tbv0Km9aSLxxFMLMFb3KmOt5cHtwI3C7QUG1OSzBiLNci06mZIz5zfC5k3FY5HA==",
+      "dev": true,
+      "peerDependencies": {
+        "@stencil/core": ">=2.9.0"
+      }
+    },
     "node_modules/react-popper": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
@@ -48514,6 +48523,7 @@
         "react-docgen-typescript-loader": "^3.7.2",
         "react-dom": "^17.0.2",
         "react-is": "^17.0.2",
+        "react-output-target": "^0.0.8",
         "sass-loader": "^10.1.1",
         "semantic-release": "^17.4.2",
         "ts-loader": "9.2.1",
@@ -49016,6 +49026,7 @@
         "react-docgen-typescript-loader": "^3.7.2",
         "react-dom": "^17.0.2",
         "react-is": "^17.0.2",
+        "react-output-target": "^0.0.8",
         "sass-loader": "^10.1.1",
         "semantic-release": "^17.4.2",
         "ts-loader": "^9.2.1",
@@ -50858,6 +50869,7 @@
         "react-docgen-typescript-loader": "^3.7.2",
         "react-dom": "^17.0.2",
         "react-is": "^17.0.2",
+        "react-output-target": "^0.0.8",
         "sass-loader": "^10.1.1",
         "semantic-release": "^17.4.2",
         "ts-loader": "9.2.1",
@@ -51200,6 +51212,7 @@
         "react-docgen-typescript-loader": "^3.7.2",
         "react-dom": "^17.0.2",
         "react-is": "^17.0.2",
+        "react-output-target": "^0.0.8",
         "sass-loader": "^10.1.1",
         "semantic-release": "^17.4.2",
         "ts-loader": "^9.2.1",
@@ -79574,6 +79587,13 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "dev": true
+    },
+    "react-output-target": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/react-output-target/-/react-output-target-0.0.8.tgz",
+      "integrity": "sha512-s8jD1KY8qJUgBjBfKosN4T+Tbv0Km9aSLxxFMLMFb3KmOt5cHtwI3C7QUG1OSzBiLNci06mZIz5zfC5k3FY5HA==",
+      "dev": true,
+      "requires": {}
     },
     "react-popper": {
       "version": "2.2.5",

--- a/packages/crayons-core/package.json
+++ b/packages/crayons-core/package.json
@@ -86,6 +86,7 @@
     "react-docgen-typescript-loader": "^3.7.2",
     "react-dom": "^17.0.2",
     "react-is": "^17.0.2",
+    "react-output-target": "^0.0.8",
     "sass-loader": "^10.1.1",
     "semantic-release": "^17.4.2",
     "ts-loader": "9.2.1",
@@ -107,5 +108,6 @@
   "bugs": {
     "url": "https://github.com/freshworks/crayons/issues"
   },
-  "homepage": "https://github.com/freshworks/crayons#readme"
+  "homepage": "https://github.com/freshworks/crayons#readme",
+  "sideEffects": false
 }

--- a/packages/crayons-core/stencil.config.ts
+++ b/packages/crayons-core/stencil.config.ts
@@ -1,5 +1,5 @@
 import { Config } from '@stencil/core';
-import { reactOutputTarget } from '@stencil/react-output-target';
+import { reactOutputTarget } from 'react-output-target';
 import { sass } from '@stencil/sass';
 
 import { generateJsonDocs } from './customElementDocGenerator';

--- a/packages/crayons-datatable/package.json
+++ b/packages/crayons-datatable/package.json
@@ -75,6 +75,7 @@
     "react-docgen-typescript-loader": "^3.7.2",
     "react-dom": "^17.0.2",
     "react-is": "^17.0.2",
+    "react-output-target": "^0.0.8",
     "sass-loader": "^10.1.1",
     "semantic-release": "^17.4.2",
     "ts-loader": "^9.2.1",
@@ -97,5 +98,6 @@
   "bugs": {
     "url": "https://github.com/freshworks/crayons/issues"
   },
-  "homepage": "https://github.com/freshworks/crayons#readme"
+  "homepage": "https://github.com/freshworks/crayons#readme",
+  "sideEffects": false
 }

--- a/packages/crayons-datatable/stencil.config.ts
+++ b/packages/crayons-datatable/stencil.config.ts
@@ -1,5 +1,5 @@
 import { Config } from '@stencil/core';
-import { reactOutputTarget } from '@stencil/react-output-target';
+import { reactOutputTarget } from 'react-output-target';
 import { sass } from '@stencil/sass';
 
 import { generateJsonDocs } from './customElementDocGenerator';


### PR DESCRIPTION

Stencil React wrapper does not have auto-import and register custom elements for dependent
components. Stencil released this feature in v2.9 but this is not yet implemented in React Wrapper.

This is a custom react wrapper based on Stencil's react wrapper which implements auto-import and
register custom elements for dependent components.  - https://github.com/arvindanta/stencil-react-wrapper

This also enables tree-shaking.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested by importing the React components in the test react app and found the tree shaking and auto import feature to be working fine.