### PR TITLE
refactor: Set custom pill color without setting attribute color as custom

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -667,7 +667,7 @@ export namespace Components {
         /**
           * Theme based on which the pill is styled.
          */
-        "color": 'blue' | 'red' | 'green' | 'yellow' | 'grey' | 'custom';
+        "color": 'blue' | 'red' | 'green' | 'yellow' | 'grey';
     }
     interface FwPopover {
         /**
@@ -2445,7 +2445,7 @@ declare namespace LocalJSX {
         /**
           * Theme based on which the pill is styled.
          */
-        "color"?: 'blue' | 'red' | 'green' | 'yellow' | 'grey' | 'custom';
+        "color"?: 'blue' | 'red' | 'green' | 'yellow' | 'grey';
     }
     interface FwPopover {
         /**

--- a/packages/crayons-core/src/components/pill/pill.scss
+++ b/packages/crayons-core/src/components/pill/pill.scss
@@ -10,8 +10,8 @@
   --pill-border: none;
   --pill-border-radius: 16px;
   --pill-padding: 5px 12px 5px 8px;
-  --pill-color: $color-elephant-900;
-  --pill-background-color: $color-milk;
+  --pill-color: #{$color-smoke-700};
+  --pill-background-color: #{$color-smoke-50};
 }
 
 .pill {
@@ -40,6 +40,7 @@
 
   ::slotted(fw-icon) {
     --icon-size: 14px;
+    --icon-color: #{$color-smoke-700};
   }
 
   &--blue {

--- a/packages/crayons-core/src/components/pill/pill.stories.mdx
+++ b/packages/crayons-core/src/components/pill/pill.stories.mdx
@@ -76,7 +76,7 @@ import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 ### Pills with custom CSS properties
 <Preview>
 <Story name='Custyom CSS styles'>
-{() => `<fw-pill color="custom" style="--pill-background-color: #fff;--pill-border: 1px solid gray;--pill-padding: 4px 12px 4px 8px;">
+{() => `<fw-pill style="--pill-background-color: #fff;--pill-border: 1px solid gray;--pill-padding: 4px 12px 4px 8px;">
   <fw-icon name="info" slot="icon"></fw-icon>
   Custom Styled Pill
 </fw-pill>`}

--- a/packages/crayons-core/src/components/pill/pill.tsx
+++ b/packages/crayons-core/src/components/pill/pill.tsx
@@ -11,18 +11,21 @@ export class Pill {
   /**
    * Theme based on which the pill is styled.
    */
-  @Prop() color: 'blue' | 'red' | 'green' | 'yellow' | 'grey' | 'custom' =
-    'grey';
+  @Prop() color: 'blue' | 'red' | 'green' | 'yellow' | 'grey';
 
   hasIcon: boolean;
+  pillClass: string;
 
   componentWillLoad() {
     this.hasIcon = !!this.el.querySelector('[slot="icon"');
+    this.pillClass = this.color
+      ? `pill pill--${this.color.toLowerCase()}`
+      : 'pill';
   }
 
   render() {
     return (
-      <span class={`pill pill--${this.color.toLowerCase()}`}>
+      <span class={this.pillClass}>
         {this.hasIcon && (
           <div class='pill-icon'>
             <slot name='icon' />

--- a/packages/crayons-core/src/components/pill/readme.md
+++ b/packages/crayons-core/src/components/pill/readme.md
@@ -39,9 +39,9 @@ Icon inside the pill must be set with attribute `slot="icon"` and it could eithe
 ```
 
 ### Styling Pills with custom CSS
-Pill can be customized with custom colors by setting attribute `color="custom"` and apply the styles using custom CSS properties listed further below in the page.
+Pill can be customized with custom colors by using custom CSS properties listed further below in the page.
 ```html live
-<fw-pill color="custom" style="--pill-background-color: #fff;--pill-border: 1px solid gray;--pill-padding: 4px 12px 4px 8px;">
+<fw-pill style="--pill-background-color: #fff;--pill-border: 1px solid gray;--pill-padding: 4px 12px 4px 8px;">
   <fw-icon name="info" slot="icon"></fw-icon>
   Custom Styled Pill
 </fw-pill>
@@ -102,9 +102,9 @@ function App() {
 
 ## Properties
 
-| Property | Attribute | Description                              | Type                                                           | Default  |
-| -------- | --------- | ---------------------------------------- | -------------------------------------------------------------- | -------- |
-| `color`  | `color`   | Theme based on which the pill is styled. | `"blue" \| "custom" \| "green" \| "grey" \| "red" \| "yellow"` | `'grey'` |
+| Property | Attribute | Description                              | Type                                               | Default     |
+| -------- | --------- | ---------------------------------------- | -------------------------------------------------- | ----------- |
+| `color`  | `color`   | Theme based on which the pill is styled. | `"blue" \| "green" \| "grey" \| "red" \| "yellow"` | `undefined` |
 
 
 ## CSS Custom Properties


### PR DESCRIPTION
 Set custom pill color without setting attribute color as custom for better user experience to use the component.

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 


![image](https://user-images.githubusercontent.com/59990784/148748731-dfd951b3-d9eb-4b96-b3be-16cd4b01e40a.png)


