### PR TITLE
fix(button-group): use correct units for margin-left

### DIFF
--- a/packages/crayons-core/src/components/button/button.scss
+++ b/packages/crayons-core/src/components/button/button.scss
@@ -372,7 +372,7 @@ $sizes:
 
 :host(.fw-button-group__button--inner) .fw-btn {
   border-radius: 0;
-  margin-left: -1;
+  margin-left: -1px;
   border-left: 0;
 }
 
@@ -380,6 +380,6 @@ $sizes:
   .fw-btn {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-  margin-left: -1;
+  margin-left: -1px;
   border-left: 0;
 }


### PR DESCRIPTION
- Use correct units for `margin-left` property without which the property would not be valid and will not be applied as expected.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
