### PR TITLE
fix(css-utils): improving class names in typography css utils

### DIFF
--- a/styles/_utils.scss
+++ b/styles/_utils.scss
@@ -74,27 +74,27 @@ $relative-spacing: (
 */
 $spacing: 28;
 @while $spacing >= 0 {
-  $spacvalue: map-get($relative-spacing, $spacing);
+  $spacevalue: map-get($relative-spacing, $spacing);
   .fw-p-#{$spacing} {
-    @include padding($spacvalue, $spacvalue, $spacvalue, $spacvalue);
+    @include padding($spacevalue, $spacevalue, $spacevalue, $spacevalue);
   }
   .fw-px-#{$spacing} {
-    @include padding(null, $spacvalue, null, $spacvalue);
+    @include padding(null, $spacevalue, null, $spacevalue);
   }
   .fw-py-#{$spacing} {
-    @include padding($spacvalue, null, $spacvalue, null);
+    @include padding($spacevalue, null, $spacevalue, null);
   }
   .fw-pt-#{$spacing} {
-    @include padding($spacvalue, null, null, null);
+    @include padding($spacevalue, null, null, null);
   }
   .fw-pr-#{$spacing} {
-    @include padding(null, $spacvalue, null, null);
+    @include padding(null, $spacevalue, null, null);
   }
   .fw-pb-#{$spacing} {
-    @include padding(null, null, $spacvalue, null);
+    @include padding(null, null, $spacevalue, null);
   }
   .fw-pl-#{$spacing} {
-    @include padding(null, null, null, $spacvalue);
+    @include padding(null, null, null, $spacevalue);
   }
   $spacing: $spacing - 4;
 }
@@ -104,27 +104,27 @@ $spacing: 28;
 */
 $spacing: 28;
 @while $spacing >= 0 {
-  $spacvalue: map-get($relative-spacing, $spacing);
+  $spacevalue: map-get($relative-spacing, $spacing);
   .fw-m-#{$spacing} {
-    @include margin($spacvalue, $spacvalue, $spacvalue, $spacvalue);
+    @include margin($spacevalue, $spacevalue, $spacevalue, $spacevalue);
   }
   .fw-mx-#{$spacing} {
-    @include margin(null, $spacvalue, null, $spacvalue);
+    @include margin(null, $spacevalue, null, $spacevalue);
   }
   .fw-my-#{$spacing} {
-    @include margin($spacvalue, null, $spacvalue, null);
+    @include margin($spacevalue, null, $spacevalue, null);
   }
   .fw-mt-#{$spacing} {
-    @include margin($spacvalue, null, null, null);
+    @include margin($spacevalue, null, null, null);
   }
   .fw-mr-#{$spacing} {
-    @include margin(null, $spacvalue, null, null);
+    @include margin(null, $spacevalue, null, null);
   }
   .fw-mb-#{$spacing} {
-    @include margin(null, null, $spacvalue, null);
+    @include margin(null, null, $spacevalue, null);
   }
   .fw-ml-#{$spacing} {
-    @include margin(null, null, null, $spacvalue);
+    @include margin(null, null, null, $spacevalue);
   }
   $spacing: $spacing - 4;
 }

--- a/styles/_utils.scss
+++ b/styles/_utils.scss
@@ -5,15 +5,44 @@
 /**
   For generating typography styles
 */
-$font-sizes: (12, 14, 16, 18, 24, 32, 44);
-@each $size in $font-sizes {
-  .fw-font-header-#{$size} {
-    @include typography('header', $size * 1px, $text-default, 600);
+$font-header-sizes: (
+  'h1': 2.75rem,
+  'h2': 2rem,
+  'h3': 1.5rem,
+  'h4': 1.125rem,
+  'h5': 1rem,
+  'h6': 0.875rem,
+  'h7': 0.75rem,
+);
+@each $name, $size in $font-header-sizes {
+  .fw-type-#{$name} {
+    @include typography('header', $size, $text-default, 600);
   }
 }
