### PR TITLE
feat(pill): Adding pill component

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -635,6 +635,12 @@ export namespace Components {
          */
         "total": number;
     }
+    interface FwPill {
+        /**
+          * Theme based on which the pill is styled.
+         */
+        "color": 'blue' | 'red' | 'green' | 'yellow' | 'grey' | 'custom';
+    }
     interface FwPopover {
         /**
           * Whether to focus on the element in popover-content slot on opening the dropdown.
@@ -1508,6 +1514,12 @@ declare global {
         prototype: HTMLFwPaginationElement;
         new (): HTMLFwPaginationElement;
     };
+    interface HTMLFwPillElement extends Components.FwPill, HTMLStencilElement {
+    }
+    var HTMLFwPillElement: {
+        prototype: HTMLFwPillElement;
+        new (): HTMLFwPillElement;
+    };
     interface HTMLFwPopoverElement extends Components.FwPopover, HTMLStencilElement {
     }
     var HTMLFwPopoverElement: {
@@ -1652,6 +1664,7 @@ declare global {
         "fw-modal-footer": HTMLFwModalFooterElement;
         "fw-modal-title": HTMLFwModalTitleElement;
         "fw-pagination": HTMLFwPaginationElement;
+        "fw-pill": HTMLFwPillElement;
         "fw-popover": HTMLFwPopoverElement;
         "fw-progress-loader": HTMLFwProgressLoaderElement;
         "fw-radio": HTMLFwRadioElement;
@@ -2349,6 +2362,12 @@ declare namespace LocalJSX {
           * The total number of records. This is a mandatory parameter.
          */
         "total"?: number;
+    }
+    interface FwPill {
+        /**
+          * Theme based on which the pill is styled.
+         */
+        "color"?: 'blue' | 'red' | 'green' | 'yellow' | 'grey' | 'custom';
     }
     interface FwPopover {
         /**
@@ -3159,6 +3178,7 @@ declare namespace LocalJSX {
         "fw-modal-footer": FwModalFooter;
         "fw-modal-title": FwModalTitle;
         "fw-pagination": FwPagination;
+        "fw-pill": FwPill;
         "fw-popover": FwPopover;
         "fw-progress-loader": FwProgressLoader;
         "fw-radio": FwRadio;
@@ -3208,6 +3228,7 @@ declare module "@stencil/core" {
             "fw-modal-footer": LocalJSX.FwModalFooter & JSXBase.HTMLAttributes<HTMLFwModalFooterElement>;
             "fw-modal-title": LocalJSX.FwModalTitle & JSXBase.HTMLAttributes<HTMLFwModalTitleElement>;
             "fw-pagination": LocalJSX.FwPagination & JSXBase.HTMLAttributes<HTMLFwPaginationElement>;
+            "fw-pill": LocalJSX.FwPill & JSXBase.HTMLAttributes<HTMLFwPillElement>;
             "fw-popover": LocalJSX.FwPopover & JSXBase.HTMLAttributes<HTMLFwPopoverElement>;
             "fw-progress-loader": LocalJSX.FwProgressLoader & JSXBase.HTMLAttributes<HTMLFwProgressLoaderElement>;
             "fw-radio": LocalJSX.FwRadio & JSXBase.HTMLAttributes<HTMLFwRadioElement>;

--- a/packages/crayons-core/src/components/accordion/readme.md
+++ b/packages/crayons-core/src/components/accordion/readme.md
@@ -21,15 +21,13 @@ fw-accordion displays a collapsible accordion component, which expands/collapses
 <fw-accordion>
   <fw-accordion-title>
      <fw-icon
-     
       name='minus'
       size="14"
-      slot="expanded-icon" ></fw-icon>
+      slot="expanded-icon"></fw-icon>
     <fw-icon
-     
       name='plus'
       size="14"
-      slot="collapsed-icon"</fw-icon>
+      slot="collapsed-icon"></fw-icon>
     Header Text
   </fw-accordion-title>
   <fw-accordion-body>

--- a/packages/crayons-core/src/components/pill/pill.e2e.ts
+++ b/packages/crayons-core/src/components/pill/pill.e2e.ts
@@ -1,0 +1,15 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('fw-pill', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <fw-pill color="blue">
+        <fw-icon name="internet" slot="icon"></fw-icon>
+        Pill
+      </fw-pill>`);
+    const element = await page.find('fw-pill');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/packages/crayons-core/src/components/pill/pill.scss
+++ b/packages/crayons-core/src/components/pill/pill.scss
@@ -1,0 +1,89 @@
+/**
+  @prop --pill-color: Pill color
+  @prop --pill-background-color: Pill background color
+  @prop --pill-padding: Pill padding
+  @prop --pill-border: Pill border
+  @prop --pill-border-radius: Pill border radius
+*/
+
+:host {
+  --pill-border: none;
+  --pill-border-radius: 16px;
+  --pill-padding: 5px 12px 5px 8px;
+  --pill-color: $color-elephant-900;
+  --pill-background-color: $color-milk;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--pill-color);
+  background-color: var(--pill-background-color);
+  padding: var(--pill-padding);
+  border: var(--pill-border);
+  border-radius: var(--pill-border-radius);
+  font-weight: 600;
+  font-size: $font-size-12;
+  line-height: 1.5;
+
+  ::slotted(*) {
+    height: 14px;
+    width: 14px;
+  }
+
+  .pill-icon {
+    height: 14px;
+    width: 14px;
+    margin-right: 6px;
+  }
+
+  ::slotted(fw-icon) {
+    --icon-size: 14px;
+  }
+
+  &--blue {
+    background-color: $color-azure-50;
+    color: $color-azure-800;
+
+    ::slotted(fw-icon) {
+      --icon-color: #{$color-azure-800};
+    }
+  }
+
+  &--red {
+    background-color: $color-persimmon-50;
+    color: $color-persimmon-800;
+
+    ::slotted(fw-icon) {
+      --icon-color: #{$color-persimmon-800};
+    }
+  }
+
+  &--green {
+    background-color: $color-jungle-50;
+    color: $color-jungle-800;
+
+    ::slotted(fw-icon) {
+      --icon-color: #{$color-jungle-800};
+    }
+  }
+
+  &--yellow {
+    background-color: $color-casablanca-50;
+    color: $color-casablanca-700;
+
+    ::slotted(fw-icon) {
+      --icon-color: #{$color-casablanca-700};
+    }
+  }
+
+  &--grey {
+    background-color: $color-smoke-50;
+    color: $color-smoke-700;
+
+    ::slotted(fw-icon) {
+      --icon-color: #{$color-smoke-700};
+    }
+  }
+}

