### PR TITLE
feat(slider): Adding new slider variation to modal component

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -340,6 +340,10 @@ export namespace Components {
          */
         "size": 'standard' | 'small' | 'large';
         /**
+          * Convert modal to slider
+         */
+        "slider": boolean;
+        /**
           * The color of submit button
          */
         "submitColor": 'primary' | 'secondary' | 'danger' | 'link' | 'text';
@@ -385,10 +389,6 @@ export namespace Components {
         "submitText": string;
     }
     interface FwModalTitle {
-        /**
-          * Function to call on close of modal
-         */
-        "close": any;
         /**
           * The title text to be displayed on the modal
          */
@@ -1470,6 +1470,10 @@ declare namespace LocalJSX {
          */
         "size"?: 'standard' | 'small' | 'large';
         /**
+          * Convert modal to slider
+         */
+        "slider"?: boolean;
+        /**
           * The color of submit button
          */
         "submitColor"?: 'primary' | 'secondary' | 'danger' | 'link' | 'text';
@@ -1515,10 +1519,6 @@ declare namespace LocalJSX {
         "submitText"?: string;
     }
     interface FwModalTitle {
-        /**
-          * Function to call on close of modal
-         */
-        "close"?: any;
         /**
           * The title text to be displayed on the modal
          */

--- a/packages/crayons-core/src/components/button/button.tsx
+++ b/packages/crayons-core/src/components/button/button.tsx
@@ -112,7 +112,9 @@ export class Button {
   }
 
   private async modalTrigger() {
-    const modal: any = document.getElementById(this.modalTriggerId);
+    const modal: any = document.querySelector(
+      `fw-modal#${this.modalTriggerId}`
+    );
     modal.open();
   }
 

--- a/packages/crayons-core/src/components/modal-content/modal-content.scss
+++ b/packages/crayons-core/src/components/modal-content/modal-content.scss
@@ -1,6 +1,10 @@
+:host {
+  flex: 1;
+  overflow-y: auto;
+}
+
 .content {
-  padding: 0 32px 32px;
-  height: 100%;
-  width: auto;
-  overflow: auto;
+  padding: 0px 32px 32px;
+  overflow: visible;
+  box-sizing: border-box;
 }

--- a/packages/crayons-core/src/components/modal-content/readme.md
+++ b/packages/crayons-core/src/components/modal-content/readme.md
@@ -5,6 +5,19 @@ Displays the content inside the component.
 <!-- Auto Generated Below -->
 
 
+## Dependencies
+
+### Used by
+
+ - [fw-modal](../modal)
+
+### Graph
+```mermaid
+graph TD;
+  fw-modal --> fw-modal-content
+  style fw-modal-content fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 Built with ❤ at Freshworks

--- a/packages/crayons-core/src/components/modal-title/modal-title.scss
+++ b/packages/crayons-core/src/components/modal-title/modal-title.scss
@@ -27,26 +27,4 @@
   .icon {
     margin-right: 8px;
   }
-
-  .close-btn {
-    background-color: transparent;
-    background-image: none;
-    border: 1px solid transparent;
-    color: #264966;
-    padding: 4px 6px;
-    min-width: 16px;
-    height: 24px;
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    transition: all 0.3s;
-
-    &:hover,
-    &:focus {
-      background-color: #ebeff3;
-      border-radius: 4px;
-      border-color: #ebeff3;
-      cursor: pointer;
-    }
-  }
 }

--- a/packages/crayons-core/src/components/modal-title/modal-title.tsx
+++ b/packages/crayons-core/src/components/modal-title/modal-title.tsx
@@ -30,12 +30,6 @@ export class ModalTitle {
   custom = null;
 
   /**
-   * Function to call on close of modal
-   */
-  // eslint-disable-next-line  @typescript-eslint/no-empty-function
-  @Prop() close: any = () => {};
-
-  /**
    * lifecycle event, called once just after the component is first connected to the DOM
    */
   componentWillLoad() {
@@ -73,9 +67,6 @@ export class ModalTitle {
             </div>
           )}
         </div>
-        <button class='close-btn' onClick={() => this.close()}>
-          <fw-icon name='cross-big' />
-        </button>
       </div>
     );
   }

--- a/packages/crayons-core/src/components/modal-title/readme.md
+++ b/packages/crayons-core/src/components/modal-title/readme.md
@@ -7,7 +7,6 @@
 
 | Property      | Attribute     | Description                                 | Type     | Default     |
 | ------------- | ------------- | ------------------------------------------- | -------- | ----------- |
-| `close`       | `close`       | Function to call on close of modal          | `any`    | `() => {}`  |
 | `description` | `description` | The title text to be displayed on the modal | `string` | `undefined` |
 | `icon`        | `icon`        | The icon to be displayed with the title     | `string` | `''`        |
 | `titleText`   | `title-text`  | The title text to be displayed on the modal | `string` | `undefined` |

--- a/packages/crayons-core/src/components/modal/modal.e2e.ts
+++ b/packages/crayons-core/src/components/modal/modal.e2e.ts
@@ -50,4 +50,12 @@ describe('fw-modal', () => {
     await page.waitForChanges();
     expect(footer).toBe(null);
   });
+
+  it('should open slider variant of modal when prop slider is passed to the component', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<fw-modal is-open slider>Hello world</fw-modal>');
+    await page.waitForChanges();
+    const slider = await page.find('fw-modal >>> .modal-overlay.slider');
+    expect(slider).not.toBeNull();
+  });
 });

--- a/packages/crayons-core/src/components/modal/modal.scss
+++ b/packages/crayons-core/src/components/modal/modal.scss
@@ -1,7 +1,6 @@
 /* stylelint-disable a11y/media-prefers-reduced-motion */
-@import '../../styles/freshworks.scss';
 
-.modal-container {
+.modal-overlay {
   height: 100vh;
   width: 100vw;
   position: fixed;
@@ -19,19 +18,47 @@
 
 .modal {
   position: relative;
-  max-height: 70vh;
-  background: #fff;
-  border-radius: 4px;
   display: flex;
+  max-height: 70vh;
+  background: $color-milk;
+  border-radius: 4px;
   z-index: 999;
-  flex-direction: column;
   animation: 'modal-entry' 0.5s 1;
 
-  .content {
-    padding: 0 32px 32px;
-    height: 100%;
-    width: auto;
-    overflow: auto;
+  .modal-container {
+    position: relative;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+
+    .content {
+      padding: 0px 32px 32px;
+      overflow: visible;
+      box-sizing: border-box;
+    }
+  }
+
+  .close-btn {
+    background-color: transparent;
+    background-image: none;
+    border: 1px solid transparent;
+    color: $color-elephant-800;
+    padding: 4px 6px;
+    min-width: 16px;
+    height: 24px;
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    transition: all 0.3s;
+    z-index: 1;
+
+    &:hover,
+    &:focus {
+      background-color: $color-smoke-50;
+      border-radius: 4px;
+      border-color: $color-smoke-50;
+      cursor: pointer;
+    }
   }
 }
 
@@ -47,6 +74,47 @@
   width: 800px;
 }
 
+.modal-overlay.slider {
+  justify-content: right;
+
+  .modal {
+    height: 100vh;
+    max-height: 100vh;
+    border-radius: 0px;
+    width: 600px;
+    animation: 'modal-entry-right' 0.5s 1;
+
+    .close-btn {
+      height: 40px;
+      width: 40px;
+      top: 0px;
+      right: 600px;
+      background-color: $color-elephant-900;
+      border-radius: 2px 0px 0px 2px;
+
+      &:hover,
+      &:focus,
+      &:focus-visible {
+        background-color: $color-elephant-900;
+        border-radius: 2px 0px 0px 2px;
+        border: 0px;
+      }
+
+      &:focus,
+      &:focus-visible {
+        border: 1px solid $color-azure-800;
+        box-shadow: $color-azure-800 0px 0px 0px 1px;
+      }
+    }
+
+    &.small,
+    &.standard,
+    &.large {
+      width: 600px;
+    }
+  }
+}
+
 .visible {
   display: flex;
 }
@@ -58,5 +126,15 @@
 
   100% {
     transform: translateY(0);
+  }
+}
+
+@keyframes modal-entry-right {
+  0% {
+    transform: translateX(calc(100% - 590px));
+  }
+
+  100% {
+    transform: translateX(0);
   }
 }

--- a/packages/crayons-core/src/components/modal/modal.stories.mdx
+++ b/packages/crayons-core/src/components/modal/modal.stories.mdx
@@ -59,15 +59,37 @@ Sed pulvinar orci in lacus semper, nec volutpat lectus pellentesque. Aliquam dic
       () => `
       <fw-button modal-trigger-id='large'> Open custom composed modal </fw-button>
       <fw-modal id='large' size="large">
-        <fw-modal-title custom>
-          <div>
-            <span style="font-weight: bold;">Header text</span>
-          </div>
+        <fw-modal-title>
+          <span>Header text</span>
         </fw-modal-title>
         <fw-modal-content>
           <div>Content text</div>
         </fw-modal-content>
-        <fw-modal-footer custom>
+        <fw-modal-footer>
+          <fw-button>OK</fw-button>
+        </fw-modal-footer>
+      </fw-modal>
+      `
+    }
+  </Story>
+</Preview>
+
+
+### Slider
+
+<Preview>
+  <Story name='Slider'>
+    {
+      () => `
+      <fw-button modal-trigger-id='modal-slider'> Open slider </fw-button>
+      <fw-modal id='modal-slider' slider='true' hide-footer='true'>
+        <fw-modal-title>
+          <span>Header text</span>
+        </fw-modal-title>
+        <fw-modal-content>
+          <div>Content text</div>
+        </fw-modal-content>
+        <fw-modal-footer>
           <fw-button>OK</fw-button>
         </fw-modal-footer>
       </fw-modal>

--- a/packages/crayons-core/src/components/modal/modal.tsx
+++ b/packages/crayons-core/src/components/modal/modal.tsx
@@ -94,6 +94,11 @@ export class Modal {
   @Prop() hideFooter = false;
 
   /**
+   * Convert modal to slider
+   */
+  @Prop() slider = false;
+
+  /**
    * Toggle the visibility of the modal
    */
   @Prop({ mutable: true, reflect: true }) isOpen = false;
@@ -126,14 +131,26 @@ export class Modal {
   escapeHandler = null;
 
   /**
+   * private
+   * styleVariation styles that vary in normal and slider variations
+   */
+  styleVariation = {
+    closeColor: {
+      modal: '#5D7587',
+      slider: '#FFFFFF',
+    },
+    closeSize: {
+      modal: 10,
+      slider: 12,
+    },
+  };
+
+  /**
    * lifecycle event, called once just after the component is first connected to the DOM
    */
   componentWillLoad() {
     if (!this.modalTitle) {
       this.modalTitle = this.el.querySelector('fw-modal-title');
-      if (this.modalTitle) {
-        this.modalTitle.close = this.close.bind(this);
-      }
     }
     if (!this.modalFooter) {
       this.modalFooter = this.el.querySelector('fw-modal-footer');
@@ -145,14 +162,32 @@ export class Modal {
     if (!this.modalContent) {
       this.modalContent = this.el.querySelector('fw-modal-content');
     }
+    if (this.hideFooter && this.modalFooter) {
+      // Removes footer when footer is added by composition.
+      this.modalFooter.parentNode.removeChild(this.modalFooter);
+    }
+    if (!this.modalContent && (this.modalTitle || this.modalFooter)) {
+      /**
+       * Error that occurs when fw-modal-header or fw-modal-footer is used without
+       * fw-modal-content component. If this not handled, the content that goes inside
+       * fw-modal-content would have fw-modal-header or fw-modal-footer.
+       * This would lead to unexpected results such as header or footer having padding and scroll.
+       */
+      throw new Error(
+        'Composition Error: fw-modal component must have fw-modal-content component when \
+         either fw-modal-header or fw-modal-footer components are used for modal composition'
+      );
+    }
   }
 
   @Watch('isOpen')
   visibilityChange(open: boolean) {
     if (!open) {
+      document.body.style.overflow = 'auto';
       this.removeAccesibilityEvents();
       this.fwClose.emit();
     } else {
+      document.body.style.overflow = 'hidden';
       this.addAccesibilityEvents();
       this.fwOpen.emit();
     }
@@ -285,7 +320,6 @@ export class Modal {
         icon={this.icon}
         titleText={this.titleText}
         description={this.description}
-        close={this.close.bind(this)}
       ></fw-modal-title>
     );
   }
@@ -296,9 +330,9 @@ export class Modal {
    */
   renderContent(): JSX.Element {
     return (
-      <div class='content'>
+      <fw-modal-content>
         <slot></slot>
-      </div>
+      </fw-modal-content>
     );
   }
 
@@ -325,12 +359,36 @@ export class Modal {
    * @returns {JSX.Element}
    */
   render(): JSX.Element {
+    const variation = this.styleVariation;
     return (
-      <div class={{ 'modal-container': true, 'visible': this.isOpen }}>
+      <div
+        class={{
+          'modal-overlay': true,
+          'visible': this.isOpen,
+          'slider': this.slider,
+        }}
+      >
         <div class={{ modal: true, [this.size]: true }} aria-modal='true'>
-          {this.modalTitle ? '' : this.renderTitle()}
-          {this.modalContent ? <slot></slot> : this.renderContent()}
-          {this.hideFooter ? '' : this.modalFooter ? '' : this.renderFooter()}
+          <button class='close-btn' onClick={() => this.close()}>
+            <fw-icon
+              name='cross-big'
+              color={
+                this.slider
+                  ? variation.closeColor.slider
+                  : variation.closeColor.modal
+              }
+              size={
+                this.slider
+                  ? variation.closeSize.slider
+                  : variation.closeSize.modal
+              }
+            />
+          </button>
+          <div class='modal-container'>
+            {this.modalTitle ? '' : this.renderTitle()}
+            {this.modalContent ? <slot></slot> : this.renderContent()}
+            {this.hideFooter ? '' : this.modalFooter ? '' : this.renderFooter()}
+          </div>
         </div>
       </div>
     );

--- a/packages/crayons-core/src/components/modal/readme.md
+++ b/packages/crayons-core/src/components/modal/readme.md
@@ -15,7 +15,16 @@ Modals are used as an overlay to display information. It can also be used as con
 
   <fw-button modal-trigger-id='welcome-large'> Open Large Modal </fw-button>
   <fw-modal id='welcome-large' title-text="Welcome" size="large" submit-disabled="true">
-    Hello, Welcome to Crayons
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque nec vulputate erat. Nulla eu sagittis felis. Sed vel porta felis, vitae sollicitudin enim. Mauris id tellus vel elit tincidunt cursus eu eget nisl. Nunc fringilla massa ac magna dapibus accumsan. Aliquam vehicula lacinia ipsum sed vehicula. Aenean pharetra suscipit nibh, ac sollicitudin justo. Suspendisse vulputate nisl auctor ornare mattis. Morbi vitae tellus ac purus faucibus aliquet ac nec purus.
+    Etiam nec dolor vitae mi tincidunt ultricies nec eu augue. Donec eget odio auctor, accumsan eros et, tristique diam. In lacinia neque a laoreet scelerisque. Suspendisse est ipsum, varius eget consequat a, varius vel nunc. Pellentesque posuere ipsum sapien, non consectetur massa pellentesque eu. In hac habitasse platea dictumst. Nulla quis tincidunt arcu, ac lacinia arcu. Donec ac tellus eu velit auctor rhoncus.
+    Aenean at eros nibh. Duis a nibh sed eros elementum sagittis. Sed erat tellus, mattis vitae mi id, condimentum bibendum purus. Nulla eget accumsan ipsum. Aenean dolor odio, tristique vel aliquam vel, faucibus eu ligula. Nulla sodales nisl pretium purus finibus, non ultricies dolor tempus. Cras felis arcu, varius a ipsum sed, laoreet laoreet diam. Donec accumsan tortor sed aliquet tempus. Pellentesque maximus, dolor sed imperdiet faucibus, neque dolor viverra lorem, ac vulputate odio purus vitae erat. Sed mollis ac orci et viverra. Curabitur sagittis, leo placerat vestibulum rutrum, leo diam ornare ligula, id sodales nisi augue vitae sapien. In hac habitasse platea dictumst. Vestibulum suscipit metus sed risus placerat, sit amet pretium lectus malesuada. Pellentesque pellentesque, mi et hendrerit elementum, augue lectus lobortis risus, ornare commodo ex odio vitae lectus.
+    Phasellus ut purus felis. Proin et turpis ac leo lacinia pulvinar ut et diam. Donec elit enim, semper sed maximus non, tristique quis turpis. Donec venenatis ante dapibus elementum sagittis. Maecenas consequat lectus sit amet ipsum tempor tincidunt. Praesent velit est, volutpat sed malesuada sed, molestie efficitur sem. Vivamus tellus risus, feugiat eu sagittis sed, eleifend vel elit. Vivamus semper porta tempor. Maecenas ut nulla mauris.
+    Sed pulvinar orci in lacus semper, nec volutpat lectus pellentesque. Aliquam dictum suscipit tellus, eu rutrum nulla tincidunt vitae. Interdum et malesuada fames ac ante ipsum primis in faucibus. Aliquam egestas, diam eu tincidunt ullamcorper, dui libero lacinia augue, non fermentum augue libero eget diam. Quisque at interdum erat. Sed lobortis sit amet mauris nec rutrum. Aliquam sit amet risus iaculis, tempor lectus commodo, varius ipsum.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque nec vulputate erat. Nulla eu sagittis felis. Sed vel porta felis, vitae sollicitudin enim. Mauris id tellus vel elit tincidunt cursus eu eget nisl. Nunc fringilla massa ac magna dapibus accumsan. Aliquam vehicula lacinia ipsum sed vehicula. Aenean pharetra suscipit nibh, ac sollicitudin justo. Suspendisse vulputate nisl auctor ornare mattis. Morbi vitae tellus ac purus faucibus aliquet ac nec purus.
+    Etiam nec dolor vitae mi tincidunt ultricies nec eu augue. Donec eget odio auctor, accumsan eros et, tristique diam. In lacinia neque a laoreet scelerisque. Suspendisse est ipsum, varius eget consequat a, varius vel nunc. Pellentesque posuere ipsum sapien, non consectetur massa pellentesque eu. In hac habitasse platea dictumst. Nulla quis tincidunt arcu, ac lacinia arcu. Donec ac tellus eu velit auctor rhoncus.
+    Aenean at eros nibh. Duis a nibh sed eros elementum sagittis. Sed erat tellus, mattis vitae mi id, condimentum bibendum purus. Nulla eget accumsan ipsum. Aenean dolor odio, tristique vel aliquam vel, faucibus eu ligula. Nulla sodales nisl pretium purus finibus, non ultricies dolor tempus. Cras felis arcu, varius a ipsum sed, laoreet laoreet diam. Donec accumsan tortor sed aliquet tempus. Pellentesque maximus, dolor sed imperdiet faucibus, neque dolor viverra lorem, ac vulputate odio purus vitae erat. Sed mollis ac orci et viverra. Curabitur sagittis, leo placerat vestibulum rutrum, leo diam ornare ligula, id sodales nisi augue vitae sapien. In hac habitasse platea dictumst. Vestibulum suscipit metus sed risus placerat, sit amet pretium lectus malesuada. Pellentesque pellentesque, mi et hendrerit elementum, augue lectus lobortis risus, ornare commodo ex odio vitae lectus.
+    Phasellus ut purus felis. Proin et turpis ac leo lacinia pulvinar ut et diam. Donec elit enim, semper sed maximus non, tristique quis turpis. Donec venenatis ante dapibus elementum sagittis. Maecenas consequat lectus sit amet ipsum tempor tincidunt. Praesent velit est, volutpat sed malesuada sed, molestie efficitur sem. Vivamus tellus risus, feugiat eu sagittis sed, eleifend vel elit. Vivamus semper porta tempor. Maecenas ut nulla mauris.
+    Sed pulvinar orci in lacus semper, nec volutpat lectus pellentesque. Aliquam dictum suscipit tellus, eu rutrum nulla tincidunt vitae. Interdum et malesuada fames ac ante ipsum primis in faucibus. Aliquam egestas, diam eu tincidunt ullamcorper, dui libero lacinia augue, non fermentum augue libero eget diam. Quisque at interdum erat. Sed lobortis sit amet mauris nec rutrum. Aliquam sit amet risus iaculis, tempor lectus commodo, varius ipsum.
   </fw-modal>
 ```
 
@@ -104,19 +113,14 @@ function App() {
 #### Custom composition Demo
 
 ```html live 
-  <fw-button modal-trigger-id='composition'> Open modal </fw-button>
-  <fw-modal id='composition'>
+  <fw-button modal-trigger-id='composition'> Open confirmation Modal </fw-button>
+  <fw-modal id='composition' size="small" submit-color="danger" submit-text="Delete">
     <fw-modal-title>
-      <div>
-        <span style="font-weight: bold;">Header text</span>
-      </div>
+      <span>Delete message</span>
     </fw-modal-title>
     <fw-modal-content>
-      <div>Content text</div>
+      <span>Are you sure you want to delete this Message?</span>
     </fw-modal-content>
-    <fw-modal-footer>
-      <fw-button>OK</fw-button>
-    </fw-modal-footer>
   </fw-modal>
 ```
 
@@ -125,19 +129,14 @@ function App() {
 <code-group>
 <code-block title="HTML">
 ```html 
-  <fw-button modal-trigger-id='composition'> Open modal </fw-button>
-  <fw-modal id='composition'>
+  <fw-button modal-trigger-id='composition'> Open confirmation Modal </fw-button>
+  <fw-modal id='composition' size="small" submit-color="danger" submit-text="Delete">
     <fw-modal-title>
-      <div>
-        <span style="font-weight: bold;">Header text</span>
-      </div>
+      <span>Delete message</span>
     </fw-modal-title>
     <fw-modal-content>
-      <div>Content text</div>
+      <span>Are you sure you want to delete this Message?</span>
     </fw-modal-content>
-    <fw-modal-footer>
-      <fw-button>OK</fw-button>
-    </fw-modal-footer>
   </fw-modal>
 ```
 </code-block>
@@ -149,20 +148,15 @@ import ReactDOM from "react-dom";
 import { FwButton, FwModal, FwModalTitle, FwModalContent, FwModalFooter } from "@freshworks/crayons/react";
 function App() {
   return (<div>
-      <FwButton modalTriggerId='composition'> Open modal </FwButton>
-      <FwModal id='composition'>
-        <FwModalTitle>
-          <div>
-            <span style="font-weight: bold;">Header text</span>
-          </div>
-        </FwModalTitle>
-        <FwModalContent>
-          <div>Content text</div>
-        </FwModalContent>
-        <FwModalFooter>
-          <FwButton>OK</FwButton>
-        </FwModalFooter>
-      </FwModal>
+    <FwButton modal-trigger-id='composition'> Open confirmation Modal </FwButton>
+    <FwModal id='composition' size="small" submit-color="danger" submit-text="Delete">
+      <FwModalTitle>
+        <span>Delete message</span>
+      </FwModalTitle>
+      <FwModalContent>
+        <span>Are you sure you want to delete this Message?</span>
+      </FwModalContent>
+    </FwModal>
  </div>);
 }
 ```
@@ -176,7 +170,7 @@ function App() {
   <fw-button modal-trigger-id='large'> Open modal </fw-button>
   <fw-modal id='large' icon="agent" size="large" hide-footer="true">
     <fw-modal-title>
-      <span style="font-weight: bold;">Header text</span>
+      <span>Header text</span>
     </fw-modal-title>
     <fw-modal-content>
       <div>Content text</div>
@@ -192,7 +186,7 @@ function App() {
   <fw-button modal-trigger-id='large'> Open modal </fw-button>
   <fw-modal id='large' icon="agent" size="large" hide-footer="true">
     <fw-modal-title>
-      <span style="font-weight: bold;">Header text</span>
+      <span>Header text</span>
     </fw-modal-title>
     <fw-modal-content>
       <div>Content text</div>
@@ -211,12 +205,91 @@ function App() {
       <FwButton modalTriggerId='large'> Open modal </FwButton>
       <FwModal id='large' icon="agent" size="large" hideFooter>
         <FwModalTitle>
-          <span style="font-weight: bold;">Header text</span>
+          <span>Header text</span>
         </FwModalTitle>
         <FwModalContent>
           <div>Content text</div>
         </FwModalContent>
       </fw-modal>
+ </div>);
+}
+```
+</code-block>
+</code-group>
+
+#### Slider
+
+This is a variation of model that takes the entire viewport as height and slides from right of the screen when entering. Properties and composition are same as modal with the exception of size property. Slider has only one standard size.
+
+```html live 
+  <fw-button modal-trigger-id='modal-slider'> Open slider </fw-button>
+  <fw-modal id='modal-slider' slider='true'>
+    <fw-modal-title>
+      <span>Header text</span>
+    </fw-modal-title>
+    <fw-modal-content>
+      <div>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque nec vulputate erat. Nulla eu sagittis felis. Sed vel porta felis, vitae sollicitudin enim. Mauris id tellus vel elit tincidunt cursus eu eget nisl. Nunc fringilla massa ac magna dapibus accumsan. Aliquam vehicula lacinia ipsum sed vehicula. Aenean pharetra suscipit nibh, ac sollicitudin justo. Suspendisse vulputate nisl auctor ornare mattis. Morbi vitae tellus ac purus faucibus aliquet ac nec purus.
+        Etiam nec dolor vitae mi tincidunt ultricies nec eu augue. Donec eget odio auctor, accumsan eros et, tristique diam. In lacinia neque a laoreet scelerisque. Suspendisse est ipsum, varius eget consequat a, varius vel nunc. Pellentesque posuere ipsum sapien, non consectetur massa pellentesque eu. In hac habitasse platea dictumst. Nulla quis tincidunt arcu, ac lacinia arcu. Donec ac tellus eu velit auctor rhoncus.
+        Aenean at eros nibh. Duis a nibh sed eros elementum sagittis. Sed erat tellus, mattis vitae mi id, condimentum bibendum purus. Nulla eget accumsan ipsum. Aenean dolor odio, tristique vel aliquam vel, faucibus eu ligula. Nulla sodales nisl pretium purus finibus, non ultricies dolor tempus. Cras felis arcu, varius a ipsum sed, laoreet laoreet diam. Donec accumsan tortor sed aliquet tempus. Pellentesque maximus, dolor sed imperdiet faucibus, neque dolor viverra lorem, ac vulputate odio purus vitae erat. Sed mollis ac orci et viverra. Curabitur sagittis, leo placerat vestibulum rutrum, leo diam ornare ligula, id sodales nisi augue vitae sapien. In hac habitasse platea dictumst. Vestibulum suscipit metus sed risus placerat, sit amet pretium lectus malesuada. Pellentesque pellentesque, mi et hendrerit elementum, augue lectus lobortis risus, ornare commodo ex odio vitae lectus.
+        Phasellus ut purus felis. Proin et turpis ac leo lacinia pulvinar ut et diam. Donec elit enim, semper sed maximus non, tristique quis turpis. Donec venenatis ante dapibus elementum sagittis. Maecenas consequat lectus sit amet ipsum tempor tincidunt. Praesent velit est, volutpat sed malesuada sed, molestie efficitur sem. Vivamus tellus risus, feugiat eu sagittis sed, eleifend vel elit. Vivamus semper porta tempor. Maecenas ut nulla mauris.
+        Sed pulvinar orci in lacus semper, nec volutpat lectus pellentesque. Aliquam dictum suscipit tellus, eu rutrum nulla tincidunt vitae. Interdum et malesuada fames ac ante ipsum primis in faucibus. Aliquam egestas, diam eu tincidunt ullamcorper, dui libero lacinia augue, non fermentum augue libero eget diam. Quisque at interdum erat. Sed lobortis sit amet mauris nec rutrum. Aliquam sit amet risus iaculis, tempor lectus commodo, varius ipsum.
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque nec vulputate erat. Nulla eu sagittis felis. Sed vel porta felis, vitae sollicitudin enim. Mauris id tellus vel elit tincidunt cursus eu eget nisl. Nunc fringilla massa ac magna dapibus accumsan. Aliquam vehicula lacinia ipsum sed vehicula. Aenean pharetra suscipit nibh, ac sollicitudin justo. Suspendisse vulputate nisl auctor ornare mattis. Morbi vitae tellus ac purus faucibus aliquet ac nec purus.
+        Etiam nec dolor vitae mi tincidunt ultricies nec eu augue. Donec eget odio auctor, accumsan eros et, tristique diam. In lacinia neque a laoreet scelerisque. Suspendisse est ipsum, varius eget consequat a, varius vel nunc. Pellentesque posuere ipsum sapien, non consectetur massa pellentesque eu. In hac habitasse platea dictumst. Nulla quis tincidunt arcu, ac lacinia arcu. Donec ac tellus eu velit auctor rhoncus.
+        Aenean at eros nibh. Duis a nibh sed eros elementum sagittis. Sed erat tellus, mattis vitae mi id, condimentum bibendum purus. Nulla eget accumsan ipsum. Aenean dolor odio, tristique vel aliquam vel, faucibus eu ligula. Nulla sodales nisl pretium purus finibus, non ultricies dolor tempus. Cras felis arcu, varius a ipsum sed, laoreet laoreet diam. Donec accumsan tortor sed aliquet tempus. Pellentesque maximus, dolor sed imperdiet faucibus, neque dolor viverra lorem, ac vulputate odio purus vitae erat. Sed mollis ac orci et viverra. Curabitur sagittis, leo placerat vestibulum rutrum, leo diam ornare ligula, id sodales nisi augue vitae sapien. In hac habitasse platea dictumst. Vestibulum suscipit metus sed risus placerat, sit amet pretium lectus malesuada. Pellentesque pellentesque, mi et hendrerit elementum, augue lectus lobortis risus, ornare commodo ex odio vitae lectus.
+        Phasellus ut purus felis. Proin et turpis ac leo lacinia pulvinar ut et diam. Donec elit enim, semper sed maximus non, tristique quis turpis. Donec venenatis ante dapibus elementum sagittis. Maecenas consequat lectus sit amet ipsum tempor tincidunt. Praesent velit est, volutpat sed malesuada sed, molestie efficitur sem. Vivamus tellus risus, feugiat eu sagittis sed, eleifend vel elit. Vivamus semper porta tempor. Maecenas ut nulla mauris.
+        Sed pulvinar orci in lacus semper, nec volutpat lectus pellentesque. Aliquam dictum suscipit tellus, eu rutrum nulla tincidunt vitae. Interdum et malesuada fames ac ante ipsum primis in faucibus. Aliquam egestas, diam eu tincidunt ullamcorper, dui libero lacinia augue, non fermentum augue libero eget diam. Quisque at interdum erat. Sed lobortis sit amet mauris nec rutrum. Aliquam sit amet risus iaculis, tempor lectus commodo, varius ipsum.
+      </div>
+    </fw-modal-content>
+    <fw-modal-footer>
+      <fw-button>OK</fw-button>
+    </fw-modal-footer>
+  </fw-modal>
+```
+
+#### Slider Usage
+
+<code-group>
+<code-block title="HTML">
+```html 
+  <fw-button modal-trigger-id='modal-slider'> Open slider </fw-button>
+  <fw-modal id='modal-slider' slider='true'>
+    <fw-modal-title>
+      <span>Header text</span>
+    </fw-modal-title>
+    <fw-modal-content>
+      <div>
+        Context text.
+      </div>
+    </fw-modal-content>
+    <fw-modal-footer>
+      <fw-button>OK</fw-button>
+    </fw-modal-footer>
+  </fw-modal>
+```
+</code-block>
+
+<code-block title="React">
+```jsx
+import React from "react";
+import ReactDOM from "react-dom";
+import { FwButton, FwModal, FwModalTitle, FwModalContent, FwModalFooter } from "@freshworks/crayons/react";
+function App() {
+  return (<div>
+      <FwButton modal-trigger-id='modal-slider'>Hello</FwButton>
+      <FwModal id='modal-slider' slider>
+        <FwModalTitle>
+          <span>Header text</span>
+        </FwModalTitle>
+        <FwModalContent>
+          <div>
+            Context text.
+          </div>
+        </FwModalContent>
+        <FwModalFooter>
+          <FwButton>OK</FwButton>
+        </FwModalFooter>
+      </FwModal>
  </div>);
 }
 ```
@@ -236,6 +309,7 @@ function App() {
 | `icon`           | `icon`            | The icon to be displayed with the title           | `string`                                                   | `''`         |
 | `isOpen`         | `is-open`         | Toggle the visibility of the modal                | `boolean`                                                  | `false`      |
 | `size`           | `size`            | Size of the modal                                 | `"large" \| "small" \| "standard"`                         | `'standard'` |
+| `slider`         | `slider`          | Convert modal to slider                           | `boolean`                                                  | `false`      |
 | `submitColor`    | `submit-color`    | The color of submit button                        | `"danger" \| "link" \| "primary" \| "secondary" \| "text"` | `'primary'`  |
 | `submitDisabled` | `submit-disabled` | Default state of submit button                    | `boolean`                                                  | `false`      |
 | `submitText`     | `submit-text`     | The text for the submit button                    | `string`                                                   | `'OK'`       |
@@ -280,6 +354,7 @@ promise that resolves to true
 
 - [fw-icon](../icon)
 - [fw-modal-title](../modal-title)
+- [fw-modal-content](../modal-content)
 - [fw-modal-footer](../modal-footer)
 
 ### Graph
@@ -287,6 +362,7 @@ promise that resolves to true
 graph TD;
   fw-modal --> fw-icon
   fw-modal --> fw-modal-title
+  fw-modal --> fw-modal-content
   fw-modal --> fw-modal-footer
   fw-modal-title --> fw-icon
   fw-modal-footer --> fw-button


### PR DESCRIPTION
Added Slider as a new variation to the existing Modal component. 

Code:
```
<fw-button modal-trigger-id='modal-slider'> Open slider </fw-button>
<fw-modal id='modal-slider' slider='true'>
  <fw-modal-title>
    <span style="font-weight: bold;">Header text</span>
  </fw-modal-title>
  <fw-modal-content>
    <div>Content text</div>
  </fw-modal-content>
  <fw-modal-footer>
    <fw-button>OK</fw-button>
  </fw-modal-footer>
</fw-modal>
```

How to run vuepress sample:
1. From root of project run `npm run build` && `npm run docs:dev`
2. Open the link that shows up in console after running both commands.
3. Navigate to Modals in sidebar.
4. Scroll down to sliders section.

Screenshot:
<img width="900" alt="Screenshot 2021-11-18 at 10 27 09 AM" src="https://user-images.githubusercontent.com/61269786/142354569-d557cada-3461-4120-a3b2-4426bfae6de7.png">

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested the implementation when documenting. The variation seems to work fine in both vuepress and storybook.
Tested by importing react version of slider in sample react application.