### PR TITLE
feat(data-table): adding row actions feature to fw-data-table

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -6,7 +6,7 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { AccordionToggleEvent } from "./components/accordion/accordion";
-import { DataTableColumn, DataTableRow, DropdownVariant, PopoverPlacementType, PopoverTriggerType, TagVariant } from "./utils/types";
+import { DataTableAction, DataTableColumn, DataTableRow, DropdownVariant, PopoverPlacementType, PopoverTriggerType, TagVariant } from "./utils/types";
 import { ToastOptions } from "./components/toast/toast-util";
 export namespace Components {
     interface FwAccordion {
@@ -158,6 +158,16 @@ export namespace Components {
           * Label attribute is not visible on screen. There for accessibility purposes.
          */
         "label": string;
+        /**
+          * loadTable - Method to call when we want to change table loading state
+          * @param state to load table or not
+          * @returns isTableLoading current state
+         */
+        "loadTable": (state: boolean) => Promise<boolean>;
+        /**
+          * To enable bulk actions on the table.
+         */
+        "rowActions": DataTableAction[];
         /**
           * Rows Array of objects to be displayed in the table.
          */
@@ -1843,6 +1853,10 @@ declare namespace LocalJSX {
           * fwSelectionChange Emits this event when row is selected/unselected.
          */
         "onFwSelectionChange"?: (event: CustomEvent<any>) => void;
+        /**
+          * To enable bulk actions on the table.
+         */
+        "rowActions"?: DataTableAction[];
         /**
           * Rows Array of objects to be displayed in the table.
          */

--- a/packages/crayons-core/src/components/button/readme.md
+++ b/packages/crayons-core/src/components/button/readme.md
@@ -298,6 +298,7 @@ Type: `Promise<any>`
 
 ### Used by
 
+ - [fw-data-table](../data-table)
  - [fw-datepicker](../datepicker)
  - [fw-dropdown-button](../dropdown-button)
  - [fw-modal-footer](../modal-footer)
@@ -317,6 +318,7 @@ graph TD;
   fw-icon --> fw-toast-message
   fw-toast-message --> fw-spinner
   fw-toast-message --> fw-icon
+  fw-data-table --> fw-button
   fw-datepicker --> fw-button
   fw-dropdown-button --> fw-button
   fw-modal-footer --> fw-button

--- a/packages/crayons-core/src/components/data-table/data-table.e2e.ts
+++ b/packages/crayons-core/src/components/data-table/data-table.e2e.ts
@@ -245,4 +245,83 @@ describe('fw-data-table', () => {
     expect(anchorComponent).toBeTruthy();
     expect(userComponent).toBeTruthy();
   });
+
+  it('should display action column when rowActions is passed to datatable', async () => {
+    const data = {
+      rows: [
+        {
+          id: '1234',
+          name: 'Alexander Goodman',
+        },
+      ],
+      columns: [
+        {
+          key: 'name',
+          text: 'Name',
+        },
+      ],
+      rowActions: [
+        {
+          name: 'Edit',
+          handler: (rowData) => {
+            console.log(rowData.name);
+          },
+        },
+      ],
+    };
+    await loadDataIntoGrid(data);
+    await page.waitForChanges();
+    const actionColumn = await page.find(
+      'fw-data-table >>> thead > tr > th:last-child'
+    );
+    const actionButton = await page.find(
+      'fw-data-table >>> tbody > tr > td.row-actions > fw-button'
+    );
+    expect(actionColumn.innerText).toEqual('Actions');
+    expect(actionButton).toBeTruthy();
+  });
+
+  it('should call the handler when action button is clicked', async () => {
+    const myMock = jest.fn();
+    const data = {
+      rows: [
+        {
+          id: '1234',
+          name: 'Alexander Goodman',
+        },
+      ],
+      columns: [
+        {
+          key: 'name',
+          text: 'Name',
+        },
+      ],
+      rowActions: [
+        {
+          name: 'Edit',
+          handler: (rowData) => {
+            console.log(rowData.name);
+          },
+        },
+      ],
+    };
+    await page.exposeFunction('actionHandler', () => {
+      myMock();
+    });
+    await page.$eval(
+      'fw-data-table',
+      (elm: any, data: any) => {
+        data.rowActions[0].handler = (window as any).actionHandler;
+        Object.assign(elm, data);
+      },
+      data
+    );
+    await page.waitForChanges();
+    const actionButton = await page.find(
+      'fw-data-table >>> tbody > tr > td.row-actions > fw-button'
+    );
+    actionButton.click();
+    await page.waitForChanges();
+    expect(myMock).toHaveBeenCalled();
+  });
 });

--- a/packages/crayons-core/src/components/data-table/data-table.scss
+++ b/packages/crayons-core/src/components/data-table/data-table.scss
@@ -15,6 +15,7 @@ div.fw-data-table-container {
   $grid-density-md: 12px 8px;
   $grid-density-lg: 16px 8px;
 
+  position: relative;
   display: inline-block;
   width: 100%;
   height: 100%;
@@ -118,7 +119,19 @@ div.fw-data-table-container {
             padding-right: 16px;
           }
         }
+
+        td.row-actions > fw-button {
+          margin-right: 5px;
+        }
       }
     }
