### PR TITLE
fix(toast): remove styling from host to avoid styles getting overridden by global styles

### DIFF
--- a/packages/crayons-core/src/components/toast-message/toast-message.e2e.ts
+++ b/packages/crayons-core/src/components/toast-message/toast-message.e2e.ts
@@ -15,10 +15,10 @@ describe('fw-toast-message', () => {
     await page.setContent(
       '<fw-toast-message content="Successfully created!" action-link-text="Undo"></fw-toast-message>'
     );
-    const element = await page.find('fw-toast-message');
+    const element = await page.find('fw-toast-message >>> .toast');
     element.classList.add('is-open');
 
-    const content = await page.find('fw-toast-message >>> .content');
+    const content = await element.find('.content');
     expect(content.innerHTML).toEqual(
       '<slot></slot>Successfully created!<div class="action-link" role="button" tabindex="0">Undo</div>'
     );
@@ -34,11 +34,11 @@ describe('fw-toast-message', () => {
     await page.setContent(
       '<fw-toast-message type="warning"></fw-toast-message>'
     );
-    const element = await page.find('fw-toast-message');
+    const element = await page.find('fw-toast-message >>> .toast');
     element.classList.add('is-open');
     await page.waitForChanges();
 
-    const divElem = await page.find('fw-toast-message');
+    const divElem = await page.find('fw-toast-message >>> .toast');
     expect(divElem).toHaveClass('warning');
   });
 
@@ -48,13 +48,13 @@ describe('fw-toast-message', () => {
     await page.setContent(
       '<fw-toast-message type="inprogress"></fw-toast-message>'
     );
-    const element = await page.find('fw-toast-message');
+    const element = await page.find('fw-toast-message >>> .toast');
     element.classList.add('is-open');
 
-    const closeIcon = await page.find('fw-toast-message >>> .remove');
+    const closeIcon = await element.find('.remove');
     expect(closeIcon).toBeTruthy();
 
-    const spinner = await page.find('fw-toast-message >>> fw-spinner');
+    const spinner = await element.find('fw-spinner');
     expect(spinner).toBeTruthy();
   });
 });

--- a/packages/crayons-core/src/components/toast-message/toast-message.scss
+++ b/packages/crayons-core/src/components/toast-message/toast-message.scss
@@ -1,21 +1,18 @@
-:host {
-  display: none;
-}
-
 @media screen and (prefers-reduced-motion: reduce) {
-  :host(.is-open) {
+  .toast.is-open {
     animation: none;
   }
 }
 
-:host(.is-open) {
+.toast.is-open {
   display: block;
   animation-duration: 0.5s;
   animation-name: fadeIn;
   z-index: 999;
 }
 
-:host(.toast) {
+.toast {
+  display: none;
   position: relative;
   top: 10px;
   width: 400px;
@@ -25,22 +22,20 @@
   background-color: $color-milk;
   margin-bottom: 16px;
   box-sizing: border-box;
-}
 
-.toast {
-  :host(&.success) {
+  &.success {
     border-top: 5px solid $color-jungle-500;
   }
 
-  :host(&.error) {
+  &.error {
     border-top: 5px solid $color-persimmon-800;
   }
 
-  :host(&.warning) {
+  &.warning {
     border-top: 5px solid $color-casablanca-300;
   }
 
-  :host(&.inprogress) {
+  &.inprogress {
     border-top: 5px solid $color-azure-800;
   }
 }
@@ -96,12 +91,12 @@
 }
 
 @media screen and (prefers-reduced-motion: reduce) {
-  :host(.fade-out) {
+  .toast.fade-out {
     animation: none;
   }
 }
 
-:host(.fade-out) {
+.toast.fade-out {
   animation-duration: 1s;
   animation-name: fadeOut;
 }

--- a/packages/crayons-core/src/components/toast-message/toast-message.tsx
+++ b/packages/crayons-core/src/components/toast-message/toast-message.tsx
@@ -143,46 +143,50 @@ export class ToastMessage {
   render(): JSX.Element {
     return (
       <Host
-        class={`toast ${this.type} ${this.open ? 'is-open' : ''} ${
-          this.fadeOut ? 'fade-out' : ''
-        }`}
         onmouseover={() => this.mouseHover(true)}
         onmouseout={() => this.mouseHover(false)}
         aria-hidden={this.open ? 'false' : 'true'}
       >
-        <div class='toast-container'>
-          {this.type === 'inprogress' ? (
-            <fw-spinner class='icon'></fw-spinner>
-          ) : (
-            <fw-icon class='icon' size={this.iconSize} name={this.type} />
-          )}
-
-          <div class='content'>
-            <slot />
-            {this.content}
-
-            {this.actionLinkText.length > 0 ? (
-              <div
-                class='action-link'
-                role='button'
-                tabindex='0'
-                onClick={() => this.fwLinkClick.emit()}
-                onKeyDown={handleKeyDown(() => this.fwLinkClick.emit())}
-              >
-                {this.actionLinkText}
-              </div>
+        <div
+          class={`toast ${this.type} ${this.open ? 'is-open' : ''} ${
+            this.fadeOut ? 'fade-out' : ''
+          }`}
+          aria-hidden={this.open ? 'false' : 'true'}
+        >
+          <div class='toast-container'>
+            {this.type === 'inprogress' ? (
+              <fw-spinner class='icon'></fw-spinner>
             ) : (
-              ''
+              <fw-icon class='icon' size={this.iconSize} name={this.type} />
             )}
-          </div>
 
-          <fw-icon
-            size={10}
-            color='#000'
-            name='cross'
-            class='remove'
-            onClick={() => this.closeToast()}
-          ></fw-icon>
+            <div class='content'>
+              <slot />
+              {this.content}
+
+              {this.actionLinkText.length > 0 ? (
+                <div
+                  class='action-link'
+                  role='button'
+                  tabindex='0'
+                  onClick={() => this.fwLinkClick.emit()}
+                  onKeyDown={handleKeyDown(() => this.fwLinkClick.emit())}
+                >
+                  {this.actionLinkText}
+                </div>
+              ) : (
+                ''
+              )}
+            </div>
+
+            <fw-icon
+              size={10}
+              color='#000'
+              name='cross'
+              class='remove'
+              onClick={() => this.closeToast()}
+            ></fw-icon>
+          </div>
         </div>
       </Host>
     );


### PR DESCRIPTION
remove styling from host to avoid styles getting overridden by global styles. Created a container and add styles instead of having the styles on the host element


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