--- a/packages/crayons-core/src/components/pill/pill.stories.mdx
+++ b/packages/crayons-core/src/components/pill/pill.stories.mdx
@@ -13,12 +13,72 @@ import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
 ## Usage
 
-### Default
+### Blue
 <Preview>
-  <Story name='Default'>
-    {
-      () => `<fw-pill></fw-pill>`
-    }
-  </Story>
+<Story name='Blue'>
+{() => `<fw-pill color="blue">
+  <fw-icon name="info" slot="icon"></fw-icon>
+  Response Received
+</fw-pill>`}
+</Story>
 </Preview>
 
+### Red
+<Preview>
+<Story name='Red'>
+{() => `<fw-pill color="red">
+  <fw-icon name="alert" slot="icon"></fw-icon>
+  Overdue
+</fw-pill>`}
+</Story>
+</Preview>
+
+### Green
+<Preview>
+<Story name='Green'>
+{() => `<fw-pill color="green">
+  <fw-icon name="add-contact" slot="icon"></fw-icon>
+  New
+</fw-pill>`}
+</Story>
+</Preview>
+
+### Yellow
+<Preview>
+<Story name='Yellow'>
+{() => `<fw-pill color="yellow">
+  <fw-icon name="help" slot="icon"></fw-icon>
+  Pending
+</fw-pill>`}
+</Story>
+</Preview>
+
+### Grey
+<Preview>
+<Story name='Grey'>
+{() => `<fw-pill color="grey">
+  <fw-icon name="add-note" slot="icon"></fw-icon>
+  Archived
+</fw-pill>`}
+</Story>
+</Preview>
+
+### Pills with custom icons or images
+<Preview>
+<Story name='Custom icons or images'>
+{() => `<fw-pill color="grey">
+  <img src="/favicon.ico" slot="icon" />
+  Crayons custom icon
+</fw-pill>`}
+</Story>
+</Preview>
+
+### Pills with custom CSS properties
+<Preview>
+<Story name='Custyom CSS styles'>
+{() => `<fw-pill color="custom" style="--pill-background-color: #fff;--pill-border: 1px solid gray;--pill-padding: 4px 12px 4px 8px;">
+  <fw-icon name="info" slot="icon"></fw-icon>
+  Custom Styled Pill
+</fw-pill>`}
+</Story>
+</Preview>