-@each $size in $font-sizes {
-  .fw-font-#{$size} {
-    @include typography('body', $size * 1px);
+$font-body-sizes: (
+  '3xl': 2.75rem,
+  '2xl': 2rem,
+  'xl': 1.5rem,
+  'lg': 1.125rem,
+  'base': 1rem,
+  'sm': 0.875rem,
+  'xs': 0.75rem,
+);
+@each $name, $size in $font-body-sizes {
+  .fw-type-#{$name} {
+    @include typography('body', $size);
+  }
+}
+
+$font-weight: (
+  'light': 300,
+  'regular': 400,
+  'semibold': 600,
+  'bold': 700,
+);
+@each $name, $size in $font-weight {
+  .fw-type-#{$name} {
+    font-weight: #{$size};
   }
 }
 
@@ -27,31 +56,45 @@ $font-sizes: (12, 14, 16, 18, 24, 32, 44);
 }
 
 /**
+  For generating spacing styles
+*/
+$relative-spacing: (
+  0: 0px,
+  4: 0.25rem,
+  8: 0.5rem,
+  12: 0.75rem,
+  16: 1rem,
+  20: 1.25rem,
+  24: 1.5rem,
+  28: 1.75rem,
+);
+
+/**
   For generating padding styles
 */
 $spacing: 28;
 @while $spacing >= 0 {
-  $spacingpx: $spacing * 1px;
+  $spacvalue: map-get($relative-spacing, $spacing);
   .fw-p-#{$spacing} {
-    @include padding($spacingpx, $spacingpx, $spacingpx, $spacingpx);
+    @include padding($spacvalue, $spacvalue, $spacvalue, $spacvalue);
   }
   .fw-px-#{$spacing} {
-    @include padding(null, $spacingpx, null, $spacingpx);
+    @include padding(null, $spacvalue, null, $spacvalue);
   }
   .fw-py-#{$spacing} {
-    @include padding($spacingpx, null, $spacingpx, null);
+    @include padding($spacvalue, null, $spacvalue, null);
   }
   .fw-pt-#{$spacing} {
-    @include padding($spacingpx, null, null, null);
+    @include padding($spacvalue, null, null, null);
   }
   .fw-pr-#{$spacing} {
-    @include padding(null, $spacingpx, null, null);
+    @include padding(null, $spacvalue, null, null);
   }
   .fw-pb-#{$spacing} {
-    @include padding(null, null, $spacingpx, null);
+    @include padding(null, null, $spacvalue, null);
   }
   .fw-pl-#{$spacing} {
-    @include padding(null, null, null, $spacingpx);
+    @include padding(null, null, null, $spacvalue);
   }
   $spacing: $spacing - 4;
 }
@@ -61,27 +104,27 @@ $spacing: 28;
 */
 $spacing: 28;
 @while $spacing >= 0 {
-  $spacingpx: $spacing * 1px;
+  $spacvalue: map-get($relative-spacing, $spacing);
   .fw-m-#{$spacing} {
-    @include margin($spacingpx, $spacingpx, $spacingpx, $spacingpx);
+    @include margin($spacvalue, $spacvalue, $spacvalue, $spacvalue);
   }
   .fw-mx-#{$spacing} {
-    @include margin(null, $spacingpx, null, $spacingpx);
+    @include margin(null, $spacvalue, null, $spacvalue);
   }
   .fw-my-#{$spacing} {
-    @include margin($spacingpx, null, $spacingpx, null);
+    @include margin($spacvalue, null, $spacvalue, null);
   }
   .fw-mt-#{$spacing} {
-    @include margin($spacingpx, null, null, null);
+    @include margin($spacvalue, null, null, null);
   }
   .fw-mr-#{$spacing} {
-    @include margin(null, $spacingpx, null, null);
+    @include margin(null, $spacvalue, null, null);
   }
   .fw-mb-#{$spacing} {
-    @include margin(null, null, $spacingpx, null);
+    @include margin(null, null, $spacvalue, null);
   }
   .fw-ml-#{$spacing} {
