### PR TITLE
fix(radio-group): remove call to componentOnReady in connected callback

### DIFF
--- a/packages/crayons-core/src/components/radio-group/radio-group.tsx
+++ b/packages/crayons-core/src/components/radio-group/radio-group.tsx
@@ -25,7 +25,7 @@ export class RadioGroup {
   @Element() host!: HTMLElement;
 
   private selectedIndex = 0;
-  private radiosPromise;
+  private radios;
 
   /**
    * If true, a radio group can be saved without selecting any option. If an option is selected, the selection can be cleared. If the attribute’s value is undefined, the value is set to false.
@@ -73,8 +73,8 @@ export class RadioGroup {
   }
 
   @Listen('keyup')
-  async handleKeyup(event: KeyboardEvent) {
-    const radios = await this.radiosPromise;
+  handleKeyup(event: KeyboardEvent) {
+    const radios = this.radios;
     const previousSelected = this.selectedIndex;
     switch (event.code) {
       case 'ArrowDown':
@@ -118,18 +118,7 @@ export class RadioGroup {
 
   async connectedCallback() {
     const el = this.host;
-
-    /**
-     * Make sure we start radio's componentOnReady promise as soon as possible in the component
-     * lifecycle and maintain a reference to the returned promise so that it can be reused.
-     * We are not using await explictly here as the radio group rendering might get
-     * affected if any of the radio's componentonReady is resolved later than expected.
-     */
-    this.radiosPromise = Promise.all(
-      Array.from(this.host.querySelectorAll('fw-radio')).map((r) =>
-        r.componentOnReady()
-      )
-    );
+    this.radios = Array.from(this.host.querySelectorAll('fw-radio'));
 
     this.host.style.display = 'flex';
     this.host.style.flexDirection = this.orientation;
@@ -178,7 +167,7 @@ export class RadioGroup {
      * so values are up to date prior
      * to caching the radio group value
      */
-    const radios = await this.radiosPromise;
+    const radios = this.radios;
     const { value } = this;
 
     let hasChecked = false;


### PR DESCRIPTION
Call to componentOnReady is removed


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
This is tested by rendering the component in the CRA for react o/p target and verified it for web component by rendering it in index.html
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