--- a/packages/crayons-core/src/components/pill/pill.stories.mdx
+++ b/packages/crayons-core/src/components/pill/pill.stories.mdx
@@ -1,0 +1,24 @@
+import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+
+# Pill
+
+<Meta
+  title='Pill'
+  component='fw-pill'
+/>
+
+## Props 
+
+<Props of="fw-pill"/>
+
+## Usage
+
+### Default
+<Preview>
+  <Story name='Default'>
+    {
+      () => `<fw-pill></fw-pill>`
+    }
+  </Story>
+</Preview>
+

--- a/packages/crayons-core/src/components/pill/pill.tsx
+++ b/packages/crayons-core/src/components/pill/pill.tsx
@@ -1,0 +1,36 @@
+import { Component, Element, Prop, h } from '@stencil/core';
+
+@Component({
+  tag: 'fw-pill',
+  styleUrl: 'pill.scss',
+  shadow: true,
+})
+export class Pill {
+  @Element() el: HTMLFwPillElement;
+
+  /**
+   * Theme based on which the pill is styled.
+   */
+  @Prop() color: 'blue' | 'red' | 'green' | 'yellow' | 'grey' | 'custom' =
+    'grey';
+
+  hasIcon: boolean;
+
+  componentWillLoad() {
+    this.hasIcon = !!this.el.querySelector('[slot="icon"');
+  }
+
+  render() {
+    return (
+      <span class={`pill pill--${this.color.toLowerCase()}`}>
+        {this.hasIcon && (
+          <div class='pill-icon'>
+            <slot name='icon' />
+          </div>
+        )}
+
+        <slot></slot>
+      </span>
+    );
+  }
+}

--- a/packages/crayons-core/src/components/pill/readme.md
+++ b/packages/crayons-core/src/components/pill/readme.md
@@ -43,7 +43,7 @@ Pill can be customized with custom colors by setting attribute `color="custom"` 
 ```html live
 <fw-pill color="custom" style="--pill-background-color: #fff;--pill-border: 1px solid gray;--pill-padding: 4px 12px 4px 8px;">
   <fw-icon name="info" slot="icon"></fw-icon>
-  Custom Pill
+  Custom Styled Pill
 </fw-pill>
 ```
 

