### PR TITLE
feat(data-table): adding select all rows to DataTable component

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -141,6 +141,10 @@ export namespace Components {
          */
         "getSelectedRows": () => Promise<DataTableRow[]>;
         /**
+          * isAllSelectable Booleam based on which select all option appears in the table header
+         */
+        "isAllSelectable": boolean;
+        /**
           * isSelectable Boolean based on which selectable options appears for rows in the table.
          */
         "isSelectable": boolean;
@@ -1809,6 +1813,10 @@ declare namespace LocalJSX {
          */
         "columns"?: DataTableColumn[];
         /**
+          * isAllSelectable Booleam based on which select all option appears in the table header
+         */
+        "isAllSelectable"?: boolean;
+        /**
           * isSelectable Boolean based on which selectable options appears for rows in the table.
          */
         "isSelectable"?: boolean;
@@ -1816,6 +1824,10 @@ declare namespace LocalJSX {
           * Label attribute is not visible on screen. There for accessibility purposes.
          */
         "label"?: string;
+        /**
+          * fwSelectAllChange Emits this event when select all is checked.
+         */
+        "onFwSelectAllChange"?: (event: CustomEvent<any>) => void;
         /**
           * fwSelectionChange Emits this event when row is selected/unselected.
          */

--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -131,6 +131,11 @@ export namespace Components {
          */
         "columns": DataTableColumn[];
         /**
+          * getColumnConfig
+          * @returns columnConfig object
+         */
+        "getColumnConfig": () => Promise<{}>;
+        /**
           * getSelectedIds
           * @returns an array of selected row IDs
          */
@@ -1824,6 +1829,10 @@ declare namespace LocalJSX {
           * Label attribute is not visible on screen. There for accessibility purposes.
          */
         "label"?: string;
+        /**
+          * fwColumnsPositionChange Emits this event when columns position changes.
+         */
+        "onFwColumnsPositionChange"?: (event: CustomEvent<any>) => void;
         /**
           * fwSelectAllChange Emits this event when select all is checked.
          */

--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -121,6 +121,7 @@ export namespace Components {
         "text": string;
     }
     interface FwCustomCellUser {
+        "alt": string;
         "email": string;
         "image": any;
         "name": string;
@@ -1808,6 +1809,7 @@ declare namespace LocalJSX {
         "text"?: string;
     }
     interface FwCustomCellUser {
+        "alt"?: string;
         "email"?: string;
         "image"?: any;
         "name"?: string;

--- a/packages/crayons-core/src/components/data-table/custom-cells/user/custom-cell-user.tsx
+++ b/packages/crayons-core/src/components/data-table/custom-cells/user/custom-cell-user.tsx
@@ -12,6 +12,8 @@ export class CustomCellUser {
 
   @Prop() email = '';
 
+  @Prop() alt = '';
+
   render() {
     return (
       <div class='name-box-container'>
@@ -20,7 +22,7 @@ export class CustomCellUser {
             size='small'
             image={this.image}
             name={this.name}
-            alt='Profile picture'
+            alt={this.alt}
           ></fw-avatar>
         </div>
         <div class='name-box'>

--- a/packages/crayons-core/src/components/data-table/custom-cells/user/custom-cell-user.tsx
+++ b/packages/crayons-core/src/components/data-table/custom-cells/user/custom-cell-user.tsx
@@ -20,6 +20,7 @@ export class CustomCellUser {
             size='small'
             image={this.image}
             name={this.name}
+            alt='Profile picture'
           ></fw-avatar>
         </div>
         <div class='name-box'>

--- a/packages/crayons-core/src/components/data-table/custom-cells/user/readme.md
+++ b/packages/crayons-core/src/components/data-table/custom-cells/user/readme.md
@@ -9,6 +9,7 @@
 
 | Property | Attribute | Description | Type     | Default |
 | -------- | --------- | ----------- | -------- | ------- |
+| `alt`    | `alt`     |             | `string` | `''`    |
 | `email`  | `email`   |             | `string` | `''`    |
 | `image`  | `image`   |             | `any`    | `null`  |
 | `name`   | `name`    |             | `string` | `''`    |

--- a/packages/crayons-core/src/components/data-table/data-table.e2e.ts
+++ b/packages/crayons-core/src/components/data-table/data-table.e2e.ts
@@ -13,7 +13,7 @@ describe('fw-data-table', () => {
       {
         key: 'name',
         text: 'Name',
-        orderIndex: 1,
+        position: 1,
       },
     ],
   };
@@ -109,12 +109,12 @@ describe('fw-data-table', () => {
         {
           key: 'name',
           text: 'Name',
-          orderIndex: 2,
+          position: 2,
         },
         {
           key: 'job',
           text: 'Job',
-          orderIndex: 1,
+          position: 1,
         },
       ],
     };
@@ -130,19 +130,96 @@ describe('fw-data-table', () => {
     expect(secondColumn.innerText).toEqual('Name');
   });
 
+  it('should render columns in right order even position value is not specified', async () => {
+    const data = {
+      rows: [
+        {
+          id: '1234',
+          name: 'Alexander Goodman',
+          job: 'Lead designer',
+        },
+      ],
+      columns: [
+        {
+          key: 'name',
+          text: 'Name',
+        },
+        {
+          key: 'job',
+          text: 'Job',
+        },
+      ],
+    };
+    await loadDataIntoGrid(data);
+    await page.waitForChanges();
+    const firstColumn = await page.find(
+      'fw-data-table >>> thead > tr > th:nth-child(1)'
+    );
+    const secondColumn = await page.find(
+      'fw-data-table >>> thead > tr > th:nth-child(2)'
+    );
+    expect(firstColumn.innerText).toEqual('Name');
+    expect(secondColumn.innerText).toEqual('Job');
+  });
+
+  it('should render columns in right order even if only some of the columns have position values', async () => {
+    const changedEvent = await page.spyOnEvent('fwColumnsPositionChange');
+    const data = {
+      rows: [
+        {
+          id: '1234',
+          name: 'Alexander Goodman',
+          job: 'Lead designer',
+          place: 'London',
+        },
+      ],
+      columns: [
+        {
+          key: 'place',
+          text: 'Place',
+          position: 2,
+        },
+        {
+          key: 'name',
+          text: 'Name',
+        },
+        {
+          key: 'job',
+          text: 'Job',
+          position: 1,
+        },
+      ],
+    };
+    await loadDataIntoGrid(data);
+    await page.waitForChanges();
+    const firstColumn = await page.find(
+      'fw-data-table >>> thead > tr > th:nth-child(1)'
+    );
+    const secondColumn = await page.find(
+      'fw-data-table >>> thead > tr > th:nth-child(2)'
+    );
+    const thirdColumn = await page.find(
+      'fw-data-table >>> thead > tr > th:nth-child(3)'
+    );
+    expect(firstColumn.innerText).toEqual('Job');
+    expect(secondColumn.innerText).toEqual('Place');
+    expect(thirdColumn.innerText).toEqual('Name');
+    expect(changedEvent).toHaveReceivedEventTimes(1);
+  });
+
   it('should render predefined components when column has variant name', async () => {
     const data = {
       columns: [
         {
           key: 'search',
           text: 'Search',
-          orderIndex: 1,
+          position: 1,
           variant: 'anchor',
         },
         {
           key: 'usedby',
           text: 'Used by',
-          orderIndex: 2,
+          position: 2,
           variant: 'user',
         },
       ],

--- a/packages/crayons-core/src/components/data-table/data-table.e2e.ts
+++ b/packages/crayons-core/src/components/data-table/data-table.e2e.ts
@@ -73,6 +73,29 @@ describe('fw-data-table', () => {
     expect(selectedRow).toBeTruthy();
   });
 
+  it('should show select all option when isAllSelectable prop is set to true', async () => {
+    const currentData = { ...data, isSelectable: true, isAllSelectable: true };
+    await loadDataIntoGrid(currentData);
+    await page.waitForChanges();
+    const checkbox = await page.find(
+      'fw-data-table >>> thead > tr:first-child > th:first-child > fw-checkbox'
+    );
+    expect(checkbox).toBeTruthy();
+  });
+
+  it('should trigger fwSelectAllChange when select-all checkbox is checked/unchecked', async () => {
+    const currentData = { ...data, isSelectable: true, isAllSelectable: true };
+    await loadDataIntoGrid(currentData);
+    await page.waitForChanges();
+    const checkbox = await page.find(
+      'fw-data-table >>> thead > tr:first-child > th:first-child > fw-checkbox'
+    );
+    const changedEvent = await page.spyOnEvent('fwSelectAllChange');
+    checkbox.click();
+    await page.waitForChanges();
+    expect(changedEvent).toHaveReceivedEventTimes(1);
+  });
+
   it('should render in the right column order', async () => {
     const data = {
       rows: [

--- a/packages/crayons-core/src/components/data-table/data-table.stories.mdx
+++ b/packages/crayons-core/src/components/data-table/data-table.stories.mdx
@@ -36,15 +36,15 @@ export const args = {
   columns: [{
     "key": "name",
     "text": "Name",
-    "orderIndex": 1
+    "position": 1
   }, {
     "key": "group",
     "text": "Group",
-    "orderIndex": 3
+    "position": 3
   }, {
     "key": "role",
     "text": "Role",
-    "orderIndex": 2
+    "position": 2
   }],
   isSelectable: false
 };

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -293,7 +293,8 @@ Row value for this column variant should be an object with the following propert
         "createdby": { 
           "image": "https://images.unsplash.com/photo-1614644147798-f8c0fc9da7f6?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=300&q=80",
           "name": "Alexander Goodman", 
-          "email": "alexander.goodman@freshdesk.com" 
+          "email": "alexander.goodman@freshdesk.com",
+          "alt": "Profile picture of Alexander Goodman"
         }
       }, {
         "id": "0022",
@@ -301,7 +302,8 @@ Row value for this column variant should be an object with the following propert
         "createdby": { 
           "image": "https://images.unsplash.com/photo-1633332755192-727a05c4013d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=300&q=80",
           "name": "Ambrose Wayne", 
-          "email": "ambrose.wayne@freshdesk.com" 
+          "email": "ambrose.wayne@freshdesk.com",
+          "alt": "Profile picture of Ambrose Wayne"
         }
       }, {
         "id": "0033",
@@ -309,7 +311,8 @@ Row value for this column variant should be an object with the following propert
         "createdby": {
           "image": "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=300&q=80",
           "name": "August hines", 
-          "email": "august.hines@freshdesk.com" 
+          "email": "august.hines@freshdesk.com",
+          "alt": "Profile picture of August hines"
         }
       }]
     }; 
@@ -345,7 +348,8 @@ Row value for this column variant should be an object with the following propert
       "createdby": { 
         "image": "https://images.unsplash.com/photo-1614644147798-f8c0fc9da7f6?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=300&q=80",
         "name": "Alexander Goodman", 
-        "email": "alexander.goodman@freshdesk.com" 
+        "email": "alexander.goodman@freshdesk.com",
+        "alt": "Profile picture of Alexander Goodman"
       }
     }, {
       "id": "0022",
@@ -353,7 +357,8 @@ Row value for this column variant should be an object with the following propert
       "createdby": { 
         "image": "https://images.unsplash.com/photo-1633332755192-727a05c4013d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=300&q=80",
         "name": "Ambrose Wayne", 
-        "email": "ambrose.wayne@freshdesk.com" 
+        "email": "ambrose.wayne@freshdesk.com",
+        "alt": "Profile picture of Ambrose Wayne"
       }
     }, {
       "id": "0033",
@@ -361,7 +366,8 @@ Row value for this column variant should be an object with the following propert
       "createdby": {
         "image": "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=300&q=80",
         "name": "August hines", 
-        "email": "august.hines@freshdesk.com" 
+        "email": "august.hines@freshdesk.com",
+        "alt": "Profile picture of August hines"
       }
     }]
   }; 
@@ -397,7 +403,8 @@ function App() {
       "createdby": { 
         "image": "https://images.unsplash.com/photo-1614644147798-f8c0fc9da7f6?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=300&q=80",
         "name": "Alexander Goodman", 
-        "email": "alexander.goodman@freshdesk.com" 
+        "email": "alexander.goodman@freshdesk.com",
+        "alt": "Profile picture of Alexander Goodman"
       }
     }, {
       "id": "0022",
@@ -405,7 +412,8 @@ function App() {
       "createdby": { 
         "image": "https://images.unsplash.com/photo-1633332755192-727a05c4013d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=300&q=80",
         "name": "Ambrose Wayne", 
-        "email": "ambrose.wayne@freshdesk.com" 
+        "email": "ambrose.wayne@freshdesk.com",
+        "alt": "Profile picture of Ambrose Wayne"
       }
     }, {
       "id": "0033",
@@ -413,7 +421,8 @@ function App() {
       "createdby": {
         "image": "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=300&q=80",
         "name": "August hines", 
-        "email": "august.hines@freshdesk.com" 
+        "email": "august.hines@freshdesk.com",
+        "alt": "Profile picture of August hines"
       }
     }]
   };

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -11,16 +11,13 @@ fw-data-table are used for data visualization.
     var data = {
       columns: [{
         "key": "name",
-        "text": "Name",
-        "orderIndex": 1
+        "text": "Name"
       }, {
         "key": "group",
-        "text": "Group",
-        "orderIndex": 3
+        "text": "Group"
       }, {
         "key": "role",
-        "text": "Role",
-        "orderIndex": 2
+        "text": "Role"
       }],
       persons: [{
         "id": "1234",
@@ -57,16 +54,13 @@ fw-data-table are used for data visualization.
   var data = {
     columns: [{
       "key": "name",
-      "text": "Name",
-      "orderIndex": 1
+      "text": "Name"
     }, {
       "key": "group",
-      "text": "Group",
-      "orderIndex": 3
+      "text": "Group"
     }, {
       "key": "role",
-      "text": "Role",
-      "orderIndex": 2
+      "text": "Role"
     }],
     persons: [{
       "id": "1234",
@@ -103,16 +97,13 @@ function App() {
   let data = {
       columns: [{
         "key": "name",
-        "text": "Name",
-        "orderIndex": 1
+        "text": "Name"
       }, {
         "key": "group",
-        "text": "Group",
-        "orderIndex": 3
+        "text": "Group"
       }, {
         "key": "role",
-        "text": "Role",
-        "orderIndex": 2
+        "text": "Role"
       }],
       persons: [{
         "id": "1234",
@@ -160,12 +151,12 @@ Row value for this column variant should be an object with the following propert
       columns: [{
         "key": "search",
         "text": "Search Engine",
-        "orderIndex": 1,
+        "position": 1,
         "variant": "anchor"
       }, {
         "key": "rank",
         "text": "Rank",
-        "orderIndex": 2
+        "position": 2
       }],
       rows: [{
         "id": "001",
@@ -200,12 +191,12 @@ Row value for this column variant should be an object with the following propert
     columns: [{
       "key": "search",
       "text": "Search Engine",
-      "orderIndex": 1,
+      "position": 1,
       "variant": "anchor"
     }, {
       "key": "rank",
       "text": "Rank",
-      "orderIndex": 2
+      "position": 2
     }],
     rows: [{
       "id": "001",
@@ -240,12 +231,12 @@ function App() {
     columns: [{
       "key": "search",
       "text": "Search Engine",
-      "orderIndex": 1,
+      "position": 1,
       "variant": "anchor"
     }, {
       "key": "rank",
       "text": "Rank",
-      "orderIndex": 2
+      "position": 2
     }],
     rows: [{
       "id": "001",
@@ -289,12 +280,12 @@ Row value for this column variant should be an object with the following propert
       columns: [{
         "key": "createdby",
         "text": "Created By",
-        "orderIndex": 1,
+        "position": 1,
         "variant": "user"
       }, {
         "key": "objectname",
         "text": "Object Name",
-        "orderIndex": 2
+        "position": 2
       }],
       rows: [{
         "id": "0011",
@@ -341,12 +332,12 @@ Row value for this column variant should be an object with the following propert
     columns: [{
       "key": "createdby",
       "text": "Created By",
-      "orderIndex": 1,
+      "position": 1,
       "variant": "user"
     }, {
       "key": "objectname",
       "text": "Object Name",
-      "orderIndex": 2
+      "position": 2
     }],
     rows: [{
       "id": "0011",
@@ -393,12 +384,12 @@ function App() {
     columns: [{
       "key": "createdby",
       "text": "Created By",
-      "orderIndex": 1,
+      "position": 1,
       "variant": "user"
     }, {
       "key": "objectname",
       "text": "Object Name",
-      "orderIndex": 2
+      "position": 2
     }],
     rows: [{
       "id": "0011",
@@ -476,13 +467,24 @@ This codeblock shows how to use custom cell function to display HTML content in 
 
 ## Events
 
-| Event               | Description                                                         | Type               |
-| ------------------- | ------------------------------------------------------------------- | ------------------ |
-| `fwSelectAllChange` | fwSelectAllChange Emits this event when select all is checked.      | `CustomEvent<any>` |
-| `fwSelectionChange` | fwSelectionChange Emits this event when row is selected/unselected. | `CustomEvent<any>` |
+| Event                     | Description                                                             | Type               |
+| ------------------------- | ----------------------------------------------------------------------- | ------------------ |
+| `fwColumnsPositionChange` | fwColumnsPositionChange Emits this event when columns position changes. | `CustomEvent<any>` |
+| `fwSelectAllChange`       | fwSelectAllChange Emits this event when select all is checked.          | `CustomEvent<any>` |
+| `fwSelectionChange`       | fwSelectionChange Emits this event when row is selected/unselected.     | `CustomEvent<any>` |
 
 
 ## Methods
+
+### `getColumnConfig() => Promise<{}>`
+
+getColumnConfig
+
+#### Returns
+
+Type: `Promise<{}>`
+
+columnConfig object
 
 ### `getSelectedIds() => Promise<string[]>`
 

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -465,18 +465,20 @@ This codeblock shows how to use custom cell function to display HTML content in 
 
 ## Properties
 
-| Property       | Attribute       | Description                                                                            | Type                | Default |
-| -------------- | --------------- | -------------------------------------------------------------------------------------- | ------------------- | ------- |
-| `columns`      | --              | Columns Array of objects that provides information regarding the columns in the table. | `DataTableColumn[]` | `[]`    |
-| `isSelectable` | `is-selectable` | isSelectable Boolean based on which selectable options appears for rows in the table.  | `boolean`           | `false` |
-| `label`        | `label`         | Label attribute is not visible on screen. There for accessibility purposes.            | `string`            | `''`    |
-| `rows`         | --              | Rows Array of objects to be displayed in the table.                                    | `DataTableRow[]`    | `[]`    |
+| Property          | Attribute           | Description                                                                            | Type                | Default |
+| ----------------- | ------------------- | -------------------------------------------------------------------------------------- | ------------------- | ------- |
+| `columns`         | --                  | Columns Array of objects that provides information regarding the columns in the table. | `DataTableColumn[]` | `[]`    |
+| `isAllSelectable` | `is-all-selectable` | isAllSelectable Booleam based on which select all option appears in the table header   | `boolean`           | `false` |
+| `isSelectable`    | `is-selectable`     | isSelectable Boolean based on which selectable options appears for rows in the table.  | `boolean`           | `false` |
+| `label`           | `label`             | Label attribute is not visible on screen. There for accessibility purposes.            | `string`            | `''`    |
+| `rows`            | --                  | Rows Array of objects to be displayed in the table.                                    | `DataTableRow[]`    | `[]`    |
 
 
 ## Events
 
 | Event               | Description                                                         | Type               |
 | ------------------- | ------------------------------------------------------------------- | ------------------ |
+| `fwSelectAllChange` | fwSelectAllChange Emits this event when select all is checked.      | `CustomEvent<any>` |
 | `fwSelectionChange` | fwSelectionChange Emits this event when row is selected/unselected. | `CustomEvent<any>` |
 
 

--- a/packages/crayons-core/src/utils/types.ts
+++ b/packages/crayons-core/src/utils/types.ts
@@ -57,5 +57,6 @@ export type DataTableColumn = {
   text: string;
   variant?: string;
   position?: number;
+  hasFocusableComponent?: boolean;
   customTemplate?: customTemplateFunc<VNode>;
 };

--- a/packages/crayons-core/src/utils/types.ts
+++ b/packages/crayons-core/src/utils/types.ts
@@ -55,7 +55,7 @@ export type customTemplateFunc<T> = (
 export type DataTableColumn = {
   key: string;
   text: string;
-  orderIndex: number;
-  customTemplate?: customTemplateFunc<VNode>;
   variant?: string;
+  position?: number;
+  customTemplate?: customTemplateFunc<VNode>;
 };


### PR DESCRIPTION
### This PR includes the following list of features for DataTable component:

1. Select all rows 
2. Making orderIndex of columns optional property. Renaming orderIndex to position.
3. a11y improvements to support custom cell variants. 

*Kindly review the PR as individual commits as this PR consists of changes across 7 files.*

#### Select all rows:
- Emits a 'fwSelectAllChange' event along with the current list of selected rowIds.

https://user-images.githubusercontent.com/61269786/147311804-2769234b-8212-4ab3-812b-5a972387ff4d.mov

#### OrderIndex of columns optional:
- Optional property.
- Renamed to position. Done to make it similar to legos API.
- If only few columns have position property, they will be sorted and shown first.

https://user-images.githubusercontent.com/61269786/147312681-9655f7dc-8311-4c78-b0c2-fe59bee7da8d.mov

#### a11y improvements for custom cell:
- If inner component is focusable, then the component is automatically focus when focus lands on the cell. Else, the table cell is focused. This configuration can be passed in the column data.
- This configuration for predefined variants is not necessary. Handled internally.

https://user-images.githubusercontent.com/61269786/147313147-59eb2617-51da-4ee4-acf2-17786843bc76.mov


### Steps to run vuepress documentation:
- From root of project run npm run docs:dev
- Open the link that shows up in console after running above command.
- Navigate to DataTable component in sidebar.


## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
- Tested manually with Vuepress documentation. 
- Supporting UTs added/passed
- For select all, a sample set with 500 rows was used for testing.
- For column position, all identified scenarios (position passed, skipped and passed only to some columns) were tested.
- a11y fixes tested on both predefined variants used.
