### PR TITLE
fix(checkbox): remove class from host and apply on container to avoid getting overridden by global styles

### DIFF
--- a/packages/crayons-core/src/components/checkbox/checkbox.e2e.ts
+++ b/packages/crayons-core/src/components/checkbox/checkbox.e2e.ts
@@ -74,8 +74,14 @@ describe('fw-checkbox', () => {
     );
     const element = await page.find('fw-checkbox >>> div');
     console.log(element);
-    expect(element).toEqualHtml(`<div id="description">
-    <slot/>
+    expect(element).toEqualHtml(`<div class="checkbox-container">
+    <input type="checkbox">
+    <label>
+      Yes
+    </label>
+    <div id="description">
+      <slot></slot>
+    </div>
     </div>`);
   });
 });

--- a/packages/crayons-core/src/components/checkbox/checkbox.scss
+++ b/packages/crayons-core/src/components/checkbox/checkbox.scss
@@ -1,23 +1,42 @@
-:host(.checkbox-container) {
+.checkbox-container {
   display: inline-block;
   position: relative;
   padding-left: 22px;
   margin-bottom: 8px;
-}
 
-/* Focus event occurs on the root element */
-:host(:focus) {
-  input[type='checkbox'] + label {
-    &::before {
-      border: 1px solid transparent;
-      box-shadow: 0 0 0 2px rgb(44, 92, 197);
+  /* Focus event occurs on the root element */
+  &:focus {
+    input[type='checkbox'] + label {
+      &::before {
+        border: 1px solid transparent;
+        box-shadow: 0 0 0 2px rgb(44, 92, 197);
+      }
+    }
+
+    input[type='checkbox'][disabled] + label {
+      &::before {
+        box-shadow: none;
+        border: 1px solid #dadfe3;
+      }
     }
   }
 
-  input[type='checkbox'][disabled] + label {
-    &::before {
-      box-shadow: none;
-      border: 1px solid #dadfe3;
+  /* Hover event occurs on the root element */
+  &:hover {
+    input[type='checkbox'] + label {
+      &::before {
+        border-color: $input-hover-color;
+        box-shadow: 0 0 0 5px rgb(235, 239, 243);
+      }
+    }
+
+    input[type='checkbox'][disabled] + label {
+      cursor: not-allowed;
+
+      &::before {
+        box-shadow: none;
+        border: 1px solid #dadfe3;
+      }
     }
   }
 }
@@ -30,25 +49,6 @@
   position: relative;
   font-weight: 400;
   word-wrap: break-word;
-}
-
-/* Hover event occurs on the root element */
-:host(:hover) {
-  input[type='checkbox'] + label {
-    &::before {
-      border-color: $input-hover-color;
-      box-shadow: 0 0 0 5px rgb(235, 239, 243);
-    }
-  }
-
-  input[type='checkbox'][disabled] + label {
-    cursor: not-allowed;
-
-    &::before {
-      box-shadow: none;
-      border: 1px solid #dadfe3;
-    }
-  }
 }
 
 input[type='checkbox'] {

--- a/packages/crayons-core/src/components/checkbox/checkbox.tsx
+++ b/packages/crayons-core/src/components/checkbox/checkbox.tsx
@@ -115,7 +115,6 @@ export class Checkbox {
 
     return (
       <Host
-        class='checkbox-container'
         onClick={() => this.toggle()}
         role='checkbox'
         tabIndex='0'
@@ -126,10 +125,12 @@ export class Checkbox {
         onFocus={() => this.onFocus()}
         onBlur={() => this.onBlur()}
       >
-        <input type='checkbox' ref={(el) => (this.checkbox = el)}></input>
-        <label>{this.label}</label>
-        <div id='description'>
-          <slot />
+        <div class='checkbox-container'>
+          <input type='checkbox' ref={(el) => (this.checkbox = el)}></input>
+          <label>{this.label}</label>
+          <div id='description'>
+            <slot />
+          </div>
         </div>
       </Host>
     );


### PR DESCRIPTION
Remove styling from host to avoid styles getting overridden by global styles. Created a container and add styles to it instead of having the styles on the host element

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