--- a/packages/crayons-core/src/components/pill/readme.md
+++ b/packages/crayons-core/src/components/pill/readme.md
@@ -1,0 +1,123 @@
+# Pill (fw-pill)
+
+fw-pill displays an informational text component with icon.
+<br>
+Icon inside the pill must be set with attribute `slot="icon"` and it could either be `fw-icon` or customised with images or SVG icons as required.
+
+## Demo
+
+```html live
+<fw-pill color="blue">
+  <fw-icon name="info" slot="icon"></fw-icon>
+  Response Received
+</fw-pill>
+<fw-pill color="red">
+  <fw-icon name="alert" slot="icon"></fw-icon>
+  Overdue
+</fw-pill>
+<fw-pill color="green">
+  <fw-icon name="add-contact" slot="icon"></fw-icon>
+  New
+</fw-pill>
+<fw-pill color="yellow">
+  <fw-icon name="help" slot="icon"></fw-icon>
+  Pending
+</fw-pill>
+<fw-pill color="grey">
+  <fw-icon name="add-note" slot="icon"></fw-icon>
+  Archived
+</fw-pill>
+```
+
+### Styling Pills with custom icons or images
+
+```html live
+<fw-pill color="grey">
+  <img src="/favicon.png" slot="icon" />
+  Crayons custom icon
+</fw-pill>
+```
+
+### Styling Pills with custom CSS
+Pill can be customized with custom colors by setting attribute `color="custom"` and apply the styles using custom CSS properties listed further below in the page.
+```html live
+<fw-pill color="custom" style="--pill-background-color: #fff;--pill-border: 1px solid gray;--pill-padding: 4px 12px 4px 8px;">
+  <fw-icon name="info" slot="icon"></fw-icon>
+  Custom Pill
+</fw-pill>
+```
+
+## Usage
+
+<code-group>
+<code-block title="HTML">
+```html
+<fw-pill>
+  <fw-icon name="internet" slot="icon"></fw-icon>
+  Meta Information
+</fw-pill>
+<fw-pill color="blue">
+  <fw-icon name="info" slot="icon"></fw-icon>
+  Response Received
+</fw-pill>
+<fw-pill color="red">
+  <fw-icon name="alert" slot="icon" ></fw-icon>
+  Overdue
+</fw-pill>
+<fw-pill color="green">
+  <fw-icon name="add-contact" slot="icon" ></fw-icon>
+  New
+</fw-pill>
+<fw-pill color="yellow">
+  <fw-icon name="help" slot="icon" ></fw-icon>
+  Pending
+</fw-pill>
+<fw-pill color="grey">
+  <fw-icon name="add-note" slot="icon" ></fw-icon>
+  Archived
+</fw-pill>
+````
+</code-block>
+
+<code-block title="React">
+```jsx
+import React from "react";
+import ReactDOM from "react-dom";
+import { FwPill } from "@freshworks/crayons/react";
+function App() {
+  return (<div>
+    <FwPill color="green">
+      <FwIcon name="internet" slot="icon"></FwIcon>
+      Meta Information
+    </FwPill>
+ </div>);
+}
+````
+
+</code-block>
+</code-group>
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property | Attribute | Description                              | Type                                                           | Default  |
+| -------- | --------- | ---------------------------------------- | -------------------------------------------------------------- | -------- |
+| `color`  | `color`   | Theme based on which the pill is styled. | `"blue" \| "custom" \| "green" \| "grey" \| "red" \| "yellow"` | `'grey'` |
+
+
+## CSS Custom Properties
+
+| Name                      | Description           |
+| ------------------------- | --------------------- |
+| `--pill-background-color` | Pill background color |
+| `--pill-border`           | Pill border           |
+| `--pill-border-radius`    | Pill border radius    |
+| `--pill-color`            | Pill color            |
+| `--pill-padding`          | Pill padding          |
+
+
+----------------------------------------------
+
+Built with ❤ at Freshworks


### PR DESCRIPTION
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
- [x] All new and existing tests passed.

# Pill (fw-pill)

fw-pill displays an informational text component with icon.
<br>
Icon inside the pill must be set with attribute `slot="icon"` and it could either be `fw-icon` or customised with images or SVG icons as required.

```html live
<fw-pill color="blue">
  <fw-icon name="info" slot="icon"></fw-icon>
  Response Received
</fw-pill>
```

![image](https://user-images.githubusercontent.com/59990784/147443346-b760cddf-9d47-4cb7-bad0-bac58e83b69d.png)

