### PR TITLE
fix(tab): remove class from host to avoid getting overridden by global styles

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -708,6 +708,10 @@ export namespace Components {
           * Describes the purpose of set of tabs.
          */
         "label": string;
+        /**
+          * The style of tab headers that needs to be displayed, box will display headers in a container.
+         */
+        "variant": 'box' | 'normal';
     }
     interface FwTag {
         /**
@@ -1930,6 +1934,10 @@ declare namespace LocalJSX {
           * Triggered when a the view switches to a new tab.
          */
         "onFwChange"?: (event: CustomEvent<any>) => void;
+        /**
+          * The style of tab headers that needs to be displayed, box will display headers in a container.
+         */
+        "variant"?: 'box' | 'normal';
     }
     interface FwTag {
         /**

--- a/packages/crayons-core/src/components/tab/tab.e2e.ts
+++ b/packages/crayons-core/src/components/tab/tab.e2e.ts
@@ -15,7 +15,9 @@ describe('fw-tab', () => {
     await page.setContent(`<fw-tab></fw-tab>`);
     const element = await page.find('fw-tab');
 
-    expect(element.shadowRoot).toEqualHtml(`<slot />`);
+    expect(element.shadowRoot).toEqualHtml(`<div class="tab">
+      <slot></slot>
+      </div>`);
   });
 
   it('Sets active class', async () => {

--- a/packages/crayons-core/src/components/tab/tab.scss
+++ b/packages/crayons-core/src/components/tab/tab.scss
@@ -1,4 +1,4 @@
-:host(.tab) {
+.tab {
   display: inline-flex;
   white-space: nowrap;
   cursor: pointer;
@@ -8,39 +8,40 @@
   color: $color-smoke-700;
   font-size: $font-size-14;
   font-weight: $font-weight-400;
-  margin-right: 20px;
+  margin: 0 4px;
+
+  /* stylelint-disable */
+  &:hover:not(.disabled) {
+    padding-bottom: 8px;
+    border-bottom: 2px solid $color-smoke-300;
+  }
+
+  &.active:not(.disabled) {
+    padding-bottom: 8px;
+    border-bottom: 2px solid $color-azure-800;
+    color: $color-azure-800;
+    font-weight: $font-weight-600;
+  }
+
+  &.disabled {
+    cursor: not-allowed;
+    color: $color-smoke-300;
+  }
+
+  &:focus {
+    outline: none;
+    border-bottom: none;
+    box-shadow: none;
+
+    &::after {
+      outline: none;
+      border-radius: 2px;
+      box-shadow: inset 0 0 0 2px $color-azure-800;
+    }
+  }
 }
 
 ::slotted(a) {
   text-decoration: none;
   color: $color-smoke-700;
-}
-/* stylelint-disable */
-:host(:hover:not(.disabled)) {
-  padding-bottom: 8px;
-  border-bottom: 2px solid $color-smoke-300;
-}
-
-:host(.active:not(.disabled)) {
-  padding-bottom: 8px;
-  border-bottom: 2px solid $color-azure-800;
-  color: $color-azure-800;
-  font-weight: $font-weight-600;
-}
-
-:host(.disabled) {
-  cursor: not-allowed;
-  color: $color-smoke-300;
-}
-
-.tab:focus {
-  outline: none;
-  border: 0;
-  box-shadow: none;
-
-  &::after {
-    outline: none;
-    border-radius: 2px;
-    box-shadow: inset 0 0 0 2px $color-azure-800;
-  }
 }

--- a/packages/crayons-core/src/components/tab/tab.tsx
+++ b/packages/crayons-core/src/components/tab/tab.tsx
@@ -50,13 +50,16 @@ export class Tab {
         aria-selected={this.active ? 'true' : 'false'}
         tabindex={this.disabled || !this.active ? '-1' : '0'}
         role='tab'
-        class={
-          'tab ' +
-          (this.disabled ? 'disabled' : '') +
-          (this.active ? 'active' : '')
-        }
       >
-        {this.tabHeader ? this.tabHeader : <slot />}
+        <div
+          class={
+            'tab ' +
+            (this.disabled ? 'disabled' : '') +
+            (this.active ? 'active' : '')
+          }
+        >
+          {this.tabHeader ? this.tabHeader : <slot />}
+        </div>
       </Host>
     );
   }