-    @include margin(null, null, null, $spacingpx);
+    @include margin(null, null, null, $spacvalue);
   }
   $spacing: $spacing - 4;
 }

--- a/styles/mixins/_typography.scss
+++ b/styles/mixins/_typography.scss
@@ -2,22 +2,22 @@
 
 $size-height-ratio: (
   header: (
-    12px: 16px,
-    14px: 20px,
-    16px: 20px,
-    18px: 24px,
-    24px: 32px,
-    32px: 40px,
-    44px: 54px,
+    0.75rem: 1rem,
+    0.875rem: 1.25rem,
+    1rem: 1.25rem,
+    1.125rem: 1.5rem,
+    1.5rem: 2rem,
+    2rem: 2.5rem,
+    2.75rem: 3.375rem,
   ),
   body: (
-    12px: 20px,
-    14px: 20px,
-    16px: 24px,
-    18px: 28px,
-    24px: 36px,
-    32px: 48px,
-    44px: 64px,
+    0.75rem: 1.25rem,
+    0.875rem: 1.25rem,
+    1rem: 1.5rem,
+    1.125rem: 1.75rem,
+    1.5rem: 2.25rem,
+    2rem: 3rem,
+    2.75rem: 4rem,
   ),
 );
 
@@ -29,7 +29,7 @@ $size-height-ratio: (
 }
 
 @mixin typography(
-  $type: 'body',
+  $type: body,
   $size: 16px,
   $color: $text-default,
   $weight: 400
@@ -39,21 +39,21 @@ $size-height-ratio: (
   font-weight: $weight;
   letter-spacing: normal;
 
-  @if (($type == 'body') or ($type == 'header')) {
-    @if $size == 12px {
-      line-height: map-deep-get($size-height-ratio, $type, 12px);
-    } @else if $size == 14px {
-      line-height: map-deep-get($size-height-ratio, $type, 14px);
-    } @else if $size == 16px {
-      line-height: map-deep-get($size-height-ratio, $type, 16px);
-    } @else if $size == 18px {
-      line-height: map-deep-get($size-height-ratio, $type, 18px);
-    } @else if $size == 24px {
-      line-height: map-deep-get($size-height-ratio, $type, 24px);
-    } @else if $size == 32px {
-      line-height: map-deep-get($size-height-ratio, $type, 32px);
-    } @else if $size == 44px {
-      line-height: map-deep-get($size-height-ratio, $type, 44px);
+  @if (($type == body) or ($type == header)) {
+    @if $size == 0.75rem {
+      line-height: map-deep-get($size-height-ratio, $type, 0.75rem);
+    } @else if $size == 0.875rem {
+      line-height: map-deep-get($size-height-ratio, $type, 0.875rem);
+    } @else if $size == 1rem {
+      line-height: map-deep-get($size-height-ratio, $type, 1rem);
+    } @else if $size == 1.125rem {
+      line-height: map-deep-get($size-height-ratio, $type, 1.125rem);
+    } @else if $size == 1.5rem {
+      line-height: map-deep-get($size-height-ratio, $type, 1.5rem);
+    } @else if $size == 2rem {
+      line-height: map-deep-get($size-height-ratio, $type, 2rem);
+    } @else if $size == 2.75rem {
+      line-height: map-deep-get($size-height-ratio, $type, 2.75rem);
     } @else {
       @error "Unacceptable font size #{$size}.";
     }

--- a/www/css-utils/card/readme.md
+++ b/www/css-utils/card/readme.md
@@ -12,12 +12,12 @@ To apply card css utils, we can use 'fw-card-#{$elevation}'
     <div>
       <div class="fw-card-1 fw-p-24 fw-flex fw-flex-row">
         <div class="fw-flex-grow">
-          <div class="fw-font-header-16">Arabic</div>
-          <div class="fw-font-12">Last updated - 25 June 2020</div>
+          <div class="fw-type-h5">Arabic</div>
+          <div class="fw-type-xs">Last updated - 25 June 2020</div>
         </div>
         <div class="fw-flex-grow-0">
-          <fw-button color="secondary" class="fw-font-header-14"> Download existing </fw-button>
-          <fw-button color="secondary" class="fw-font-header-14 fw-ml-8"> Update file </fw-button>
+          <fw-button color="secondary" class="fw-type-h6"> Download existing </fw-button>
+          <fw-button color="secondary" class="fw-type-h6 fw-ml-8"> Update file </fw-button>
         </div>
         <div class="fw-flex-grow-0">
           <fw-button size="icon" color="text" role="button" class="fw-ml-12">
@@ -35,8 +35,8 @@ To apply card css utils, we can use 'fw-card-#{$elevation}'
   <div>
     <div class="fw-card-2 fw-p-24 fw-flex fw-flex-row fw-items-center">
       <div class="fw-flex-grow">
-        <div class="fw-font-header-14">Show typing indicator</div>
-        <div class="fw-font-12">An indicator to see and share when messages are being typed</div>
+        <div class="fw-type-h6">Show typing indicator</div>
+        <div class="fw-type-xs">An indicator to see and share when messages are being typed</div>
       </div>
       <div class="fw-flex-grow-0">
         <fw-toggle size="medium" checked></fw-toggle>
@@ -52,13 +52,13 @@ To apply card css utils, we can use 'fw-card-#{$elevation}'
   <div>
     <div class="fw-card-3 fw-p-20 fw-flex fw-flex-column">
       <div class="fw-flex">
-        <span class="fw-flex-grow fw-font-header-18">Chat with us</span>
-        <span class="fw-font-12"><a href="#">View history</a></span>
+        <span class="fw-flex-grow fw-type-h4">Chat with us</span>
+        <span class="fw-type-xs"><a href="#">View history</a></span>
       </div>
       <div>
         <div class="fw-flex fw-flex-column fw-mt-4">
-          <div class="fw-font-header-14">Support</div>
-          <div class="fw-font-12">Typically replies within 5 minutes</div>
+          <div class="fw-type-h6">Support</div>
+          <div class="fw-type-xs">Typically replies within 5 minutes</div>
         </div>
       </div>
     </div>
@@ -83,9 +83,9 @@ To apply card css utils, we can use 'fw-card-#{$elevation}'
   ></fw-avatar>
       </div>
       <div class="fw-flex-grow fw-px-16 fw-flex fw-flex-column">
-        <div class="fw-font-header-16 fw-mb-8">Courtney Henry</div>
-        <div class="fw-font-12 fw-mb-16">Hey! I need help with cancellation of a combo pack that I had ordered yesterday.</div>
-        <div class="fw-font-12 fw-flex fw-flex-row options">
+        <div class="fw-type-h5 fw-mb-8">Courtney Henry</div>
+        <div class="fw-type-xs fw-mb-16">Hey! I need help with cancellation of a combo pack that I had ordered yesterday.</div>
+        <div class="fw-type-xs fw-flex fw-flex-row options">
           <div class="fw-pr-12">
             <span class="fw-mr-8"><fw-icon name="inbox" size="12"></fw-icon></span>
             <span>Cancellation</span>
@@ -96,7 +96,7 @@ To apply card css utils, we can use 'fw-card-#{$elevation}'
         </div>
       </div>
       <div>
-        <span class="fw-font-12">11 May 2021, 5:30 PM</span>
+        <span class="fw-type-xs">11 May 2021, 5:30 PM</span>
       </div>
     </div>
   </div>

--- a/www/css-utils/spacing/readme.md
+++ b/www/css-utils/spacing/readme.md
@@ -40,6 +40,13 @@
 </template>
 ```
 
+### Spacing size chart
+
+spacing | 0 | 4 | 8 | 12 | 16 | 20 | 24 | 28
+--- | --- | --- | --- |--- |--- |--- |--- |---
+rem | 0rem | 0.25rem | 0.5rem | 0.75rem | 1rem | 1.25rem | 1.5rem | 1.75
+px (font size of the root element being 16px) | 0px | 4px | 8px | 12px | 16px | 20px | 24px | 28px
+
 
 ----------------------------------------------
 

--- a/www/css-utils/typography/readme.md
+++ b/www/css-utils/typography/readme.md
@@ -2,20 +2,70 @@
 
 We can easily add font related styles through SASS mixin and CSS Utils.
 
-For header content, we can use the 'fw-font-header-#{$size}'.  
-For body content, we can use the 'fw-font-#{$size}'. 
+## Heading
 
-*#{$size} has to be substituted with font size number.*
+For heading text, we can use 'fw-type-#{size}'. 
 
-```html live
-<template>
-  <div class="container">
-    <div class="fw-font-header-16">Lorem ipsum dolor</div>
-    <div class="fw-font-12">
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla pretium velit feugiat rutrum ultrices. Morbi elementum id velit sit amet scelerisque. Proin tempus placerat luctus. Maecenas pulvinar quis libero nec accumsan. Pellentesque in pharetra odio.
-    </div>
-  </div>
-</template>
+*#{size} can be 'h1', 'h2' .. 'h6', 'h7'*
+
+#### Heading size chart:
+
+name | h1 | h2 | h3 | h4 | h5 | h6 | h7
+--- | --- | --- | --- |--- |--- |--- |---
+rem | 2.75rem | 2rem | 1.5rem | 1.125rem | 1rem | 0.875rem | 0.75rem
+px (font size of the root element being 16px) | 44px | 32px | 24px | 18px | 16px | 14px | 12px
+
+```html  live
+<div>
+  <div class="fw-type-h1">The quick brown fox jumps</div>
+  <div class="fw-type-h2">The quick brown fox jumps</div>
+  <div class="fw-type-h3">The quick brown fox jumps</div>
+  <div class="fw-type-h4">The quick brown fox jumps</div>
+  <div class="fw-type-h5">The quick brown fox jumps</div>
+  <div class="fw-type-h6">The quick brown fox jumps</div>
+  <div class="fw-type-h7">The quick brown fox jumps</div>
+</div>
+```
+
+## Body
+
+For Body text, we can use 'fw-type-#{size}'.
+
+*#{size} can be '3xl', '2xl', 'xl', 'lg', 'base', 'sm', 'xs'*
+
+#### Body size chart
+
+name | 3xl | 2xl | xl | lg | base | sm | xs
+--- | --- | --- | --- |--- |--- |--- |---
+rem | 2.75rem | 2rem | 1.5rem | 1.125rem | 1rem | 0.875rem | 0.75rem
+px (font size of the root element being 16px) | 44px | 32px | 24px | 18px | 16px | 14px | 12px
+
+
+```html  live
+<div>
+  <div class="fw-type-3xl">The quick brown fox jumps</div>
+  <div class="fw-type-2xl">The quick brown fox jumps</div>
+  <div class="fw-type-xl">The quick brown fox jumps</div>
+  <div class="fw-type-lg">The quick brown fox jumps</div>
+  <div class="fw-type-base">The quick brown fox jumps</div>
+  <div class="fw-type-sm">The quick brown fox jumps</div>
+  <div class="fw-type-xs">The quick brown fox jumps</div>
+</div>
+```
+
+## Font weight
+
+For font weight, we can use 'fw-type-#{weight}'
+
+*#{weight} can be 'bold', 'semibold', 'regular', 'light'*
+
+```html  live
+<div>
+  <div class="fw-type-bold">The quick brown fox jumps</div>
+  <div class="fw-type-semibold">The quick brown fox jumps</div>
+  <div class="fw-type-regular">The quick brown fox jumps</div>
+  <div class="fw-type-light">The quick brown fox jumps</div>
+</div>
 ```
 
 ----------------------------------------------


### PR DESCRIPTION
In this PR,

- Changed the class names of typography related css utils.
- Added a font weight util to typography section.
- Used rem units instead of px units for typography and spacing css utils.
- Improved documentation.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Testing using Vuepress docs.