+  }
+
+  .fw-data-table-disable {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    width: 100%;
+    height: 100%;
   }
 }

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -11,7 +11,11 @@ import {
   Method,
 } from '@stencil/core';
 
-import { DataTableColumn, DataTableRow } from '../../utils/types';
+import {
+  DataTableColumn,
+  DataTableRow,
+  DataTableAction,
+} from '../../utils/types';
 
 const PREDEFINED_VARIANTS_META = {
   anchor: {
@@ -39,6 +43,11 @@ export class DataTable {
    * Label attribute is not visible on screen. There for accessibility purposes.
    */
   @Prop({ mutable: true, reflect: false }) label = '';
+
+  /**
+   * To enable bulk actions on the table.
+   */
+  @Prop({ mutable: false }) rowActions: DataTableAction[] = [];
 
   /**
    * Rows Array of objects to be displayed in the table.
@@ -71,6 +80,16 @@ export class DataTable {
   @State() selected: string[] = [];
 
   /**
+   * To disable table during async operations
+   */
+  @State() isTableLoading = false;
+
+  /**
+   * Collection of rows loading
+   */
+  @State() rowsLoading = {};
+
+  /**
    * fwSelectionChange Emits this event when row is selected/unselected.
    */
   @Event() fwSelectionChange: EventEmitter;
@@ -92,10 +111,27 @@ export class DataTable {
   selectAllProgressCount = 0;
 
   /**
+   * Private
+   * To perform actions after a render
+   * WorkAround for stencil wait for next render
+   * https://github.com/ionic-team/stencil/issues/2744
+   */
+  renderPromiseResolve = null;
+
+  /**
    * componentWillLoad lifecycle event
    */
   componentWillLoad() {
     this.columnOrdering(this.columns);
+  }
+
+  /**
+   * componentDidRender lifecycle event
+   */
+  componentDidRender() {
+    if (this.renderPromiseResolve) {
+      this.renderPromiseResolve();
+    }
   }
 
   /**
@@ -150,18 +186,52 @@ export class DataTable {
    */
   @Listen('keydown')
   keyDownHandler(event) {
-    const currentElement: HTMLElement = this.closestTableCell(event.path);
-    if (currentElement) {
+    const currentElement: HTMLElement = event.path[0];
+    const currentCell: HTMLElement = this.closestTableCell(event.path);
+    let cellFocusChange = false;
+
+    // Switch focus between components inside a cell
+    if (currentElement !== currentCell) {
+      let nextFocusElement = null;
+      switch (event.code) {
+        case 'ArrowRight':
+          if (currentElement.nextElementSibling) {
+            nextFocusElement = currentElement.nextElementSibling as any;
+          } else {
+            cellFocusChange = true;
+          }
+          break;
+        case 'ArrowLeft':
+          if (currentElement.previousElementSibling) {
+            nextFocusElement = currentElement.previousElementSibling as any;
+          } else {
+            cellFocusChange = true;
+          }
+          break;
+        default:
+          cellFocusChange = true;
+          break;
+      }
+      if (nextFocusElement) {
+        nextFocusElement.setAttribute('tabIndex', '0');
+        nextFocusElement.focus();
+      }
+    } else {
+      cellFocusChange = true;
+    }
+
+    // Switch focus between cells
+    if (cellFocusChange && currentCell) {
       const currentRowIndex: number =
-        +currentElement.parentElement.getAttribute('aria-rowIndex');
+        +currentCell.parentElement.getAttribute('aria-rowIndex');
       const currentColIndex: number =
-        +currentElement.getAttribute('aria-colIndex');
+        +currentCell.getAttribute('aria-colIndex');
       let nextRowIndex: number;
       let nextColIndex: number;
-      const columnLength: number = this.isSelectable
-        ? this.orderedColumns.length + 1
-        : this.orderedColumns.length;
-      switch (event.key) {
+      let columnLength: number = this.orderedColumns.length;
+      columnLength = this.isSelectable ? columnLength + 1 : columnLength;
+      columnLength = this.rowActions.length ? columnLength + 1 : columnLength;
+      switch (event.code) {
         case 'ArrowDown':
           nextRowIndex = currentRowIndex + 1;
           nextColIndex = currentColIndex;
@@ -195,18 +265,8 @@ export class DataTable {
         `[aria-rowIndex="${nextRowIndex}"] > [aria-colIndex="${nextColIndex}"]`
       );
       if (nextCell) {
-        currentElement.setAttribute('tabIndex', '-1');
-        if (
-          nextCell.dataset.hasFocusableChild &&
-          nextCell.dataset.hasFocusableChild === 'true'
-        ) {
-          nextCell.removeAttribute('tabIndex');
-          nextCell.firstChild.setAttribute('tabIndex', 0);
-          nextCell.firstChild.focus();
-        } else {
-          nextCell.setAttribute('tabIndex', '0');
-          nextCell.focus();
-        }
+        this.removeFocusCell(currentCell);
+        this.focusCell(nextCell, event.code);
       }
     }
   }
@@ -249,6 +309,61 @@ export class DataTable {
       columnConfig[column.key] = { position: column.position };
     });
     return columnConfig;
+  }
+
+  /**
+   * loadTable - Method to call when we want to change table loading state
+   * @param state to load table or not
+   * @returns isTableLoading current state
+   */
+  @Method()
+  async loadTable(state: boolean) {
+    this.isTableLoading = state;
+    return this.isTableLoading;
+  }
+
+  /**
+   * WorkAround for wait until next render in stenciljs
+   * https://github.com/ionic-team/stencil/issues/2744
+   */
+  waitForNextRender() {
+    return new Promise((resolve) => (this.renderPromiseResolve = resolve));
+  }
+
+  /**
+   * Function to call when removing the focus of a table cell
+   * @param cell table cell
+   */
+  removeFocusCell(cell: HTMLElement) {
+    cell.setAttribute('tabIndex', '-1');
+  }
+
+  /**
+   * Function to call when focusing a table cell
+   * @param cell table cell
+   * @param direction key direction when focus comes into cell
+   */
+  focusCell(cell: HTMLElement, direction = 'ArrowRight') {
+    if (
+      cell.dataset.hasFocusableChild &&
+      cell.dataset.hasFocusableChild === 'true'
+    ) {
+      cell.removeAttribute('tabIndex');
+      let childElement = null;
+      switch (direction) {
+        case 'ArrowLeft':
+          childElement = cell.children[cell.children.length - 1];
+          break;
+        default:
+          childElement = cell.children[0];
+          break;
+      }
+      childElement.setAttribute('tabIndex', '0');
+      childElement.focus();
+    } else {
+      cell.setAttribute('tabIndex', '0');
+      cell.focus();
+    }
   }
 
   /**
@@ -319,6 +434,61 @@ export class DataTable {
     if (positionChangedColumns.length) {
       this.fwColumnsPositionChange.emit(positionChangedColumns);
     }
+  }
+
+  /**
+   * getShimmerHeight from one of the table's cell
+   * @param tableCell one of the table cell
+   * @returns {string} shimmer height
+   */
+  getShimmerHeight(tableCell) {
+    const tableRow = tableCell.parentNode;
+    const tableHeight = parseFloat(window.getComputedStyle(tableRow).height);
+    const tablCellTopPadding = parseFloat(
+      window.getComputedStyle(tableCell).paddingTop
+    );
+    const tableCellBottomPadding = parseFloat(
+      window.getComputedStyle(tableCell).paddingBottom
+    );
+    return tableHeight - tablCellTopPadding - tableCellBottomPadding + 'px';
+  }
+
+  /**
+   * performRowAction
+   * @param event UI event
+   * @param action action object - has information related to the action to be performed
+   * @param rowData rowData - complete data of the current row
+   */
+  async performRowAction(
+    event: any,
+    action: DataTableAction,
+    rowData: DataTableRow
+  ) {
+    const tableRow = this.closestTableCell(event.path).parentNode;
+    const tableRowHeight = window.getComputedStyle(tableRow).height;
+    tableRow.style.height = tableRowHeight;
+    const skeletonHeight = this.getShimmerHeight(
+      this.closestTableCell(event.path)
+    );
+    const selectAll: any = this.el.shadowRoot.querySelector(
+      'fw-checkbox#select-all'
+    );
+    if (selectAll) {
+      selectAll.disabled = true;
+    }
+    this.rowsLoading = { ...this.rowsLoading, [rowData.id]: skeletonHeight };
+    try {
+      await action.handler(rowData);
+    } catch (error) {
+      console.log(error.message);
+    }
+    delete this.rowsLoading[rowData.id];
+    this.rowsLoading = { ...this.rowsLoading };
+    if (selectAll && Object.keys(this.rowsLoading).length === 0) {
+      selectAll.disabled = false;
+    }
+    await this.waitForNextRender(); // To avoid UI jitter when shimmer disappears.
+    tableRow.style.height = 'auto';
   }
 
   /**
@@ -408,6 +578,18 @@ export class DataTable {
             {column.text}
           </th>
         ))}
+        {this.rowActions.length !== 0 && (
+          <th
+            role='columnheader'
+            aria-colindex={
+              this.isSelectable
+                ? this.orderedColumns.length + 2
+                : this.orderedColumns.length + 1
+            }
+          >
+            Actions
+          </th>
+        )}
       </tr>
     ) : null;
   }
@@ -426,7 +608,15 @@ export class DataTable {
                 aria-colindex={1}
                 data-has-focusable-child='true'
               >
-                <fw-checkbox value={row.id ? row.id : ''}></fw-checkbox>
+                {!this.rowsLoading[row.id] ? (
+                  <fw-checkbox value={row.id ? row.id : ''}></fw-checkbox>
+                ) : (
+                  <fw-skeleton
+                    style={{ '--skeleton-margin-bottom': '0px' }}
+                    height={this.rowsLoading[row.id]}
+                    variant='rect'
+                  ></fw-skeleton>
+                )}
               </td>
             )}
             {this.orderedColumns.map((orderedColumn, columnIndex) => {
@@ -448,10 +638,64 @@ export class DataTable {
                 : 'false';
               return (
                 <td role='gridcell' {...attrs}>
-                  {this.renderTableCell(orderedColumn, row[orderedColumn.key])}
+                  {!this.rowsLoading[row.id] ? (
+                    this.renderTableCell(orderedColumn, row[orderedColumn.key])
+                  ) : (
+                    <fw-skeleton
+                      style={{ '--skeleton-margin-bottom': '0px' }}
+                      height={this.rowsLoading[row.id]}
+                      variant='rect'
+                    ></fw-skeleton>
+                  )}
                 </td>
               );
             })}
+            {this.rowActions.length !== 0 && (
+              <td
+                class='row-actions'
+                data-has-focusable-child='true'
+                aria-colindex={
+                  this.isSelectable
+                    ? this.orderedColumns.length + 2
+                    : this.orderedColumns.length + 1
+                }
+              >
+                {!this.rowsLoading[row.id] ? (
+                  this.rowActions.map((action: DataTableAction) => {
+                    let actionTemplate = null;
+                    if (
+                      !action.hideForRowIds ||
+                      (action.hideForRowIds &&
+                        !action.hideForRowIds.includes(row.id))
+                    ) {
+                      actionTemplate = (
+                        <fw-button
+                          size='small'
+                          color='secondary'
+                          onKeyUp={(event) =>
+                            (event.code === 'Space' ||
+                              event.code === 'Enter') &&
+                            this.performRowAction(event, action, row)
+                          }
+                          onClick={(event) =>
+                            this.performRowAction(event, action, row)
+                          }
+                        >
+                          {action.name}
+                        </fw-button>
+                      );
+                    }
+                    return actionTemplate;
+                  })
+                ) : (
+                  <fw-skeleton
+                    style={{ '--skeleton-margin-bottom': '0px' }}
+                    height={this.rowsLoading[row.id]}
+                    variant='rect'
+                  ></fw-skeleton>
+                )}
+              </td>
+            )}
           </tr>
         ))
       : null;
@@ -472,6 +716,7 @@ export class DataTable {
           <thead>{this.renderTableHeader()}</thead>
           <tbody>{this.renderTableBody()}</tbody>
         </table>
+        {this.isTableLoading && <div class='fw-data-table-disable'></div>}
       </div>
     );
   }

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -460,6 +460,195 @@ This codeblock shows how to use custom cell function to display HTML content in 
 ```
 
 
+### Row Actions:
+
+You can easily add an actions column by passing in rowActions prop to the component.
+
+```html live
+  <fw-data-table id="datatable-4"  is-selectable="true" is-all-selectable="true" label="Data table 4">
+  </fw-data-table>
+
+  <script type="application/javascript">
+    var data = {
+      columns: [{
+        "key": "name",
+        "text": "Name"
+      }, {
+        "key": "role",
+        "text": "Role"
+      }],
+      rows: [{
+        "id": "0001",
+        "name": "Alexander Goodman",
+        "role": "Member"
+      }, {
+        "id": "0002",
+        "name": "Ambrose Wayne",
+        "role": "Member"
+      }, {
+        "id": "0003",
+        "name": "August hines",
+        "role": "Administrator"
+      }],
+      rowActions: [{
+        "name": "Alert",
+        "handler": (rowData) => {
+          window.alert(rowData.name);
+        }
+      }, {
+        "name": "Delete",
+        "handler": async (rowData) => {
+          let deletePromise = new Promise((resolve, reject) => {
+            const dataTable = document.querySelector('#datatable-4');
+            setTimeout(() => {
+              if (dataTable) {
+                dataTable.rows = dataTable.rows.filter((row) => (row.id !== rowData.id));
+                resolve();
+              } else {
+                reject();
+              }
+            }, 3000); 
+          });
+          await deletePromise;
+        },
+        "hideForRowIds": ["0003"]
+      }]
+    }
+
+    var datatable4 = document.getElementById('datatable-4');
+    datatable4.columns = data.columns;
+    datatable4.rows = data.rows;
+    datatable4.rowActions = data.rowActions;
+  </script>
+```
+
+<code-group>
+<code-block title="HTML">
+
+```html
+  <fw-data-table id="datatable-4"  is-selectable="true" is-all-selectable="true" label="Data table 4">
+  </fw-data-table>
+```
+
+```javascript
+  var data = {
+    columns: [{
+      "key": "name",
+      "text": "Name"
+    }, {
+      "key": "role",
+      "text": "Role"
+    }],
+    rows: [{
+      "id": "0001",
+      "name": "Alexander Goodman",
+      "role": "Member"
+    }, {
+      "id": "0002",
+      "name": "Ambrose Wayne",
+      "role": "Member"
+    }, {
+      "id": "0003",
+      "name": "August hines",
+      "role": "Administrator"
+    }],
+    rowActions: [{
+      "name": "Alert",
+      "handler": (rowData) => {
+        window.alert(rowData.name);
+      }
+    }, {
+      "name": "Delete",
+      "handler": async (rowData) => {
+        let deletePromise = new Promise((resolve, reject) => {
+          const dataTable = document.querySelector('#datatable-4');
+          setTimeout(() => {
+            if (dataTable) {
+              dataTable.rows = dataTable.rows.filter((row) => (row.id !== rowData.id));
+              resolve();
+            } else {
+              reject();
+            }
+          }, 3000); 
+        });
+        await deletePromise;
+      },
+      "hideForRowIds": ["0003"]
+    }]
+  }
+
+  var datatable4 = document.getElementById('datatable-4');
+  datatable4.columns = data.columns;
+  datatable4.rows = data.rows;
+  datatable4.rowActions = data.rowActions;
+```
+
+</code-block>
+
+<code-block title="React">
+
+```jsx
+  import React from "react";
+  import ReactDOM from "react-dom";
+  import { FWDataTable } from "@freshworks/crayons/react";
+  function App() {
+
+    var data = {
+      columns: [{
+        "key": "name",
+        "text": "Name"
+      }, {
+        "key": "role",
+        "text": "Role"
+      }],
+      rows: [{
+        "id": "0001",
+        "name": "Alexander Goodman",
+        "role": "Member"
+      }, {
+        "id": "0002",
+        "name": "Ambrose Wayne",
+        "role": "Member"
+      }, {
+        "id": "0003",
+        "name": "August hines",
+        "role": "Administrator"
+      }],
+      rowActions: [{
+        "name": "Alert",
+        "handler": (rowData) => {
+          window.alert(rowData.name);
+        }
+      }, {
+        "name": "Delete",
+        "handler": async (rowData) => {
+          let deletePromise = new Promise((resolve, reject) => {
+            const dataTable = document.querySelector('#datatable-4');
+            setTimeout(() => {
+              if (dataTable) {
+                dataTable.rows = dataTable.rows.filter((row) => (row.id !== rowData.id));
+                resolve();
+              } else {
+                reject();
+              }
+            }, 3000); 
+          });
+          await deletePromise;
+        },
+        "hideForRowIds": ["0003"]
+      }]
+    }
+
+    return (
+      <FWDataTable columns={data.columns} rows={data.persons} rowActions={data.rowActions} label="Data Table 3">
+      </FWDataTable>
+    );
+  }
+```
+
+</code-block>
+</code-group>
+
 <!-- Auto Generated Below -->
 
 
@@ -471,6 +660,7 @@ This codeblock shows how to use custom cell function to display HTML content in 
 | `isAllSelectable` | `is-all-selectable` | isAllSelectable Booleam based on which select all option appears in the table header   | `boolean`           | `false` |
 | `isSelectable`    | `is-selectable`     | isSelectable Boolean based on which selectable options appears for rows in the table.  | `boolean`           | `false` |
 | `label`           | `label`             | Label attribute is not visible on screen. There for accessibility purposes.            | `string`            | `''`    |
+| `rowActions`      | --                  | To enable bulk actions on the table.                                                   | `DataTableAction[]` | `[]`    |
 | `rows`            | --                  | Rows Array of objects to be displayed in the table.                                    | `DataTableRow[]`    | `[]`    |
 
 
@@ -515,17 +705,36 @@ Type: `Promise<DataTableRow[]>`
 
 selected rows from the data table
 
+### `loadTable(state: boolean) => Promise<boolean>`
+
+loadTable - Method to call when we want to change table loading state
+
+#### Returns
+
+Type: `Promise<boolean>`
+
+isTableLoading current state
+
 
 ## Dependencies
 
 ### Depends on
 
 - [fw-checkbox](../checkbox)
+- [fw-skeleton](../skeleton)
+- [fw-button](../button)
 
 ### Graph
 ```mermaid
 graph TD;
   fw-data-table --> fw-checkbox
+  fw-data-table --> fw-skeleton
+  fw-data-table --> fw-button
+  fw-button --> fw-spinner
+  fw-button --> fw-icon
+  fw-icon --> fw-toast-message
+  fw-toast-message --> fw-spinner
+  fw-toast-message --> fw-icon
   style fw-data-table fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/crayons-core/src/components/skeleton/readme.md
+++ b/packages/crayons-core/src/components/skeleton/readme.md
@@ -229,6 +229,19 @@ function App() {
 | `--skeleton-width`         | Skeleton width: Default: 100% for the text and rect, 32px for the circle                  |
 
 
+## Dependencies
+
+### Used by
+
+ - [fw-data-table](../data-table)
+
+### Graph
+```mermaid
+graph TD;
+  fw-data-table --> fw-skeleton
+  style fw-skeleton fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 Built with ❤ at Freshworks

--- a/packages/crayons-core/src/index.html
+++ b/packages/crayons-core/src/index.html
@@ -12,9 +12,9 @@
     <script nomodule src="/build/crayons.js"></script>
   </head>
   <body>
-    <fw-button expand color="primary">Primary Button</fw-button>
+  <fw-button expand color="primary">Primary Button</fw-button>
 
-    <!-- <br />
+  <!-- <br />
   <fw-button-group>
     <fw-button color="secondary"> Test 1</fw-button>
     <fw-button color="secondary">Test 2</fw-button>
@@ -28,7 +28,7 @@
     <fw-button size="icon" color="secondary"> <fw-icon name="more-horizontal"  library="system" ></fw-icon></fw-button>
   </fw-button-group> -->
 
-    <!--  <fw-input value="kjhgfdrftgyjhkujlnhbgvhfcty kjghfcftgh"></fw-input>
+  <!--  <fw-input value="kjhgfdrftgyjhkujlnhbgvhfcty kjghfcftgh"></fw-input>
 
    <fw-select
       label="Select App type"
@@ -191,5 +191,181 @@
       .addEventListener('fwOptionClick', (e) => console.log('Selected values are ', e.detail.value))
   </script> 
 -->
-  </body>
+
+  <!-- <div style="display: flex; align-items: center; justify-content: center;">
+    <div style="width: 1200px; margin-top: 80px;">
+      <fw-data-table id="datatable-0" is-selectable="true" is-all-selectable="true" label="Data table 0">
+      </fw-data-table>
+
+      <fw-data-table id="datatable-1"></fw-data-table>
+    </div>
+  </div> -->
+
+  <!-- <script>
+    var data = {
+      columns: [{
+        "key": "name",
+        "text": "Name",
+        "position": 2
+      }, {
+        "key": "group",
+        "text": "Group",
+        "position": 3
+      }, {
+        "key": "role",
+        "text": "Role",
+        "position": 1
+      }, {
+        "key": "school",
+        "text": "School"
+      }, {
+        "key": "place",
+        "text": "Place",
+        "position": 5
+      }],
+      persons: [
+        {
+          "id": "61c443eac41891ee584cc2c2",
+          "name": "dolore",
+          "role": "est",
+          "group": "sunt",
+          "school": "cillum",
+          "place": "non"
+        },
+        {
+          "id": "61c443eade33a3b23e1ba388",
+          "name": "et",
+          "role": "quis",
+          "group": "ipsum",
+          "school": "mollit",
+          "place": "sit"
+        },
+        {
+          "id": "61c443eaf6ffceda052527ca",
+          "name": "velit",
+          "role": "id",
+          "group": "incididunt",
+          "school": "culpa",
+          "place": "eiusmod"
+        },
+        {
+          "id": "61c443ea9f6d4df981cb697d",
+          "name": "do",
+          "role": "in",
+          "group": "veniam",
+          "school": "sit",
+          "place": "qui"
+        },
+        {
+          "id": "61c443eab03c9692f3782ce3",
+          "name": "nostrud",
+          "role": "ea",
+          "group": "fugiat",
+          "school": "mollit",
+          "place": "et"
+        },
+        {
+          "id": "61c443eadc0aa4d77f9ce50b",
+          "name": "ex",
+          "role": "pariatur",
+          "group": "sint",
+          "school": "mollit",
+          "place": "non"
+        },
+        {
+          "id": "61c443eafa776aa88180fb93",
+          "name": "sit",
+          "role": "eiusmod",
+          "group": "enim",
+          "school": "occaecat",
+          "place": "elit"
+        },
+        {
+          "id": "61c443ea47480024fb82103f",
+          "name": "anim",
+          "role": "nisi",
+          "group": "minim",
+          "school": "excepteur",
+          "place": "ad"
+        },
+        {
+          "id": "61c443ea7cd7ad9b57a25c30",
+          "name": "amet",
+          "role": "qui",
+          "group": "laborum",
+          "school": "Lorem",
+          "place": "ipsum"
+        },
+        {
+          "id": "61c443ea06902015b1d10b0a",
+          "name": "sit",
+          "role": "reprehenderit",
+          "group": "reprehenderit",
+          "school": "incididunt",
+          "place": "velit"
+        },
+        {
+          "id": "61c443ea499fa2176088b569",
+          "name": "ipsum",
+          "role": "aute",
+          "group": "eu",
+          "school": "amet",
+          "place": "eu"
+        }
+      ]
+    };
+
+    var datatable = document.getElementById('datatable-0');
+    datatable.columns = data.columns;
+    datatable.rows = data.persons;
+    datatable.rowActions = [{
+      name: 'Edit',
+      handler: (rowData) => {
+        console.log(rowData);
+      }
+    }, {
+      name: 'Delete',
+      handler: async (rowData) => {
+        let deleteActionPromise = new Promise((resolve, reject) => {
+          setTimeout(() => {
+            console.log(rowData);
+            resolve();
+          }, 5000);
+        });
+        return deleteActionPromise;
+      },
+      hideForRowIds: ['61c443ea499fa2176088b569']
+    }];
+
+    var data1 = {
+      columns: [{
+        "key": "search",
+        "text": "Search Engine",
+        "position": 1,
+        "variant": "anchor"
+      }, {
+        "key": "rank",
+        "text": "Rank",
+        "position": 2
+      }],
+      rows: [{
+        "id": "001",
+        "search": { "text": "Google", "href": "https://www.google.com" },
+        "rank": 1
+      }, {
+        "id": "002",
+        "search": { "text": "Bing", "href": "https://www.bing.com" },
+        "rank": 2
+      }, {
+        "id": "003",
+        "search": { "text": "DuckDuckGo", "href": "https://www.duckduckgo.com" },
+        "rank": 3
+      }]
+    };
+
+    var datatable1 = document.getElementById('datatable-1');
+    datatable1.columns = data1.columns;
+    datatable1.rows = data1.rows;
+  </script> -->
+</body>
 </html>

--- a/packages/crayons-core/src/utils/types.ts
+++ b/packages/crayons-core/src/utils/types.ts
@@ -60,3 +60,9 @@ export type DataTableColumn = {
   hasFocusableComponent?: boolean;
   customTemplate?: customTemplateFunc<VNode>;
 };
+
+export type DataTableAction = {
+  name: string;
+  handler: (row: DataTableRow) => any;
+  hideForRowIds?: string[];
+};


### PR DESCRIPTION
This PR includes a feature that gives the ability to individually perform actions on a row. Row actions configuration can be passed to the data-table as prop just like we do rows and columns. Made all necessary accessibility related changes to support row actions.

#### Demo:

https://user-images.githubusercontent.com/61269786/148520524-365bcb44-a628-48d8-83c0-5a7c0872457a.mov



#### Code:
```js
const rowActions = [{
  "name": "Alert",
  "handler": (rowData) => {
    window.alert(rowData.name);
  }
}, {
  "name": "Delete",
  "handler": async (rowData) => {
    let deletePromise = new Promise((resolve, reject) => {
      const dataTable = document.querySelector('#datatable-4');
      setTimeout(() => {
        if (dataTable) {
          dataTable.rows = dataTable.rows.filter((row) => (row.id !== rowData.id));
          resolve();
        } else {
          reject();
        }
      }, 3000); 
    });
    await deletePromise;
  },
  "hideForRowIds": ["0003"]
}];

document.querySelector('#data-table').rowActions = rowActions;
```

#### Steps to run vuepress documentation:
- From root of project run npm run docs:dev
- Open the link that shows up in console after running above command.
- Navigate to DataTable component in sidebar.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
- Tested manually with Vuepress documentation.
- Supporting UTs added/passed.