--- a/packages/crayons-core/src/components/tabs/readme.md
+++ b/packages/crayons-core/src/components/tabs/readme.md
@@ -118,11 +118,12 @@ function App() {
 
 ## Properties
 
-| Property         | Attribute          | Description                                   | Type     | Default     |
-| ---------------- | ------------------ | --------------------------------------------- | -------- | ----------- |
-| `activeTabIndex` | `active-tab-index` | The index of the activated Tab(Starts from 0) | `number` | `0`         |
-| `activeTabName`  | `active-tab-name`  | The name of the tab to be activated.          | `string` | `undefined` |
-| `label`          | `label`            | Describes the purpose of set of tabs.         | `string` | `''`        |
+| Property         | Attribute          | Description                                                                                   | Type                | Default     |
+| ---------------- | ------------------ | --------------------------------------------------------------------------------------------- | ------------------- | ----------- |
+| `activeTabIndex` | `active-tab-index` | The index of the activated Tab(Starts from 0)                                                 | `number`            | `0`         |
+| `activeTabName`  | `active-tab-name`  | The name of the tab to be activated.                                                          | `string`            | `undefined` |
+| `label`          | `label`            | Describes the purpose of set of tabs.                                                         | `string`            | `''`        |
+| `variant`        | `variant`          | The style of tab headers that needs to be displayed, box will display headers in a container. | `"box" \| "normal"` | `'normal'`  |
 
 
 ## Events

--- a/packages/crayons-core/src/components/tabs/tabs.scss
+++ b/packages/crayons-core/src/components/tabs/tabs.scss
@@ -7,6 +7,13 @@
     display: flex;
     border-bottom: 1px solid $color-smoke-50;
     overflow-x: auto;
+
+    &__box {
+      background-color: $app-header-bg-secondary;
+      border: 1px solid $color-smoke-50;
+      box-sizing: border-box;
+      border-radius: $radius;
+    }
   }
 
   &__items__tabs {

--- a/packages/crayons-core/src/components/tabs/tabs.stories.mdx
+++ b/packages/crayons-core/src/components/tabs/tabs.stories.mdx
@@ -29,6 +29,23 @@ import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 `}</Story>
 </Preview>
 
+### With variant box
+<Preview>
+<Story name='with box variant'>{() => `
+<fw-tabs variant="box">
+  <fw-tab slot="tab" panel="one">Tab 1</fw-tab>
+  <fw-tab slot="tab" panel="two">Tab 2</fw-tab>
+  <fw-tab slot="tab" panel="three" disabled>Tab 3</fw-tab>
+  <fw-tab slot="tab" panel="four">Tab 4</fw-tab>
+
+  <fw-tab-panel name="one">Tab 1 Content</fw-tab-panel>
+  <fw-tab-panel name="two">Tab 2 Content</fw-tab-panel>
+  <fw-tab-panel name="three">Tab 3 Content</fw-tab-panel>
+  <fw-tab-panel name="four">Tab 4 Content</fw-tab-panel>
+</fw-tabs>
+`}</Story>
+</Preview>
+
 ### With HTML headers
 <Preview>
 <Story name='With HTML Headers'>{() => `

--- a/packages/crayons-core/src/components/tabs/tabs.tsx
+++ b/packages/crayons-core/src/components/tabs/tabs.tsx
@@ -41,6 +41,10 @@ export class Tabs {
   activeTabName?: string;
 
   /**
+   * The style of tab headers that needs to be displayed, box will display headers in a container.
+   */
+  @Prop() variant: 'box' | 'normal' = 'normal';
+  /**
    * Triggered when a the view switches to a new tab.
    */
   @Event() fwChange: EventEmitter;
@@ -184,7 +188,9 @@ export class Tabs {
   render() {
     return (
       <div class='tabs'>
-        <div class='tabs__items__nav'>
+        <div
+          class={'tabs__items__nav' + (this.variant === 'box' ? '__box' : '')}
+        >
           <div class='tabs__items__tabs' role='tablist' aria-label={this.label}>
             <slot name='tab'></slot>
           </div>


### PR DESCRIPTION
Remove styling from host to avoid styles getting overridden by global styles. Created a container and add styles to it instead of having the styles on the host element


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
