### PR TITLE
refactor(radio): revert checkbox to previous behaviour and mark label prop as deprecated

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -492,6 +492,10 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
+          * @deprecated Use `description` instead. Label displayed on the interface, for the check box.
+         */
+        "label": string;
+        /**
           * Name of the component, saved as part of form data.
          */
         "name": string;
@@ -1744,6 +1748,10 @@ declare namespace LocalJSX {
           * Disables the component on the interface. If the attribute’s value is undefined, the value is set to false.
          */
         "disabled"?: boolean;
+        /**
+          * @deprecated Use `description` instead. Label displayed on the interface, for the check box.
+         */
+        "label"?: string;
         /**
           * Name of the component, saved as part of form data.
          */

--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -484,13 +484,13 @@ export namespace Components {
          */
         "checked": boolean;
         /**
+          * Description to be displayed for the checkbox.
+         */
+        "description": string;
+        /**
           * Disables the component on the interface. If the attribute’s value is undefined, the value is set to false.
          */
         "disabled": boolean;
-        /**
-          * Label displayed on the interface, for the component.
-         */
-        "label": string;
         /**
           * Name of the component, saved as part of form data.
          */
@@ -1737,13 +1737,13 @@ declare namespace LocalJSX {
          */
         "checked"?: boolean;
         /**
+          * Description to be displayed for the checkbox.
+         */
+        "description"?: string;
+        /**
           * Disables the component on the interface. If the attribute’s value is undefined, the value is set to false.
          */
         "disabled"?: boolean;
-        /**
-          * Label displayed on the interface, for the component.
-         */
-        "label"?: string;
         /**
           * Name of the component, saved as part of form data.
          */

--- a/packages/crayons-core/src/components/radio-group/readme.md
+++ b/packages/crayons-core/src/components/radio-group/readme.md
@@ -5,9 +5,9 @@ fw-radio-group displays a group of options with radio buttons and enables select
 
 ```html live
 <fw-radio-group name="Profile" value="au" allow-empty>
-  <fw-radio label="Auditory" value="au"></fw-radio>
-  <fw-radio label="Visual" value="vi"></fw-radio>
-  <fw-radio label="Restless" value="re"></fw-radio>
+  <fw-radio value="au">Auditory</fw-radio>
+  <fw-radio value="vi">Visual</fw-radio>
+  <fw-radio value="re">Restless</fw-radio>
 </fw-radio-group>
 ```
 
@@ -17,9 +17,9 @@ fw-radio-group displays a group of options with radio buttons and enables select
 <code-block title="HTML">
 ```html 
 <fw-radio-group name="Profile" value="au" allow-empty>
-  <fw-radio label="Auditory" value="au"></fw-radio>
-  <fw-radio label="Visual" value="vi"></fw-radio>
-  <fw-radio label="Restless" value="re"></fw-radio>
+  <fw-radio value="au">Auditory</fw-radio>
+  <fw-radio value="vi">Visual</fw-radio>
+  <fw-radio value="re">Restless</fw-radio>
 </fw-radio-group>
 ```
 </code-block>
@@ -32,9 +32,9 @@ import { FwRadio, FwRadioGroup } from "@freshworks/crayons/react";
 function App() {
   return (<div>
         <FwRadioGroup name="Profile" value="au" allowEmpty>
-          <FwRadio label="Auditory" value="au"></FwRadio>
-          <FwRadio label="Visual" value="vi"></FwRadio>
-          <FwRadio label="Restless" value="re"></FwRadio>
+          <FwRadio value="au">Auditory</FwRadio>
+          <FwRadio value="vi">Visual</FwRadio>
+          <FwRadio value="re">Restless</FwRadio>
         </FwRadioGroup>
     </div>);
 }

--- a/packages/crayons-core/src/components/radio/radio.e2e.ts
+++ b/packages/crayons-core/src/components/radio/radio.e2e.ts
@@ -60,36 +60,21 @@ describe('fw-radio', () => {
     expect(fwSelect.events).toEqual([]);
   });
 
-  it('it should set label when passed as a prop', async () => {
-    const page = await newE2EPage();
-
-    await page.setContent('<fw-radio label="Yes"></fw-radio>');
-    const element = await page.find('fw-radio >>> label');
-    expect(element).toEqualText('Yes');
-  });
-
   it('it should return html structure with slot when content is passed between opening and closing tag', async () => {
     const page = await newE2EPage();
 
-    await page.setContent('<fw-radio label="Yes">Agree</fw-radio>');
+    await page.setContent('<fw-radio description="Yes">Agree</fw-radio>');
     const element = await page.find('fw-radio >>> div');
     expect(element).toEqualHtml(`<div class="radio-container">
     <input type="radio">
     <label>
-      Yes
-    </label>
-    <div id="description">
+      <span id="label">
       <slot></slot>
-    </div>
+      </span>
+      <div id="description">
+        Yes
+      </div>
+    </label>
     </div>`);
-  });
-
-  it('it should set aria-label when label is passed as param', async () => {
-    const page = await newE2EPage();
-
-    await page.setContent('<fw-radio value="1" label="yes">1</fw-radio>');
-    const element = await page.find('fw-radio');
-    const label = element.getAttribute('aria-label');
-    expect(label).toBe('yes');
   });
 });

--- a/packages/crayons-core/src/components/radio/radio.scss
+++ b/packages/crayons-core/src/components/radio/radio.scss
@@ -2,6 +2,7 @@
   display: inline-block;
   position: relative;
   padding-left: 22px;
+  margin-right: 10px;
   margin-bottom: 8px;
   max-width: 80ch;
   word-wrap: break-word;
@@ -65,7 +66,6 @@ input[type='radio'] {
     line-height: 20px;
     color: #12344d;
     font-weight: 600;
-    margin-right: 10px;
 
     &::before,
     &::after {

--- a/packages/crayons-core/src/components/radio/radio.stories.mdx
+++ b/packages/crayons-core/src/components/radio/radio.stories.mdx
@@ -40,29 +40,29 @@ import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 ### With label
 <Preview>
 <Story name="WithLabel">
-  {() => '<fw-radio label="Radio Label Here"></fw-radio>'}
+  {() => '<fw-radio>Radio Label Here</fw-radio>'}
 </Story>
 </Preview>
 
 ### With label and disabled
 <Preview>
 <Story name="DisabledWithLabel">
-  {() => '<fw-radio disabled label="Radio Label Here"></fw-radio>'}
+  {() => '<fw-radio disabled>Radio Label Here</fw-radio>'}
 </Story>
 </Preview>
 
-### With text and label
+### With description and label
 <Preview>
-<Story name="withTextAndLabel">
-  {() => '<fw-radio label="Radio Label Here">This is a subheading</fw-radio>'}
+<Story name="withDescriptionAndLabel">
+  {() => '<fw-radio description="This is a subheading">Radio Label Here</fw-radio>'}
 </Story>
 </Preview>
 
-### With text and label Disabled
+### With description and label Disabled
 <Preview>
-<Story name="WithTextAndLabelDisabled">
+<Story name="WithDescriptionAndLabelDisabled">
   {() =>
-    '<fw-radio disabled label="Radio Label Here">This is a subheading</fw-radio>'
+    '<fw-radio disabled description="This is a subheading">Radio Label Here</fw-radio>'
   }
 </Story>
 </Preview>

--- a/packages/crayons-core/src/components/radio/radio.tsx
+++ b/packages/crayons-core/src/components/radio/radio.tsx
@@ -23,9 +23,9 @@ export class Radio {
    */
   @Prop({ mutable: true, reflect: true }) disabled = false;
   /**
-   * Label displayed on the interface, for the component.
+   * Description to be displayed for the checkbox.
    */
-  @Prop() label = '';
+  @Prop() description = '';
   /**
    * Identifier corresponding to the component, that is saved when the form data is saved.
    */
@@ -104,8 +104,8 @@ export class Radio {
         onClick={() => this.toggle()}
         role='radio'
         tabIndex='-1'
-        aria-label={this.label}
-        aria-describedby='description'
+        aria-labelledby='label'
+        aria-describedby={this.description}
         aria-disabled={this.disabled ? 'true' : 'false'}
         aria-checked={this.checked ? 'true' : 'false'}
         onFocus={() => this.onFocus()}
@@ -113,10 +113,16 @@ export class Radio {
       >
         <div class='radio-container'>
           <input type='radio' ref={(el) => (this.radio = el)}></input>
-          <label>{this.label}</label>
-          <div id='description'>
-            <slot />
-          </div>
+          <label>
+            <span id='label'>
+              <slot />
+            </span>
+            {this.description ? (
+              <div id='description'>{this.description}</div>
+            ) : (
+              ''
+            )}
+          </label>
         </div>
       </Host>
     );

--- a/packages/crayons-core/src/components/radio/radio.tsx
+++ b/packages/crayons-core/src/components/radio/radio.tsx
@@ -27,6 +27,11 @@ export class Radio {
    */
   @Prop() description = '';
   /**
+   * @deprecated Use `description` instead.
+   * Label displayed on the interface, for the check box.
+   */
+  @Prop() label = '';
+  /**
    * Identifier corresponding to the component, that is saved when the form data is saved.
    */
   @Prop() value = '';
@@ -117,8 +122,10 @@ export class Radio {
             <span id='label'>
               <slot />
             </span>
-            {this.description ? (
-              <div id='description'>{this.description}</div>
+            {this.description !== '' || this.label !== '' ? (
+              <div id='description'>
+                {this.description ? this.description : this.label}
+              </div>
             ) : (
               ''
             )}

--- a/packages/crayons-core/src/components/radio/readme.md
+++ b/packages/crayons-core/src/components/radio/readme.md
@@ -5,8 +5,8 @@ fw-radio displays a radio button on the user interface and enables assigning a s
 ## Demo
 
 ```html live
-<fw-radio checked label="Agree or Disagree">Select to agree</fw-radio><br><br>
-<fw-radio checked disabled label="Disabled radio" value="dr"></fw-radio>
+<fw-radio checked description="Select to agree">Agree or Disagree</fw-radio><br><br>
+<fw-radio checked disabled value="dr">Disabled radio</fw-radio>
 ```
 
 
@@ -15,8 +15,8 @@ fw-radio displays a radio button on the user interface and enables assigning a s
 <code-group>
 <code-block title="HTML">
 ```html 
-<fw-radio checked label="Agree or Disagree">Select to agree</fw-radio><br><br>
-<fw-radio checked disabled label="Disabled radio" value="dr"></fw-radio>
+<fw-radio checked description="Select to agree">Agree or Disagree</fw-radio><br><br>
+<fw-radio checked disabled value="dr">Disabled radio</fw-radio>
 ```
 </code-block>
 
@@ -27,8 +27,8 @@ import ReactDOM from "react-dom";
 import { FwRadio } from "@freshworks/crayons/react";
 function App() {
   return (<div>
-        <FwRadio checked label="Agree or Disagree">Select to agree</FwRadio><br/><br/>
-        <FwRadio checked disabled label="Disabled radio" value="dr"></FwRadio>
+        <FwRadio checked description="Select to agree">Agree or Disagree</FwRadio><br/><br/>
+        <FwRadio checked disabled value="dr">Disabled radio</FwRadio>
     </div>);
 }
 ```
@@ -40,13 +40,13 @@ function App() {
 
 ## Properties
 
-| Property   | Attribute  | Description                                                                                                | Type      | Default |
-| ---------- | ---------- | ---------------------------------------------------------------------------------------------------------- | --------- | ------- |
-| `checked`  | `checked`  | Sets the state to selected. If the attribute’s value is undefined, the value is set to false.              | `boolean` | `false` |
-| `disabled` | `disabled` | Disables the component on the interface. If the attribute’s value is undefined, the value is set to false. | `boolean` | `false` |
-| `label`    | `label`    | Label displayed on the interface, for the component.                                                       | `string`  | `''`    |
-| `name`     | `name`     | Name of the component, saved as part of form data.                                                         | `string`  | `''`    |
-| `value`    | `value`    | Identifier corresponding to the component, that is saved when the form data is saved.                      | `string`  | `''`    |
+| Property      | Attribute     | Description                                                                                                | Type      | Default |
+| ------------- | ------------- | ---------------------------------------------------------------------------------------------------------- | --------- | ------- |
+| `checked`     | `checked`     | Sets the state to selected. If the attribute’s value is undefined, the value is set to false.              | `boolean` | `false` |
+| `description` | `description` | Description to be displayed for the checkbox.                                                              | `string`  | `''`    |
+| `disabled`    | `disabled`    | Disables the component on the interface. If the attribute’s value is undefined, the value is set to false. | `boolean` | `false` |
+| `name`        | `name`        | Name of the component, saved as part of form data.                                                         | `string`  | `''`    |
+| `value`       | `value`       | Identifier corresponding to the component, that is saved when the form data is saved.                      | `string`  | `''`    |
 
 
 ## Events

--- a/packages/crayons-core/src/components/radio/readme.md
+++ b/packages/crayons-core/src/components/radio/readme.md
@@ -40,13 +40,14 @@ function App() {
 
 ## Properties
 
-| Property      | Attribute     | Description                                                                                                | Type      | Default |
-| ------------- | ------------- | ---------------------------------------------------------------------------------------------------------- | --------- | ------- |
-| `checked`     | `checked`     | Sets the state to selected. If the attribute’s value is undefined, the value is set to false.              | `boolean` | `false` |
-| `description` | `description` | Description to be displayed for the checkbox.                                                              | `string`  | `''`    |
-| `disabled`    | `disabled`    | Disables the component on the interface. If the attribute’s value is undefined, the value is set to false. | `boolean` | `false` |
-| `name`        | `name`        | Name of the component, saved as part of form data.                                                         | `string`  | `''`    |
-| `value`       | `value`       | Identifier corresponding to the component, that is saved when the form data is saved.                      | `string`  | `''`    |
+| Property      | Attribute     | Description                                                                                                                               | Type      | Default |
+| ------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------- |
+| `checked`     | `checked`     | Sets the state to selected. If the attribute’s value is undefined, the value is set to false.                                             | `boolean` | `false` |
+| `description` | `description` | Description to be displayed for the checkbox.                                                                                             | `string`  | `''`    |
+| `disabled`    | `disabled`    | Disables the component on the interface. If the attribute’s value is undefined, the value is set to false.                                | `boolean` | `false` |
+| `label`       | `label`       | <span style="color:red">**[DEPRECATED]**</span> Use `description` instead. Label displayed on the interface, for the check box.<br/><br/> | `string`  | `''`    |
+| `name`        | `name`        | Name of the component, saved as part of form data.                                                                                        | `string`  | `''`    |
+| `value`       | `value`       | Identifier corresponding to the component, that is saved when the form data is saved.                                                     | `string`  | `''`    |
 
 
 ## Events


### PR DESCRIPTION
- `label` prop is marked as deprecated.
-  When both `label` and `description` are present, `description` takes priority.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
