### PR TITLE
refactor(checkbox): revert checkbox to previous behaviour and mark label prop as deprecated

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -65,13 +65,13 @@ export namespace Components {
          */
         "checked": boolean;
         /**
+          * Description to be displayed for the checkbox.
+         */
+        "description": string;
+        /**
           * Disables the check box on the interface. If the attribute’s value is undefined, the value is set to false.
          */
         "disabled": boolean;
-        /**
-          * Label displayed on the interface, for the check box.
-         */
-        "label": string;
         /**
           * Name of the component, saved as part of form data.
          */
@@ -1263,13 +1263,13 @@ declare namespace LocalJSX {
          */
         "checked"?: boolean;
         /**
+          * Description to be displayed for the checkbox.
+         */
+        "description"?: string;
+        /**
           * Disables the check box on the interface. If the attribute’s value is undefined, the value is set to false.
          */
         "disabled"?: boolean;
-        /**
-          * Label displayed on the interface, for the check box.
-         */
-        "label"?: string;
         /**
           * Name of the component, saved as part of form data.
          */

--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -73,6 +73,10 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
+          * @deprecated Use `description` instead. Label displayed on the interface, for the check box.
+         */
+        "label": string;
+        /**
           * Name of the component, saved as part of form data.
          */
         "name": string;
@@ -1270,6 +1274,10 @@ declare namespace LocalJSX {
           * Disables the check box on the interface. If the attribute’s value is undefined, the value is set to false.
          */
         "disabled"?: boolean;
+        /**
+          * @deprecated Use `description` instead. Label displayed on the interface, for the check box.
+         */
+        "label"?: string;
         /**
           * Name of the component, saved as part of form data.
          */

--- a/packages/crayons-core/src/components/checkbox/checkbox.e2e.ts
+++ b/packages/crayons-core/src/components/checkbox/checkbox.e2e.ts
@@ -72,10 +72,9 @@ describe('fw-checkbox', () => {
     <span id="label">
       <slot></slot>
     </span>
-    <br>
-    <span id="description">
+    <div id="description">
     Yes
-    </span>
+    </div>
     </label>
     </div>`);
   });

--- a/packages/crayons-core/src/components/checkbox/checkbox.e2e.ts
+++ b/packages/crayons-core/src/components/checkbox/checkbox.e2e.ts
@@ -58,30 +58,25 @@ describe('fw-checkbox', () => {
     expect(fwChange.events).toEqual([]);
   });
 
-  it('it should set label when passed as a prop', async () => {
-    const page = await newE2EPage();
-
-    await page.setContent('<fw-checkbox label="Yes"></fw-checkbox>');
-    const element = await page.find('fw-checkbox >>> label');
-    expect(element).toEqualText('Yes');
-  });
-
   it('it should return html structure with slot when content is passed between opening and closing tag', async () => {
     const page = await newE2EPage();
 
     await page.setContent(
-      '<fw-checkbox label="Yes">Select to Agree</fw-checkbox>'
+      '<fw-checkbox description="Yes">Select to Agree</fw-checkbox>'
     );
     const element = await page.find('fw-checkbox >>> div');
     console.log(element);
     expect(element).toEqualHtml(`<div class="checkbox-container">
     <input type="checkbox">
     <label>
-      Yes
-    </label>
-    <div id="description">
+    <span id="label">
       <slot></slot>
-    </div>
+    </span>
+    <br>
+    <span id="description">
+    Yes
+    </span>
+    </label>
     </div>`);
   });
 });

--- a/packages/crayons-core/src/components/checkbox/checkbox.stories.mdx
+++ b/packages/crayons-core/src/components/checkbox/checkbox.stories.mdx
@@ -42,28 +42,28 @@ import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 ### Checkbox with Label
 <Preview>
 <Story name='withLabel'>
-{() => '<fw-checkbox label="Checkbox Label Here"></fw-checkbox>'}
+{() => '<fw-checkbox>Checkbox Label Here</fw-checkbox>'}
 </Story>
 </Preview>
 
 ### Checkbox with Label and in Disabled State
 <Preview>
 <Story name='DisabledWithLabel'>
-{() => '<fw-checkbox disabled label="Checkbox Label Here"></fw-checkbox>'}
+{() => '<fw-checkbox disabled>Checkbox Label Here</fw-checkbox>'}
 </Story>
 </Preview>
 
-### Checkbox with Text and Label
+### Checkbox with Description and Label
 <Preview>
-<Story name='WithTextAndLabel'>
-{() => '<fw-checkbox label="Checkbox Label Here"> This is a subheading</fw-checkbox>'}
+<Story name='WithDescriptionAndLabel'>
+{() => '<fw-checkbox description="This is a subheading">Checkbox Label Here</fw-checkbox>'}
 </Story>
 </Preview>
 
 
-### Checkbox with Text and Label in Disabled State
+### Checkbox with Description and Label in Disabled State
 <Preview>
-<Story name='WithTextAndLabelDisabled'>
-{() => '<fw-checkbox disabled label="Checkbox Label Here">This is a subheading </fw-checkbox>'}
+<Story name='WithDescriptionAndLabelDisabled'>
+{() => '<fw-checkbox disabled description="This is a subheading">Checkbox Label Here</fw-checkbox>'}
 </Story>
 </Preview>

--- a/packages/crayons-core/src/components/checkbox/checkbox.tsx
+++ b/packages/crayons-core/src/components/checkbox/checkbox.tsx
@@ -32,6 +32,11 @@ export class Checkbox {
    */
   @Prop() description = '';
   /**
+   * @deprecated Use `description` instead.
+   * Label displayed on the interface, for the check box.
+   */
+  @Prop() label = '';
+  /**
    * Name of the component, saved as part of form data.
    */
   @Prop() name = '';
@@ -131,8 +136,10 @@ export class Checkbox {
             <span id='label'>
               <slot />
             </span>
-            {this.description !== '' ? (
-              <div id='description'>{this.description}</div>
+            {this.description !== '' || this.label !== '' ? (
+              <div id='description'>
+                {this.description ? this.description : this.label}
+              </div>
             ) : (
               ''
             )}

--- a/packages/crayons-core/src/components/checkbox/checkbox.tsx
+++ b/packages/crayons-core/src/components/checkbox/checkbox.tsx
@@ -28,9 +28,9 @@ export class Checkbox {
    */
   @Prop({ mutable: true, reflect: true }) disabled = false;
   /**
-   * Label displayed on the interface, for the check box.
+   * Description to be displayed for the checkbox.
    */
-  @Prop() label = '';
+  @Prop() description = '';
   /**
    * Name of the component, saved as part of form data.
    */
@@ -120,17 +120,24 @@ export class Checkbox {
         tabIndex='0'
         aria-disabled={this.disabled ? 'true' : 'false'}
         aria-checked={this.checked ? 'true' : 'false'}
-        aria-label={this.label}
-        aria-describedby='description'
+        aria-labelledby='label'
+        aria-describedby={this.description}
         onFocus={() => this.onFocus()}
         onBlur={() => this.onBlur()}
       >
         <div class='checkbox-container'>
           <input type='checkbox' ref={(el) => (this.checkbox = el)}></input>
-          <label>{this.label}</label>
-          <div id='description'>
-            <slot />
-          </div>
+          <label>
+            <span id='label'>
+              <slot />
+            </span>
+            <br />
+            {this.description !== '' ? (
+              <span id='description'>{this.description}</span>
+            ) : (
+              ''
+            )}
+          </label>
         </div>
       </Host>
     );

--- a/packages/crayons-core/src/components/checkbox/checkbox.tsx
+++ b/packages/crayons-core/src/components/checkbox/checkbox.tsx
@@ -131,9 +131,8 @@ export class Checkbox {
             <span id='label'>
               <slot />
             </span>
-            <br />
             {this.description !== '' ? (
-              <span id='description'>{this.description}</span>
+              <div id='description'>{this.description}</div>
             ) : (
               ''
             )}

--- a/packages/crayons-core/src/components/checkbox/readme.md
+++ b/packages/crayons-core/src/components/checkbox/readme.md
@@ -4,16 +4,16 @@ fw-checkbox displays a check box on the user interface and enables assigning a s
 ## Demo
 
 ```html live
-<fw-checkbox checked label="Select to agree">Agree or Disagree</fw-checkbox><br><br>
-<fw-checkbox checked disabled value="dcb">Disable check box</fw-checkbox>
+<fw-checkbox checked description="Agree or Disagree">Select to agree</fw-checkbox><br><br>
+<fw-checkbox checked disabled value="dcb">Disabled check box</fw-checkbox>
 ```
 ## Usage
 
 <code-group>
 <code-block title="HTML">
 ```html
-<fw-checkbox checked label="Select to agree">Agree or Disagree</fw-checkbox><br><br>
-<fw-checkbox checked disabled value="dcb">Disable check box</fw-checkbox>
+<fw-checkbox checked description="Agree or Disagree">Select to agree</fw-checkbox><br><br>
+<fw-checkbox checked disabled value="dcb">Disabled check box</fw-checkbox>
 ```
 </code-block>
 
@@ -24,8 +24,8 @@ import ReactDOM from "react-dom";
 import { FwCheckbox } from "@freshworks/crayons/react";
 function App() {
   return (<div>
-    <FwCheckbox checked label="Select to agree">Agree or Disagree</FwCheckbox><br/><br/>
-    <FwCheckbox checked disabled value="dcb">Disable check box</FwCheckbox>
+    <FwCheckbox checked description="Agree or Disagree">Select to agree</FwCheckbox><br/><br/>
+    <FwCheckbox checked disabled value="dcb">Disabled check box</FwCheckbox>
   </div>)
 }
 ```
@@ -37,13 +37,13 @@ function App() {
 
 ## Properties
 
-| Property   | Attribute  | Description                                                                                                    | Type      | Default |
-| ---------- | ---------- | -------------------------------------------------------------------------------------------------------------- | --------- | ------- |
-| `checked`  | `checked`  | Sets the state of the check box to selected. If the attribute’s value is undefined, the value is set to false. | `boolean` | `false` |
-| `disabled` | `disabled` | Disables the check box on the interface. If the attribute’s value is undefined, the value is set to false.     | `boolean` | `false` |
-| `label`    | `label`    | Label displayed on the interface, for the check box.                                                           | `string`  | `''`    |
-| `name`     | `name`     | Name of the component, saved as part of form data.                                                             | `string`  | `''`    |
-| `value`    | `value`    | Identifier corresponding to the component, that is saved when the form data is saved.                          | `string`  | `''`    |
+| Property      | Attribute     | Description                                                                                                    | Type      | Default |
+| ------------- | ------------- | -------------------------------------------------------------------------------------------------------------- | --------- | ------- |
+| `checked`     | `checked`     | Sets the state of the check box to selected. If the attribute’s value is undefined, the value is set to false. | `boolean` | `false` |
+| `description` | `description` | Description to be displayed for the checkbox.                                                                  | `string`  | `''`    |
+| `disabled`    | `disabled`    | Disables the check box on the interface. If the attribute’s value is undefined, the value is set to false.     | `boolean` | `false` |
+| `name`        | `name`        | Name of the component, saved as part of form data.                                                             | `string`  | `''`    |
+| `value`       | `value`       | Identifier corresponding to the component, that is saved when the form data is saved.                          | `string`  | `''`    |
 
 
 ## Events

--- a/packages/crayons-core/src/components/checkbox/readme.md
+++ b/packages/crayons-core/src/components/checkbox/readme.md
@@ -37,13 +37,14 @@ function App() {
 
 ## Properties
 
-| Property      | Attribute     | Description                                                                                                    | Type      | Default |
-| ------------- | ------------- | -------------------------------------------------------------------------------------------------------------- | --------- | ------- |
-| `checked`     | `checked`     | Sets the state of the check box to selected. If the attribute’s value is undefined, the value is set to false. | `boolean` | `false` |
-| `description` | `description` | Description to be displayed for the checkbox.                                                                  | `string`  | `''`    |
-| `disabled`    | `disabled`    | Disables the check box on the interface. If the attribute’s value is undefined, the value is set to false.     | `boolean` | `false` |
-| `name`        | `name`        | Name of the component, saved as part of form data.                                                             | `string`  | `''`    |
-| `value`       | `value`       | Identifier corresponding to the component, that is saved when the form data is saved.                          | `string`  | `''`    |
+| Property      | Attribute     | Description                                                                                                                               | Type      | Default |
+| ------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------- |
+| `checked`     | `checked`     | Sets the state of the check box to selected. If the attribute’s value is undefined, the value is set to false.                            | `boolean` | `false` |
+| `description` | `description` | Description to be displayed for the checkbox.                                                                                             | `string`  | `''`    |
+| `disabled`    | `disabled`    | Disables the check box on the interface. If the attribute’s value is undefined, the value is set to false.                                | `boolean` | `false` |
+| `label`       | `label`       | <span style="color:red">**[DEPRECATED]**</span> Use `description` instead. Label displayed on the interface, for the check box.<br/><br/> | `string`  | `''`    |
+| `name`        | `name`        | Name of the component, saved as part of form data.                                                                                        | `string`  | `''`    |
+| `value`       | `value`       | Identifier corresponding to the component, that is saved when the form data is saved.                                                     | `string`  | `''`    |
 
 
 ## Events


### PR DESCRIPTION
- `label` prop is marked as deprecated.
-  When both `label` and `description` are present, `description` takes priority.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
