### PR TITLE
fix(modal): slider variant position justify-content to flex-end

### DIFF
--- a/packages/crayons-core/src/components/modal/modal.scss
+++ b/packages/crayons-core/src/components/modal/modal.scss
@@ -75,7 +75,7 @@
 }
 
 .modal-overlay.slider {
-  justify-content: right;
+  justify-content: flex-end;
 
   .modal {
     height: 100vh;


### PR DESCRIPTION
**Issue:** 
Slider variant in Modal component appears in left side rather than the expected right side.

**Fix:** 
Flex justify-content 'right' does not work consistently across browsers. So changing the property value to 'flex-end'.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested the fix in Safari, chrome browsers.