### PR TITLE
fix(popover): prevent scroll chaining and expose props for min, max heights

### DIFF
--- a/packages/crayons-core/src/components/popover/popover.scss
+++ b/packages/crayons-core/src/components/popover/popover.scss
@@ -1,4 +1,6 @@
 /**
+  @prop --popover-min-width: Minimum width of the popover content.
+  @prop --popover-max-width: Maximum width of the popover content.
   @prop --popover-min-height: Minimum height of the popover content.
   @prop --popover-max-height: Maximum height of the popover content.
 */
@@ -6,6 +8,8 @@
 .popper-content {
   display: none;
   z-index: 99;
+  min-width: var(--popover-min-width);
+  max-width: var(--popover-max-width);
   min-height: var(--popover-min-height, 10px);
   max-height: var(--popover-max-height, 400px);
   overflow-y: scroll;

--- a/packages/crayons-core/src/components/popover/popover.scss
+++ b/packages/crayons-core/src/components/popover/popover.scss
@@ -1,15 +1,16 @@
-:host {
-  --popover-min-height: 10px;
-  --popover-max-height: 400px;
-}
+/**
+  @prop --popover-min-height: Minimum height of the popover content.
+  @prop --popover-max-height: Maximum height of the popover content.
+*/
 
 .popper-content {
   display: none;
   z-index: 99;
-  min-height: var(--popover-min-height);
-  max-height: var(--popover-max-height);
+  min-height: var(--popover-min-height, 10px);
+  max-height: var(--popover-max-height, 400px);
   overflow-y: scroll;
   overflow-x: hidden;
+  overscroll-behavior-y: contain;
   margin: 0px;
   border-radius: 8px;
   border: 1px solid $app-border-secondary;

--- a/packages/crayons-core/src/components/popover/readme.md
+++ b/packages/crayons-core/src/components/popover/readme.md
@@ -81,6 +81,14 @@ Type: `Promise<void>`
 
 
 
+## CSS Custom Properties
+
+| Name                   | Description                            |
+| ---------------------- | -------------------------------------- |
+| `--popover-max-height` | Maximum height of the popover content. |
+| `--popover-min-height` | Minimum height of the popover content. |
+
+
 ## Dependencies
 
 ### Used by

--- a/packages/crayons-core/src/components/popover/readme.md
+++ b/packages/crayons-core/src/components/popover/readme.md
@@ -86,7 +86,9 @@ Type: `Promise<void>`
 | Name                   | Description                            |
 | ---------------------- | -------------------------------------- |
 | `--popover-max-height` | Maximum height of the popover content. |
+| `--popover-max-width`  | Maximum width of the popover content.  |
 | `--popover-min-height` | Minimum height of the popover content. |
+| `--popover-min-width`  | Minimum width of the popover content.  |
 
 
 ## Dependencies


### PR DESCRIPTION
-  `--popover-min-height` and `--popover-max-height` were defined at the `:host` selector, so passing them as props was not possible if we need to change heights.
- Add `overscroll-behavior-y`to prevent scroll chaining. In scenarios where we have one select inside another select, upon reaching the end of inner scroll, outer scroll starts to happen, preventing this behaviour by adding this prop.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
