### PR TITLE
feat(data-table): adding 'icon' cell variant, column text-align, icon button in row actions, selectAllRows api to data table

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -133,6 +133,12 @@ export namespace Components {
         "href": string;
         "text": string;
     }
+    interface FwCustomCellIcon {
+        "color": string;
+        "library": string;
+        "name": string;
+        "size": number;
+    }
     interface FwCustomCellUser {
         "alt": string;
         "email": string;
@@ -1644,6 +1650,12 @@ declare global {
         prototype: HTMLFwCustomCellAnchorElement;
         new (): HTMLFwCustomCellAnchorElement;
     };
+    interface HTMLFwCustomCellIconElement extends Components.FwCustomCellIcon, HTMLStencilElement {
+    }
+    var HTMLFwCustomCellIconElement: {
+        prototype: HTMLFwCustomCellIconElement;
+        new (): HTMLFwCustomCellIconElement;
+    };
     interface HTMLFwCustomCellUserElement extends Components.FwCustomCellUser, HTMLStencilElement {
     }
     var HTMLFwCustomCellUserElement: {
@@ -1905,6 +1917,7 @@ declare global {
         "fw-button-group": HTMLFwButtonGroupElement;
         "fw-checkbox": HTMLFwCheckboxElement;
         "fw-custom-cell-anchor": HTMLFwCustomCellAnchorElement;
+        "fw-custom-cell-icon": HTMLFwCustomCellIconElement;
         "fw-custom-cell-user": HTMLFwCustomCellUserElement;
         "fw-data-table": HTMLFwDataTableElement;
         "fw-datepicker": HTMLFwDatepickerElement;
@@ -2094,6 +2107,12 @@ declare namespace LocalJSX {
     interface FwCustomCellAnchor {
         "href"?: string;
         "text"?: string;
+    }
+    interface FwCustomCellIcon {
+        "color"?: string;
+        "library"?: string;
+        "name"?: string;
+        "size"?: number;
     }
     interface FwCustomCellUser {
         "alt"?: string;
@@ -3634,6 +3653,7 @@ declare namespace LocalJSX {
         "fw-button-group": FwButtonGroup;
         "fw-checkbox": FwCheckbox;
         "fw-custom-cell-anchor": FwCustomCellAnchor;
+        "fw-custom-cell-icon": FwCustomCellIcon;
         "fw-custom-cell-user": FwCustomCellUser;
         "fw-data-table": FwDataTable;
         "fw-datepicker": FwDatepicker;
@@ -3690,6 +3710,7 @@ declare module "@stencil/core" {
             "fw-button-group": LocalJSX.FwButtonGroup & JSXBase.HTMLAttributes<HTMLFwButtonGroupElement>;
             "fw-checkbox": LocalJSX.FwCheckbox & JSXBase.HTMLAttributes<HTMLFwCheckboxElement>;
             "fw-custom-cell-anchor": LocalJSX.FwCustomCellAnchor & JSXBase.HTMLAttributes<HTMLFwCustomCellAnchorElement>;
+            "fw-custom-cell-icon": LocalJSX.FwCustomCellIcon & JSXBase.HTMLAttributes<HTMLFwCustomCellIconElement>;
             "fw-custom-cell-user": LocalJSX.FwCustomCellUser & JSXBase.HTMLAttributes<HTMLFwCustomCellUserElement>;
             "fw-data-table": LocalJSX.FwDataTable & JSXBase.HTMLAttributes<HTMLFwDataTableElement>;
             "fw-datepicker": LocalJSX.FwDatepicker & JSXBase.HTMLAttributes<HTMLFwDatepickerElement>;

--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -195,7 +195,7 @@ export namespace Components {
           * selectAllRows method we can use to select/unselect rows in the table
           * @param checked denotes if we want to check or uncheck the rows
          */
-        "selectAllRows": (checked?: boolean) => Promise<void>;
+        "selectAllRows": (checked?: boolean) => Promise<string[]>;
     }
     interface FwDatepicker {
         /**

--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -78,7 +78,7 @@ export namespace Components {
         /**
           * Size of the button.
          */
-        "size": 'normal' | 'small' | 'icon';
+        "size": 'normal' | 'small' | 'icon' | 'icon-small';
         /**
           * Sets the delay for throttle in milliseconds. Defaults to 200 milliseconds.
          */
@@ -2041,7 +2041,7 @@ declare namespace LocalJSX {
         /**
           * Size of the button.
          */
-        "size"?: 'normal' | 'small' | 'icon';
+        "size"?: 'normal' | 'small' | 'icon' | 'icon-small';
         /**
           * Sets the delay for throttle in milliseconds. Defaults to 200 milliseconds.
          */

--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -191,6 +191,11 @@ export namespace Components {
           * Rows Array of objects to be displayed in the table.
          */
         "rows": DataTableRow[];
+        /**
+          * selectAllRows method we can use to select/unselect rows in the table
+          * @param checked denotes if we want to check or uncheck the rows
+         */
+        "selectAllRows": (checked?: boolean) => Promise<void>;
     }
     interface FwDatepicker {
         /**

--- a/packages/crayons-core/src/components/button/button.scss
+++ b/packages/crayons-core/src/components/button/button.scss
@@ -259,6 +259,14 @@ $input-height-mini: 16px;
     padding: 0;
     line-height: calc(32px - #{$btn-border-width} * 2);
   }
+
+  &--icon-small {
+    min-width: 24px;
+    width: 24px;
+    height: 22px;
+    padding: 0;
+    line-height: calc(22px - #{$btn-border-width} * 2);
+  }
 }
 
 .fw-btn--before,

--- a/packages/crayons-core/src/components/button/button.tsx
+++ b/packages/crayons-core/src/components/button/button.tsx
@@ -36,7 +36,7 @@ export class Button {
   /**
    * Size of the button.
    */
-  @Prop() size: 'normal' | 'small' | 'icon' = 'normal';
+  @Prop() size: 'normal' | 'small' | 'icon' | 'icon-small' = 'normal';
 
   /**
    * Disables the button on the interface. Default value is false.

--- a/packages/crayons-core/src/components/button/readme.md
+++ b/packages/crayons-core/src/components/button/readme.md
@@ -272,7 +272,7 @@ function App() {
 | `loading`        | `loading`          | Loading state for the button, Default value is false.                        | `boolean`                                                  | `false`     |
 | `modalTriggerId` | `modal-trigger-id` | Accepts the id of the fw-modal component to open it on click.                | `string`                                                   | `''`        |
 | `showCaretIcon`  | `show-caret-icon`  | Caret indicator for the button, Default value is false.                      | `boolean`                                                  | `false`     |
-| `size`           | `size`             | Size of the button.                                                          | `"icon" \| "normal" \| "small"`                            | `'normal'`  |
+| `size`           | `size`             | Size of the button.                                                          | `"icon" \| "icon-small" \| "normal" \| "small"`            | `'normal'`  |
 | `throttleDelay`  | `throttle-delay`   | Sets the delay for throttle in milliseconds. Defaults to 200 milliseconds.   | `number`                                                   | `200`       |
 | `type`           | `type`             | Button type based on which actions are performed when the button is clicked. | `"button" \| "submit"`                                     | `'button'`  |
 

--- a/packages/crayons-core/src/components/data-table/custom-cells/anchor/custom-cell-anchor.scss
+++ b/packages/crayons-core/src/components/data-table/custom-cells/anchor/custom-cell-anchor.scss
@@ -2,4 +2,9 @@
 
 .anchor {
   @include anchor;
+  display: inline-block;
+  width: 250px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }

--- a/packages/crayons-core/src/components/data-table/custom-cells/icon/custom-cell-icon.tsx
+++ b/packages/crayons-core/src/components/data-table/custom-cells/icon/custom-cell-icon.tsx
@@ -1,0 +1,26 @@
+import { Component, h, Prop } from '@stencil/core';
+
+@Component({
+  tag: 'fw-custom-cell-icon',
+  shadow: true,
+})
+export class CustomCellUser {
+  @Prop() name = '';
+
+  @Prop() size = 18;
+
+  @Prop() color = '#647A8E';
+
+  @Prop() library = 'crayons';
+
+  render() {
+    return (
+      <fw-icon
+        name={this.name}
+        size={this.size}
+        color={this.color}
+        library={this.library}
+      ></fw-icon>
+    );
+  }
+}

--- a/packages/crayons-core/src/components/data-table/custom-cells/icon/readme.md
+++ b/packages/crayons-core/src/components/data-table/custom-cells/icon/readme.md
@@ -1,0 +1,36 @@
+# fw-custom-cell-icon
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property  | Attribute | Description | Type     | Default     |
+| --------- | --------- | ----------- | -------- | ----------- |
+| `color`   | `color`   |             | `string` | `'#647A8E'` |
+| `library` | `library` |             | `string` | `'crayons'` |
+| `name`    | `name`    |             | `string` | `''`        |
+| `size`    | `size`    |             | `number` | `18`        |
+
+
+## Dependencies
+
+### Depends on
+
+- [fw-icon](../../../icon)
+
+### Graph
+```mermaid
+graph TD;
+  fw-custom-cell-icon --> fw-icon
+  fw-icon --> fw-toast-message
+  fw-toast-message --> fw-spinner
+  fw-toast-message --> fw-icon
+  style fw-custom-cell-icon fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+Built with ❤ at Freshworks

--- a/packages/crayons-core/src/components/data-table/custom-cells/user/custom-cell-user.scss
+++ b/packages/crayons-core/src/components/data-table/custom-cells/user/custom-cell-user.scss
@@ -13,12 +13,20 @@
       font-weight: 600;
       font-size: 14px;
       line-height: 20px;
+      width: 250px;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
     }
 
     .name-box-email {
       font-size: 12px;
       color: #475867;
       line-height: 18px;
+      width: 250px;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
     }
   }
 }

--- a/packages/crayons-core/src/components/data-table/data-table.e2e.ts
+++ b/packages/crayons-core/src/components/data-table/data-table.e2e.ts
@@ -386,4 +386,54 @@ describe('fw-data-table', () => {
     );
     expect(columnWidth).toEqual(testColumnWidth);
   });
+
+  it('should call formatData function when it is passed in column configuration', async () => {
+    const data = {
+      rows: [
+        {
+          id: '1234',
+          name: 'Alexander Goodman',
+          knowledge: ['HTML', 'CSS', 'JS'],
+        },
+      ],
+      columns: [
+        {
+          key: 'name',
+          text: 'Name',
+        },
+        {
+          key: 'knowledge',
+          text: 'Knowledge',
+        },
+      ],
+    };
+    const formatData = (cellData) => cellData.join(', ');
+    const formatDataResult = formatData(data.rows[0].knowledge);
+    const myMockFn = jest.fn(formatData);
+    await page.exposeFunction('myMockFn', myMockFn);
+    await page.$eval(
+      'fw-data-table',
+      (elm: any, data: any, formatDataResult: string) => {
+        data.columns[1].formatData = (cellData) => {
+          (window as any).myMockFn(cellData);
+          /**
+           * Hardcoded result because myMockFn turns async on page.exposeFunction
+           * https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pageexposefunctionname-puppeteerfunction
+           * but render in JSX expects sync call.
+           */
+          return formatDataResult;
+        };
+        Object.assign(elm, data);
+      },
+      data,
+      formatDataResult
+    );
+    await page.waitForChanges();
+    const formattedCell = await page.find(
+      'fw-data-table >>> tbody > tr > td:nth-child(2)'
+    );
+    expect(myMockFn).toHaveBeenCalled();
+    expect(myMockFn.mock.results[0].value).toBe(formatDataResult);
+    expect(formattedCell.innerText).toEqual(formatDataResult);
+  });
 });

--- a/packages/crayons-core/src/components/data-table/data-table.e2e.ts
+++ b/packages/crayons-core/src/components/data-table/data-table.e2e.ts
@@ -324,4 +324,33 @@ describe('fw-data-table', () => {
     await page.waitForChanges();
     expect(myMock).toHaveBeenCalled();
   });
+
+  it('should hide a column when hide is passed in column configuration', async () => {
+    const data = {
+      rows: [
+        {
+          id: '1234',
+          name: 'Alexander Goodman',
+          job: 'Lead designer',
+        },
+      ],
+      columns: [
+        {
+          key: 'name',
+          text: 'Name',
+          hide: true,
+        },
+        {
+          key: 'job',
+          text: 'Job',
+        },
+      ],
+    };
+    await loadDataIntoGrid(data);
+    await page.waitForChanges();
+    const firstColumn = await page.find(
+      'fw-data-table >>> thead > tr > th:first-child'
+    );
+    expect(firstColumn).toHaveClass('hidden');
+  });
 });

--- a/packages/crayons-core/src/components/data-table/data-table.e2e.ts
+++ b/packages/crayons-core/src/components/data-table/data-table.e2e.ts
@@ -353,4 +353,37 @@ describe('fw-data-table', () => {
     );
     expect(firstColumn).toHaveClass('hidden');
   });
+
+  it('should set column width if widthProperties is passed in column configuration', async () => {
+    const testColumnWidth = '200px';
+    const data = {
+      rows: [
+        {
+          id: '1234',
+          name: 'Alexander Goodman',
+        },
+      ],
+      columns: [
+        {
+          key: 'name',
+          text: 'Name',
+          widthProperties: {
+            width: testColumnWidth,
+          },
+        },
+      ],
+    };
+    await loadDataIntoGrid(data);
+    await page.waitForChanges();
+    const columnWidth = await page.evaluate(
+      (component, selector) => {
+        const cmpEl = document.querySelector(component);
+        const headerCell = cmpEl.shadowRoot.querySelector(selector);
+        return headerCell.style.width;
+      },
+      'fw-data-table',
+      'th:first-child'
+    );
+    expect(columnWidth).toEqual(testColumnWidth);
+  });
 });

--- a/packages/crayons-core/src/components/data-table/data-table.e2e.ts
+++ b/packages/crayons-core/src/components/data-table/data-table.e2e.ts
@@ -222,6 +222,12 @@ describe('fw-data-table', () => {
           position: 2,
           variant: 'user',
         },
+        {
+          key: 'icon',
+          text: 'Icon',
+          position: 3,
+          variant: 'icon',
+        },
       ],
       rows: [
         {
@@ -231,6 +237,7 @@ describe('fw-data-table', () => {
             name: 'Alexander Goodman',
             email: 'alexander.goodman@freshworks.com',
           },
+          icon: { name: 'agent' },
         },
       ],
     };
@@ -242,8 +249,12 @@ describe('fw-data-table', () => {
     const userComponent = await page.find(
       'fw-data-table >>> tbody > tr:first-child > td:nth-child(2) > fw-custom-cell-user'
     );
+    const iconComponent = await page.find(
+      'fw-data-table >>> tbody > tr:first-child > td:nth-child(3) > fw-custom-cell-icon'
+    );
     expect(anchorComponent).toBeTruthy();
     expect(userComponent).toBeTruthy();
+    expect(iconComponent).toBeTruthy();
   });
 
   it('should display action column when rowActions is passed to datatable', async () => {

--- a/packages/crayons-core/src/components/data-table/data-table.e2e.ts
+++ b/packages/crayons-core/src/components/data-table/data-table.e2e.ts
@@ -83,18 +83,28 @@ describe('fw-data-table', () => {
     expect(checkbox).toBeTruthy();
   });
 
-  // it('should trigger fwSelectAllChange when select-all checkbox is checked/unchecked', async () => {
-  //   const currentData = { ...data, isSelectable: true, isAllSelectable: true };
-  //   await loadDataIntoGrid(currentData);
-  //   await page.waitForChanges();
-  //   const checkbox = await page.find(
-  //     'fw-data-table >>> thead > tr:first-child > th:first-child > fw-checkbox'
-  //   );
-  //   const changedEvent = await page.spyOnEvent('fwSelectAllChange');
-  //   checkbox.click();
-  //   await page.waitForChanges();
-  //   expect(changedEvent).toHaveReceivedEventTimes(1);
-  // });
+  it('should trigger fwSelectAllChange when select-all checkbox is checked/unchecked', async () => {
+    const currentData = { ...data, isSelectable: true, isAllSelectable: true };
+    await loadDataIntoGrid(currentData);
+    await page.waitForChanges();
+    const checkbox = await page.find(
+      'fw-data-table >>> thead > tr:first-child > th:first-child > fw-checkbox'
+    );
+    const changedEvent = await page.spyOnEvent('fwSelectAllChange');
+    checkbox.click();
+    await page.waitForChanges();
+    expect(changedEvent).toHaveReceivedEventTimes(1);
+  });
+
+  it('should trigger fwSelectAllChange when selectAllRows method is called', async () => {
+    const currentData = { ...data, isSelectable: true };
+    await loadDataIntoGrid(currentData);
+    const changedEvent = await page.spyOnEvent('fwSelectAllChange');
+    const dataTable = await page.find('fw-data-table');
+    await dataTable.callMethod('selectAllRows');
+    await page.waitForChanges();
+    expect(changedEvent).toHaveReceivedEventTimes(1);
+  });
 
   it('should render in the right column order', async () => {
     const data = {

--- a/packages/crayons-core/src/components/data-table/data-table.e2e.ts
+++ b/packages/crayons-core/src/components/data-table/data-table.e2e.ts
@@ -257,6 +257,37 @@ describe('fw-data-table', () => {
     expect(iconComponent).toBeTruthy();
   });
 
+  it('should align text in a column when textAlign is passed as a column configuration', async () => {
+    const data = {
+      columns: [
+        {
+          key: 'icon',
+          text: 'Icon',
+          variant: 'icon',
+          textAlign: 'center',
+        },
+      ],
+      rows: [
+        {
+          id: '01',
+          icon: { name: 'agent' },
+        },
+      ],
+    };
+    await loadDataIntoGrid(data);
+    await page.waitForChanges();
+    const textAlign = await page.evaluate(
+      (component, selector) => {
+        const cmpEl = document.querySelector(component);
+        const headerCell = cmpEl.shadowRoot.querySelector(selector);
+        return headerCell.style.textAlign;
+      },
+      'fw-data-table',
+      'td'
+    );
+    expect(textAlign).toEqual('center');
+  });
+
   it('should display action column when rowActions is passed to datatable', async () => {
     const data = {
       rows: [

--- a/packages/crayons-core/src/components/data-table/data-table.scss
+++ b/packages/crayons-core/src/components/data-table/data-table.scss
@@ -35,40 +35,45 @@ div.fw-data-table-container {
       width: 100%;
       border-radius: 4px;
 
-      tr th {
-        color: $grid-header-txt-color;
-        font-size: $grid-header-txt-size;
-        line-height: $grid-line-height;
-        padding: $grid-density-md;
-        font-weight: 600;
-        letter-spacing: 0.2px;
-        text-overflow: ellipsis;
-        text-align: left;
-        z-index: 1;
-
-        &.data-grid-sm {
-          padding: $grid-density-sm;
-        }
-
-        &.data-grid-md {
+      tr {
+        th {
+          color: $grid-header-txt-color;
+          font-size: $grid-header-txt-size;
+          line-height: $grid-line-height;
           padding: $grid-density-md;
+          font-weight: 600;
+          letter-spacing: 0.2px;
+          text-overflow: ellipsis;
+          text-align: left;
+          z-index: 1;
+          box-sizing: border-box;
+          min-width: 50px;
+          max-width: 1000px;
+
+          &.data-grid-sm {
+            padding: $grid-density-sm;
+          }
+
+          &.data-grid-md {
+            padding: $grid-density-md;
+          }
+
+          &.data-grid-lg {
+            padding: $grid-density-lg;
+          }
+
+          &:first-child {
+            padding-left: 16px;
+          }
+
+          &:last-child {
+            padding-right: 16px;
+          }
         }
 
-        &.data-grid-lg {
-          padding: $grid-density-lg;
+        th.hidden {
+          display: none;
         }
-
-        &:first-child {
-          padding-left: 16px;
-        }
-
-        &:last-child {
-          padding-right: 16px;
-        }
-      }
-
-      tr th.hidden {
-        display: none;
       }
     }
 
@@ -96,6 +101,7 @@ div.fw-data-table-container {
           line-height: $grid-line-height;
           padding: $grid-density-md;
           text-overflow: ellipsis;
+          box-sizing: border-box;
           z-index: 0;
 
           &.data-grid-checkbox {
@@ -124,12 +130,30 @@ div.fw-data-table-container {
           }
         }
 
-        td.row-actions > fw-button {
-          margin-right: 5px;
+        td.row-actions {
+          // column has to take up only required space
+          width: 1px;
+          white-space: nowrap;
+
+          & > fw-button {
+            margin-right: 5px;
+          }
         }
 
         td.hidden {
           display: none;
+        }
+      }
+    }
+
+    &.is-selectable {
+      td:first-child,
+      th:first-child {
+        text-align: center;
+
+        fw-checkbox {
+          width: 16px;
+          height: 20px;
         }
       }
     }

--- a/packages/crayons-core/src/components/data-table/data-table.scss
+++ b/packages/crayons-core/src/components/data-table/data-table.scss
@@ -66,6 +66,10 @@ div.fw-data-table-container {
           padding-right: 16px;
         }
       }
+
+      tr th.hidden {
+        display: none;
+      }
     }
 
     tbody {
@@ -122,6 +126,10 @@ div.fw-data-table-container {
 
         td.row-actions > fw-button {
           margin-right: 5px;
+        }
+
+        td.hidden {
+          display: none;
         }
       }
     }

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -334,6 +334,31 @@ export class DataTable {
   }
 
   /**
+   * selectAllRows method we can use to select/unselect rows in the table
+   * @param checked denotes if we want to check or uncheck the rows
+   */
+  @Method()
+  async selectAllRows(checked = true) {
+    if (this.isAllSelectable) {
+      const selectAll: HTMLFwCheckboxElement = this.el.shadowRoot.querySelector(
+        'tr > th > fw-checkbox'
+      );
+      if (selectAll) {
+        selectAll.checked = checked;
+      }
+    } else if (this.isSelectable) {
+      const checkboxSelector = checked
+        ? 'tr > td:first-child > fw-checkbox:not([checked])'
+        : 'tr > td:first-child > fw-checkbox[checked]';
+      const checkboxes = this.el.shadowRoot.querySelectorAll(checkboxSelector);
+      this.selectAllProgressCount = checkboxes.length;
+      checkboxes.forEach((checkbox: HTMLFwCheckboxElement) => {
+        checkbox.checked = checked;
+      });
+    }
+  }
+
+  /**
    * getSelectedRows
    * @returns selected rows from the data table
    */

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -739,8 +739,8 @@ export class DataTable {
                       (action.hideForRowIds &&
                         !action.hideForRowIds.includes(row.id))
                     ) {
-                      const buttonSize: 'icon' | 'small' = action.iconName
-                        ? 'icon'
+                      const buttonSize: 'icon-small' | 'small' = action.iconName
+                        ? 'icon-small'
                         : 'small';
                       actionTemplate = (
                         <fw-button
@@ -765,6 +765,7 @@ export class DataTable {
                                   ? action.iconLibrary
                                   : 'crayons'
                               }
+                              size={10}
                             ></fw-icon>
                           ) : (
                             action.name

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -26,6 +26,10 @@ const PREDEFINED_VARIANTS_META = {
     componentName: 'fw-custom-cell-user',
     isFocusable: false,
   },
+  icon: {
+    componentName: 'fw-custom-cell-icon',
+    isFocusable: false,
+  },
 };
 
 @Component({

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -739,9 +739,12 @@ export class DataTable {
                       (action.hideForRowIds &&
                         !action.hideForRowIds.includes(row.id))
                     ) {
+                      const buttonSize: 'icon' | 'small' = action.iconName
+                        ? 'icon'
+                        : 'small';
                       actionTemplate = (
                         <fw-button
-                          size='small'
+                          size={buttonSize}
                           color='secondary'
                           onKeyUp={(event) =>
                             (event.code === 'Space' ||
@@ -751,8 +754,21 @@ export class DataTable {
                           onClick={(event) =>
                             this.performRowAction(event, action, row)
                           }
+                          title={action.name}
+                          aria-label={action.name}
                         >
-                          {action.name}
+                          {action.iconName ? (
+                            <fw-icon
+                              name={action.iconName}
+                              library={
+                                action.iconLibrary
+                                  ? action.iconLibrary
+                                  : 'crayons'
+                              }
+                            ></fw-icon>
+                          ) : (
+                            action.name
+                          )}
                         </fw-button>
                       );
                     }

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -25,6 +25,7 @@ const PREDEFINED_VARIANTS_META = {
   user: {
     componentName: 'fw-custom-cell-user',
     isFocusable: false,
+    skipTextAlign: true,
   },
   icon: {
     componentName: 'fw-custom-cell-icon',
@@ -654,7 +655,21 @@ export class DataTable {
           </th>
         )}
         {this.orderedColumns.map((column, columnIndex) => {
-          const headerStyles = column.widthProperties;
+          let textAlign = null;
+          if (
+            column.textAlign &&
+            !(
+              column.variant &&
+              PREDEFINED_VARIANTS_META[column.variant].skipTextAlign
+            )
+          ) {
+            textAlign = column.textAlign;
+          }
+          const headerStyles = Object.assign(
+            {},
+            column.widthProperties ? column.widthProperties : {},
+            textAlign ? { textAlign } : {}
+          );
           return (
             <th
               role='columnheader'
@@ -728,10 +743,25 @@ export class DataTable {
               attrs['data-has-focusable-child'] = isFocusable
                 ? 'true'
                 : 'false';
+              let textAlign = null;
+              if (
+                orderedColumn.textAlign &&
+                !(
+                  orderedColumn.variant &&
+                  PREDEFINED_VARIANTS_META[orderedColumn.variant].skipTextAlign
+                )
+              ) {
+                textAlign = orderedColumn.textAlign;
+              }
+              const cellStyle: any = Object.assign(
+                {},
+                textAlign ? { textAlign } : {}
+              );
               return (
                 <td
                   role='gridcell'
                   class={{ hidden: orderedColumn.hide }}
+                  style={cellStyle}
                   {...attrs}
                 >
                   {!this.rowsLoading[row.id] ? (

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -608,26 +608,31 @@ export class DataTable {
     return this.orderedColumns.length ? (
       <tr role='row'>
         {this.orderedColumns.length && this.isSelectable && (
-          <th key='isSelectable' aria-colindex={1}>
+          <th key='isSelectable' aria-colindex={1} style={{ width: '42px' }}>
             {this.isAllSelectable && (
               <fw-checkbox id='select-all' value={'select-all'}></fw-checkbox>
             )}
           </th>
         )}
-        {this.orderedColumns.map((column, columnIndex) => (
-          <th
-            role='columnheader'
-            key={column.key}
-            aria-colindex={
-              this.isSelectable ? columnIndex + 2 : columnIndex + 1
-            }
-            class={`${column.hide ? 'hidden' : ''}`}
-          >
-            {column.text}
-          </th>
-        ))}
+        {this.orderedColumns.map((column, columnIndex) => {
+          const headerStyles = column.widthProperties;
+          return (
+            <th
+              role='columnheader'
+              key={column.key}
+              aria-colindex={
+                this.isSelectable ? columnIndex + 2 : columnIndex + 1
+              }
+              class={{ hidden: column.hide }}
+              style={headerStyles}
+            >
+              {column.text}
+            </th>
+          );
+        })}
         {this.rowActions.length !== 0 && (
           <th
+            class='row-actions'
             role='columnheader'
             aria-colindex={
               this.isSelectable
@@ -687,7 +692,7 @@ export class DataTable {
               return (
                 <td
                   role='gridcell'
-                  class={`${orderedColumn.hide ? 'hidden' : ''}`}
+                  class={{ hidden: orderedColumn.hide }}
                   {...attrs}
                 >
                   {!this.rowsLoading[row.id] ? (
@@ -760,7 +765,7 @@ export class DataTable {
     return (
       <div class='fw-data-table-container'>
         <table
-          class='fw-data-table'
+          class={{ 'fw-data-table': true, 'is-selectable': this.isSelectable }}
           role='grid'
           aria-colcount={this.orderedColumns.length}
           aria-label={this.label}

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -142,7 +142,7 @@ export class DataTable {
     if (event.detail) {
       if (
         event.detail.value === 'select-all' &&
-        event.path[0].id === 'select-all'
+        this.getEventPath(event)[0].id === 'select-all'
       ) {
         const checkboxSelector = event.detail.checked
           ? 'tr > td:first-child > fw-checkbox:not([checked])'
@@ -156,10 +156,10 @@ export class DataTable {
       } else {
         if (event.detail.checked) {
           this.selected.push(event.detail.value);
-          event.path[0].closest('tr').classList.add('active');
+          this.getEventPath(event)[0].closest('tr').classList.add('active');
         } else {
           this.selected.splice(this.selected.indexOf(event.detail.value), 1);
-          event.path[0].closest('tr').classList.remove('active');
+          this.getEventPath(event)[0].closest('tr').classList.remove('active');
         }
         if (!this.selectAllProgressCount) {
           this.fwSelectionChange.emit({
@@ -186,8 +186,10 @@ export class DataTable {
    */
   @Listen('keydown')
   keyDownHandler(event) {
-    const currentElement: HTMLElement = event.path[0];
-    const currentCell: HTMLElement = this.closestTableCell(event.path);
+    const currentElement: HTMLElement = this.getEventPath(event)[0];
+    const currentCell: HTMLElement = this.closestTableCell(
+      this.getEventPath(event)
+    );
     let cellFocusChange = false;
 
     // Switch focus between components inside a cell
@@ -370,6 +372,14 @@ export class DataTable {
   }
 
   /**
+   * get event's path which is an array of the objects
+   * event.path unsupported in safari
+   */
+  getEventPath(event) {
+    return event.path ? event.path : event.composedPath();
+  }
+
+  /**
    * WorkAround for wait until next render in stenciljs
    * https://github.com/ionic-team/stencil/issues/2744
    */
@@ -511,11 +521,11 @@ export class DataTable {
     action: DataTableAction,
     rowData: DataTableRow
   ) {
-    const tableRow = this.closestTableCell(event.path).parentNode;
+    const tableRow = this.closestTableCell(this.getEventPath(event)).parentNode;
     const tableRowHeight = window.getComputedStyle(tableRow).height;
     tableRow.style.height = tableRowHeight;
     const skeletonHeight = this.getShimmerHeight(
-      this.closestTableCell(event.path)
+      this.closestTableCell(this.getEventPath(event))
     );
     const selectAll: any = this.el.shadowRoot.querySelector(
       'fw-checkbox#select-all'

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -605,7 +605,7 @@ export class DataTable {
     } else if (column.customTemplate) {
       template = this.renderCustomTemplate(column.customTemplate, cellValue);
     } else {
-      template = cellValue;
+      template = column.formatData ? column.formatData(cellValue) : cellValue;
     }
     return template;
   }

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -574,6 +574,8 @@ This codeblock shows how to use custom cell function to display HTML content in 
 
 You can easily add an actions column by passing in rowActions prop to the component.
 
+*You can also use icons instead of text in buttons. Pass 'iconName' and 'iconLibrary' properties as part of configuration.*
+
 ```html live
   <fw-data-table id="datatable-4"  is-selectable="true" is-all-selectable="true" label="Data table 4">
   </fw-data-table>
@@ -1230,6 +1232,7 @@ isLoading current state
 - [fw-checkbox](../checkbox)
 - [fw-skeleton](../skeleton)
 - [fw-button](../button)
+- [fw-icon](../icon)
 
 ### Graph
 ```mermaid
@@ -1237,6 +1240,7 @@ graph TD;
   fw-data-table --> fw-checkbox
   fw-data-table --> fw-skeleton
   fw-data-table --> fw-button
+  fw-data-table --> fw-icon
   fw-button --> fw-spinner
   fw-button --> fw-icon
   fw-icon --> fw-toast-message

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -1224,6 +1224,16 @@ Type: `Promise<boolean>`
 
 isLoading current state
 
+### `selectAllRows(checked?: boolean) => Promise<void>`
+
+selectAllRows method we can use to select/unselect rows in the table
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 
 ## Dependencies
 

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -1,7 +1,7 @@
 # DataTable (fw-data-table)
 fw-data-table are used for data visualization.
 
-## Usage
+## Basic Usage
 
 ```html live
   <fw-data-table id="datatable" is-selectable="true" label="Data table 1">
@@ -91,7 +91,7 @@ fw-data-table are used for data visualization.
 ```jsx
 import React from "react";
 import ReactDOM from "react-dom";
-import { FWDataTable } from "@freshworks/crayons/react";
+import { FwDataTable } from "@freshworks/crayons/react";
 function App() {
 
   let data = {
@@ -124,8 +124,8 @@ function App() {
     };
 
   return (
-    <FWDataTable columns={data.columns} rows={data.persons} label="Data Table 1" isSelectable>
-    </FWDataTable>
+    <FwDataTable columns={data.columns} rows={data.persons} label="Data Table 1" isSelectable>
+    </FwDataTable>
   );
 }
 ```
@@ -224,7 +224,7 @@ Row value for this column variant should be an object with the following propert
 ```jsx
 import React from "react";
 import ReactDOM from "react-dom";
-import { FWDataTable } from "@freshworks/crayons/react";
+import { FwDataTable } from "@freshworks/crayons/react";
 function App() {
 
   var data = {
@@ -254,8 +254,8 @@ function App() {
   };
 
   return (
-    <FWDataTable columns={data.columns} rows={data.persons} label="Data Table 2">
-    </FWDataTable>
+    <FwDataTable columns={data.columns} rows={data.persons} label="Data Table 2">
+    </FwDataTable>
   );
 }
 ```
@@ -383,7 +383,7 @@ Row value for this column variant should be an object with the following propert
 ```jsx
 import React from "react";
 import ReactDOM from "react-dom";
-import { FWDataTable } from "@freshworks/crayons/react";
+import { FwDataTable } from "@freshworks/crayons/react";
 function App() {
 
   var data = {
@@ -428,8 +428,8 @@ function App() {
   };
 
   return (
-    <FWDataTable columns={data.columns} rows={data.persons} label="Data Table 3">
-    </FWDataTable>
+    <FwDataTable columns={data.columns} rows={data.persons} label="Data Table 3">
+    </FwDataTable>
   );
 }
 ```
@@ -460,7 +460,7 @@ This codeblock shows how to use custom cell function to display HTML content in 
 ```
 
 
-### Row Actions:
+## Row Actions:
 
 You can easily add an actions column by passing in rowActions prop to the component.
 
@@ -590,7 +590,7 @@ You can easily add an actions column by passing in rowActions prop to the compon
 ```jsx
   import React from "react";
   import ReactDOM from "react-dom";
-  import { FWDataTable } from "@freshworks/crayons/react";
+  import { FwDataTable } from "@freshworks/crayons/react";
   function App() {
 
     var data = {
@@ -640,8 +640,405 @@ You can easily add an actions column by passing in rowActions prop to the compon
     }
 
     return (
-      <FWDataTable columns={data.columns} rows={data.persons} rowActions={data.rowActions} label="Data Table 3">
-      </FWDataTable>
+      <FwDataTable columns={data.columns} rows={data.persons} rowActions={data.rowActions} label="Data Table 3">
+      </FwDataTable>
+    );
+  }
+```
+
+</code-block>
+</code-group>
+
+## Hide columns
+
+To hide certain columns, we can pass the 'hide' property set to true in the column's configuration.
+
+```html live
+  <span>'Role' column hidden in below table.</span> <br><br>
+  <fw-data-table id="datatable-5" label="Data table 5">
+  </fw-data-table>
+
+  <script type="application/javascript">
+    var data = {
+      columns: [{
+        "key": "name",
+        "text": "Name"
+      }, {
+        "key": "role",
+        "text": "Role",
+        "hide": true
+      }],
+      rows: [{
+        "id": "0001",
+        "name": "Alexander Goodman",
+        "role": "Member"
+      }, {
+        "id": "0002",
+        "name": "Ambrose Wayne",
+        "role": "Member"
+      }]
+    }
+
+    var datatable5 = document.getElementById('datatable-5');
+    datatable5.columns = data.columns;
+    datatable5.rows = data.rows;
+  </script>
+```
+
+<code-group>
+<code-block title="HTML">
+
+```html
+  <fw-data-table id="datatable-5" label="Data table 5">
+  </fw-data-table>
+```
+
+```javascript
+  var data = {
+    columns: [{
+      "key": "name",
+      "text": "Name"
+    }, {
+      "key": "role",
+      "text": "Role",
+      "hide": true
+    }],
+    rows: [{
+      "id": "0001",
+      "name": "Alexander Goodman",
+      "role": "Member"
+    }, {
+      "id": "0002",
+      "name": "Ambrose Wayne",
+      "role": "Member"
+    }]
+  }
+
+  var datatable5 = document.getElementById('datatable-5');
+  datatable5.columns = data.columns;
+  datatable5.rows = data.rows;
+```
+
+</code-block>
+
+<code-block title="React">
+
+```jsx
+  import React from "react";
+  import ReactDOM from "react-dom";
+  import { FwDataTable } from "@freshworks/crayons/react";
+  function App() {
+
+    var data = {
+      columns: [{
+        "key": "name",
+        "text": "Name"
+      }, {
+        "key": "role",
+        "text": "Role",
+        "hide": true
+      }],
+      rows: [{
+        "id": "0001",
+        "name": "Alexander Goodman",
+        "role": "Member"
+      }, {
+        "id": "0002",
+        "name": "Ambrose Wayne",
+        "role": "Member"
+      }]
+    }
+
+    return (
+      <FwDataTable columns={data.columns} rows={data.persons} label="Data Table 5">
+      </FwDataTable>
+    );
+  }
+```
+
+</code-block>
+</code-group>
+
+## Column width
+
+We can pass width for every column using 'widthProperties' in column's configuration. Every column has a minimum width of 50px and maximum width of 1000px by default. We can override min/max width for every column using the 'widthProperties' too.
+
+```html live
+  <span>'Name' column has 400px width and 'Role' column has 200px width.</span> <br><br>
+  <fw-data-table id="datatable-6" label="Data table 6">
+  </fw-data-table>
+
+  <script type="application/javascript">
+    var data = {
+      columns: [{
+        "key": "name",
+        "text": "Name",
+        "widthProperties": {
+          "minWidth": "400px"
+        }
+      }, {
+        "key": "role",
+        "text": "Role",
+        "widthProperties": {
+          "width": "200px"
+        }
+      }, {
+        "key": "level",
+        "text": "Level"
+      }],
+      rows: [{
+        "id": "0001",
+        "name": "Alexander Goodman",
+        "role": "Member",
+        "level": "L1"
+      }, {
+        "id": "0002",
+        "name": "Ambrose Wayne",
+        "role": "Member",
+        "level": "L2"
+      }]
+    }
+
+    var datatable6 = document.getElementById('datatable-6');
+    datatable6.columns = data.columns;
+    datatable6.rows = data.rows;
+  </script>
+```
+
+<code-group>
+<code-block title="HTML">
+
+```html
+  <fw-data-table id="datatable-6" label="Data table 6">
+  </fw-data-table>
+```
+
+```javascript
+  var data = {
+      columns: [{
+        "key": "name",
+        "text": "Name",
+        "widthProperties": {
+          "minWidth": "400px"
+        }
+      }, {
+        "key": "role",
+        "text": "Role",
+        "widthProperties": {
+          "width": "200px"
+        }
+      }, {
+        "key": "level",
+        "text": "Level"
+      }],
+      rows: [{
+        "id": "0001",
+        "name": "Alexander Goodman",
+        "role": "Member",
+        "level": "L1"
+      }, {
+        "id": "0002",
+        "name": "Ambrose Wayne",
+        "role": "Member",
+        "level": "L2"
+      }]
+    }
+
+  var datatable6 = document.getElementById('datatable-6');
+  datatable6.columns = data.columns;
+  datatable6.rows = data.rows;
+```
+
+</code-block>
+
+<code-block title="React">
+
+```jsx
+  import React from "react";
+  import ReactDOM from "react-dom";
+  import { FwDataTable } from "@freshworks/crayons/react";
+  function App() {
+
+    var data = {
+      columns: [{
+        "key": "name",
+        "text": "Name",
+        "widthProperties": {
+          "minWidth": "400px"
+        }
+      }, {
+        "key": "role",
+        "text": "Role",
+        "widthProperties": {
+          "width": "200px"
+        }
+      }, {
+        "key": "level",
+        "text": "Level"
+      }],
+      rows: [{
+        "id": "0001",
+        "name": "Alexander Goodman",
+        "role": "Member",
+        "level": "L1"
+      }, {
+        "id": "0002",
+        "name": "Ambrose Wayne",
+        "role": "Member",
+        "level": "L2"
+      }]
+    }
+
+    return (
+      <FwDataTable columns={data.columns} rows={data.persons} label="Data Table 6">
+      </FwDataTable>
+    );
+  }
+```
+
+</code-block>
+</code-group>
+
+## Formatting data 
+
+We can format row's data before rendering into a cell by passing 'formatData' in column's configuration. 
+
+*This option wont work when using this with 'variant' or 'customTemplate' properties in column's configuration.*
+
+```html live
+  <fw-data-table id="datatable-7" label="Data table 7">
+  </fw-data-table>
+
+  <script type="application/javascript">
+    var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
+    var data = {
+      columns: [{
+        "key": "name",
+        "text": "Name"
+      }, {
+        "key": "courses",
+        "text": "Courses",
+        "formatData": (courses) => {
+          return courses.join(', ');
+        }
+      }, {
+        "key": "appliedon",
+        "text": "Applied on",
+        "formatData": (ISOString) => {
+          const date = new Date(ISOString);
+          return date.getDate() + " " + months[date.getMonth()] + ", " + date.getFullYear();
+        }
+      }],
+      rows: [{
+        "id": "0001",
+        "name": "Alexander Goodman",
+        "courses": ["HTML", "CSS", "JS"],
+        "appliedon": "2021-10-21T14:48:00.000Z"
+      }, {
+        "id": "0002",
+        "name": "Ambrose Wayne",
+        "courses": ["Ruby on Rails", "PostgreSQL"],
+        "appliedon": "2022-01-14T16:14:00.000Z"
+      }]
+    }
+
+    var datatable7 = document.getElementById('datatable-7');
+    datatable7.columns = data.columns;
+    datatable7.rows = data.rows;
+  </script>
+```
+
+<code-group>
+<code-block title="HTML">
+
+```html
+  <fw-data-table id="datatable-7" label="Data table 7">
+  </fw-data-table>
+```
+
+```javascript
+  var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
+  var data = {
+    columns: [{
+      "key": "name",
+      "text": "Name"
+    }, {
+      "key": "courses",
+      "text": "Courses",
+      "formatData": (courses) => {
+        return courses.join(', ');
+      }
+    }, {
+      "key": "appliedon",
+      "text": "Applied on",
+      "formatData": (ISOString) => {
+        const date = new Date(ISOString);
+        return date.getDate() + " " + months[date.getMonth()] + ", " + date.getFullYear();
+      }
+    }],
+    rows: [{
+      "id": "0001",
+      "name": "Alexander Goodman",
+      "courses": ["HTML", "CSS", "JS"],
+      "appliedon": "2021-10-21T14:48:00.000Z"
+    }, {
+      "id": "0002",
+      "name": "Ambrose Wayne",
+      "courses": ["Ruby on Rails", "PostgreSQL"],
+      "appliedon": "2022-01-14T16:14:00.000Z"
+    }]
+  }
+
+  var datatable7 = document.getElementById('datatable-7');
+  datatable7.columns = data.columns;
+  datatable7.rows = data.rows;
+```
+
+</code-block>
+
+<code-block title="React">
+
+```jsx
+  import React from "react";
+  import ReactDOM from "react-dom";
+  import { FwDataTable } from "@freshworks/crayons/react";
+  function App() {
+
+    var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
+    var data = {
+      columns: [{
+        "key": "name",
+        "text": "Name"
+      }, {
+        "key": "courses",
+        "text": "Courses",
+        "formatData": (courses) => {
+          return courses.join(', ');
+        }
+      }, {
+        "key": "appliedon",
+        "text": "Applied on",
+        "formatData": (ISOString) => {
+          const date = new Date(ISOString);
+          return date.getDate() + " " + months[date.getMonth()] + ", " + date.getFullYear();
+        }
+      }],
+      rows: [{
+        "id": "0001",
+        "name": "Alexander Goodman",
+        "courses": ["HTML", "CSS", "JS"],
+        "appliedon": "2021-10-21T14:48:00.000Z"
+      }, {
+        "id": "0002",
+        "name": "Ambrose Wayne",
+        "courses": ["Ruby on Rails", "PostgreSQL"],
+        "appliedon": "2022-01-14T16:14:00.000Z"
+      }]
+    }
+
+    return (
+      <FwDataTable columns={data.columns} rows={data.persons} label="Data Table 7">
+      </FwDataTable>
     );
   }
 ```

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -254,7 +254,7 @@ function App() {
   };
 
   return (
-    <FwDataTable columns={data.columns} rows={data.persons} label="Data Table 2">
+    <FwDataTable columns={data.columns} rows={data.rows} label="Data Table 2">
     </FwDataTable>
   );
 }
@@ -428,7 +428,117 @@ function App() {
   };
 
   return (
-    <FwDataTable columns={data.columns} rows={data.persons} label="Data Table 3">
+    <FwDataTable columns={data.columns} rows={data.rows} label="Data Table 3">
+    </FwDataTable>
+  );
+}
+```
+</code-block>
+</code-group>
+
+#### Icon column variant
+
+```html live
+  <fw-data-table id="datatable-31" label="Data table 31">
+  </fw-data-table>
+
+  <script type="application/javascript">
+    var data = {
+      columns: [{
+        "key": "icon",
+        "text": "Icon",
+        "position": 1,
+        "variant": "icon"
+      }, {
+        "key": "name",
+        "text": "Name",
+        "position": 2
+      }],
+      rows: [{
+        "id": "0011",
+        "icon": { "name": "agent" },
+        "name": "Agent"
+      }, {
+        "id": "0022",
+        "icon": { "name": "chat-online" },
+        "name": "Chat"
+      }]
+    }; 
+
+    var datatable = document.getElementById('datatable-31');
+    datatable.columns = data.columns;
+    datatable.rows = data.rows;
+  </script>
+```
+
+<code-group>
+<code-block title="HTML">
+```html 
+  <fw-data-table id="datatable-31" label="Data table 31">
+  </fw-data-table>
+```
+
+```javascript
+  var data = {
+      columns: [{
+        "key": "icon",
+        "text": "Icon",
+        "position": 1,
+        "variant": "icon"
+      }, {
+        "key": "name",
+        "text": "Name",
+        "position": 2
+      }],
+      rows: [{
+        "id": "0011",
+        "icon": { "name": "agent" },
+        "name": "Agent"
+      }, {
+        "id": "0022",
+        "icon": { "name": "chat-online" },
+        "name": "Chat"
+      }]
+    }; 
+
+  var datatable = document.getElementById('datatable-31');
+  datatable.columns = data.columns;
+  datatable.rows = data.rows;
+```
+</code-block>
+
+<code-block title="React">
+
+```jsx
+import React from "react";
+import ReactDOM from "react-dom";
+import { FwDataTable } from "@freshworks/crayons/react";
+function App() {
+
+  var data = {
+      columns: [{
+        "key": "icon",
+        "text": "Icon",
+        "position": 1,
+        "variant": "icon"
+      }, {
+        "key": "name",
+        "text": "Name",
+        "position": 2
+      }],
+      rows: [{
+        "id": "0011",
+        "icon": { "name": "agent" },
+        "name": "Agent"
+      }, {
+        "id": "0022",
+        "icon": { "name": "chat-online" },
+        "name": "Chat"
+      }]
+    }; 
+
+  return (
+    <FwDataTable columns={data.columns} rows={data.rows} label="Data Table 31">
     </FwDataTable>
   );
 }
@@ -640,7 +750,7 @@ You can easily add an actions column by passing in rowActions prop to the compon
     }
 
     return (
-      <FwDataTable columns={data.columns} rows={data.persons} rowActions={data.rowActions} label="Data Table 3">
+      <FwDataTable columns={data.columns} rows={data.rows} rowActions={data.rowActions} label="Data Table 3">
       </FwDataTable>
     );
   }
@@ -750,7 +860,7 @@ To hide certain columns, we can pass the 'hide' property set to true in the colu
     }
 
     return (
-      <FwDataTable columns={data.columns} rows={data.persons} label="Data Table 5">
+      <FwDataTable columns={data.columns} rows={data.rows} label="Data Table 5">
       </FwDataTable>
     );
   }
@@ -890,7 +1000,7 @@ We can pass width for every column using 'widthProperties' in column's configura
     }
 
     return (
-      <FwDataTable columns={data.columns} rows={data.persons} label="Data Table 6">
+      <FwDataTable columns={data.columns} rows={data.rows} label="Data Table 6">
       </FwDataTable>
     );
   }
@@ -1037,7 +1147,7 @@ We can format row's data before rendering into a cell by passing 'formatData' in
     }
 
     return (
-      <FwDataTable columns={data.columns} rows={data.persons} label="Data Table 7">
+      <FwDataTable columns={data.columns} rows={data.rows} label="Data Table 7">
       </FwDataTable>
     );
   }

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -1356,13 +1356,13 @@ Type: `Promise<boolean>`
 
 isLoading current state
 
-### `selectAllRows(checked?: boolean) => Promise<void>`
+### `selectAllRows(checked?: boolean) => Promise<string[]>`
 
 selectAllRows method we can use to select/unselect rows in the table
 
 #### Returns
 
-Type: `Promise<void>`
+Type: `Promise<string[]>`
 
 
 

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -451,7 +451,7 @@ function App() {
         "variant": "icon"
       }, {
         "key": "name",
-        "text": "Name",
+        "text": "Icon name",
         "position": 2
       }],
       rows: [{
@@ -487,7 +487,7 @@ function App() {
         "variant": "icon"
       }, {
         "key": "name",
-        "text": "Name",
+        "text": "Icon name",
         "position": 2
       }],
       rows: [{
@@ -523,7 +523,7 @@ function App() {
         "variant": "icon"
       }, {
         "key": "name",
-        "text": "Name",
+        "text": "Icon name",
         "position": 2
       }],
       rows: [{
@@ -569,6 +569,138 @@ This codeblock shows how to use custom cell function to display HTML content in 
   createElement('div', {className: 'greeting'}, [createElement('h2', 'Hello')]);
 ```
 
+## Column text alignment
+
+You can set text alignment in the column by passing the textAlign in column configuration. In the below example, column 'Icon' is center aligned.
+
+```html live
+  <fw-data-table id="data-table-40" label="Data table 40">
+  </fw-data-table>
+
+  <script type="application/javascript">
+    var data = {
+      columns: [{
+        "key": "icon",
+        "text": "Icon",
+        "variant": "icon",
+        "textAlign": "center",
+        "widthProperties": {
+          "width": "140px"
+        }
+      }, {
+        "key": "name",
+        "text": "Object Name"
+      }, {
+        "key": "description",
+        "text": "description"
+      }],
+      rows: [{
+        "id": "01",
+        "icon": { "name": "company" },
+        "name": "Company",
+        "description": "Contains information about the company."
+      }, {
+        "id": "02",
+        "icon": { "name": "calendar" },
+        "name": "Bookings",
+        "description": "Contains information about the booking made."
+      }]
+    };
+
+    var datatable = document.getElementById('data-table-40');
+    datatable.columns = data.columns;
+    datatable.rows = data.rows;
+  </script>
+```
+
+<code-group>
+<code-block title="HTML">
+```html 
+  <fw-data-table id="datatable-40" label="Data table 40">
+  </fw-data-table>
+```
+
+```javascript
+  var data = {
+    columns: [{
+      "key": "icon",
+      "text": "Icon",
+      "variant": "icon",
+      "textAlign": "center",
+      "widthProperties": {
+        "width": "140px"
+      }
+    }, {
+      "key": "name",
+      "text": "Object Name"
+    }, {
+      "key": "description",
+      "text": "description"
+    }],
+    rows: [{
+      "id": "01",
+      "icon": { "name": "company" },
+      "name": "Company",
+      "description": "Contains information about the company."
+    }, {
+      "id": "02",
+      "icon": { "name": "calendar" },
+      "name": "Bookings",
+      "description": "Contains information about the booking made."
+    }]
+  };
+
+  var datatable = document.getElementById('data-table-40');
+  datatable.columns = data.columns;
+  datatable.rows = data.rows;
+```
+</code-block>
+
+<code-block title="React">
+
+```jsx
+import React from "react";
+import ReactDOM from "react-dom";
+import { FwDataTable } from "@freshworks/crayons/react";
+function App() {
+
+  var data = {
+    columns: [{
+      "key": "icon",
+      "text": "Icon",
+      "variant": "icon",
+      "textAlign": "center",
+      "widthProperties": {
+        "width": "140px"
+      }
+    }, {
+      "key": "name",
+      "text": "Object Name"
+    }, {
+      "key": "description",
+      "text": "description"
+    }],
+    rows: [{
+      "id": "01",
+      "icon": { "name": "company" },
+      "name": "Company",
+      "description": "Contains information about the company."
+    }, {
+      "id": "02",
+      "icon": { "name": "calendar" },
+      "name": "Bookings",
+      "description": "Contains information about the booking made."
+    }]
+  };
+
+  return (
+    <FwDataTable columns={data.columns} rows={data.rows} label="Data Table 40">
+    </FwDataTable>
+  );
+}
+```
+</code-block>
+</code-group>
 
 ## Row Actions:
 

--- a/packages/crayons-core/src/components/icon/readme.md
+++ b/packages/crayons-core/src/components/icon/readme.md
@@ -239,6 +239,7 @@ It comes packed with a ultra tuned svgo-config. We support YML Config convention
 
  - [fw-accordion-title](../accordion-title)
  - [fw-button](../button)
+ - [fw-custom-cell-icon](../data-table/custom-cells/icon)
  - [fw-drag-item](../drag-item)
  - [fw-dropdown-button](../dropdown-button)
  - [fw-inline-message](../inline-message)
@@ -265,6 +266,7 @@ graph TD;
   fw-toast-message --> fw-icon
   fw-accordion-title --> fw-icon
   fw-button --> fw-icon
+  fw-custom-cell-icon --> fw-icon
   fw-drag-item --> fw-icon
   fw-dropdown-button --> fw-icon
   fw-inline-message --> fw-icon

--- a/packages/crayons-core/src/components/icon/readme.md
+++ b/packages/crayons-core/src/components/icon/readme.md
@@ -240,6 +240,7 @@ It comes packed with a ultra tuned svgo-config. We support YML Config convention
  - [fw-accordion-title](../accordion-title)
  - [fw-button](../button)
  - [fw-custom-cell-icon](../data-table/custom-cells/icon)
+ - [fw-data-table](../data-table)
  - [fw-drag-item](../drag-item)
  - [fw-dropdown-button](../dropdown-button)
  - [fw-inline-message](../inline-message)
@@ -267,6 +268,7 @@ graph TD;
   fw-accordion-title --> fw-icon
   fw-button --> fw-icon
   fw-custom-cell-icon --> fw-icon
+  fw-data-table --> fw-icon
   fw-drag-item --> fw-icon
   fw-dropdown-button --> fw-icon
   fw-inline-message --> fw-icon

--- a/packages/crayons-core/src/utils/types.ts
+++ b/packages/crayons-core/src/utils/types.ts
@@ -50,7 +50,7 @@ export type WidthStyles = {
 
 export type DataTableRow = {
   id: string;
-  [prop: string]: string;
+  [prop: string]: any;
 };
 
 export type customTemplateFunc<T> = (
@@ -66,6 +66,7 @@ export type DataTableColumn = {
   hide?: boolean;
   widthProperties?: WidthStyles;
   hasFocusableComponent?: boolean;
+  formatData?: (cellValue: any) => string;
   customTemplate?: customTemplateFunc<VNode>;
 };
 

--- a/packages/crayons-core/src/utils/types.ts
+++ b/packages/crayons-core/src/utils/types.ts
@@ -45,7 +45,7 @@ interface HyperFunc<T> {
 export type AllowedStyles = 'width' | 'minWidth' | 'maxWidth';
 
 export type WidthStyles = {
-  [prop in AllowedStyles]: any;
+  [prop in AllowedStyles]: string;
 };
 
 export type DataTableRow = {
@@ -72,6 +72,8 @@ export type DataTableColumn = {
 
 export type DataTableAction = {
   name: string;
-  handler: (row: DataTableRow) => any;
+  iconName?: string;
+  iconLibrary?: string;
   hideForRowIds?: string[];
+  handler: (row: DataTableRow) => any;
 };

--- a/packages/crayons-core/src/utils/types.ts
+++ b/packages/crayons-core/src/utils/types.ts
@@ -42,9 +42,15 @@ interface HyperFunc<T> {
   (sel: any, data: any, children: T): T;
 }
 
+export type AllowedStyles = 'width' | 'minWidth' | 'maxWidth';
+
+export type WidthStyles = {
+  [prop in AllowedStyles]: any;
+};
+
 export type DataTableRow = {
   id: string;
-  [prop: string]: any;
+  [prop: string]: string;
 };
 
 export type customTemplateFunc<T> = (
@@ -58,6 +64,7 @@ export type DataTableColumn = {
   variant?: string;
   position?: number;
   hide?: boolean;
+  widthProperties?: WidthStyles;
   hasFocusableComponent?: boolean;
   customTemplate?: customTemplateFunc<VNode>;
 };

--- a/packages/crayons-core/src/utils/types.ts
+++ b/packages/crayons-core/src/utils/types.ts
@@ -65,6 +65,7 @@ export type DataTableColumn = {
   position?: number;
   hide?: boolean;
   widthProperties?: WidthStyles;
+  textAlign?: 'left' | 'center' | 'right';
   hasFocusableComponent?: boolean;
   formatData?: (cellValue: any) => string;
   customTemplate?: customTemplateFunc<VNode>;

--- a/packages/crayons-core/src/utils/types.ts
+++ b/packages/crayons-core/src/utils/types.ts
@@ -57,6 +57,7 @@ export type DataTableColumn = {
   text: string;
   variant?: string;
   position?: number;
+  hide?: boolean;
   hasFocusableComponent?: boolean;
   customTemplate?: customTemplateFunc<VNode>;
 };


### PR DESCRIPTION
### This PR has the following feature set for fw-data-table component:

- Adding 'icon' variant for Table cell.
- Ability to have row actions as icon buttons.
- Exposing a method to select/unselect all rows in the table.
- Adding 'textAlign' column configuration to align text in a particular column. Ex: Icons columns have center aligned text.

#### Column icon variant configuration:
```js 
const columns = [{
  "key": "icon",
  "text": "Object Icons",
  "variant": "icon"
}]
```
Example:
<img width="407" alt="Screenshot 2022-01-20 at 1 12 41 PM" src="https://user-images.githubusercontent.com/61269786/150294791-2faf0658-87ec-4b27-8e94-c1efd990128a.png">

#### Column text align configuration:
```js
const columns = [{
  "key": "name",
  "text": "Name",
  "textAlign": "center"
}]
```
Example: (Icons column is center aligned)
<img width="687" alt="Screenshot 2022-01-20 at 1 14 04 PM" src="https://user-images.githubusercontent.com/61269786/150294961-16756ffd-9ef7-4528-8103-df454e0bf831.png">


#### RowActions as icons:
```js
const rowActions = [{
  name: 'Edit',
  iconName: 'edit',
  handler: (rowData) => {
    console.log(rowData);
  }
}];
```
Example:
<img width="698" alt="Screenshot 2022-01-20 at 1 14 43 PM" src="https://user-images.githubusercontent.com/61269786/150295044-b7e15063-e729-4f7b-9004-a094747ab746.png">

#### select all rows from table

```js
const dataTable = document.querySelector('fw-data-table');
await dataTable.selectAllRows();
await dataTable.selectAllRows(false);
```
Example:

https://user-images.githubusercontent.com/61269786/150295742-629e72e7-d709-4a18-8eac-a6338fc388ec.mov



#### Steps to run vuepress documentation:

- From root of project run npm run docs:dev
- Open the link that shows up in console after running above command.
- Navigate to DataTable component in sidebar

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
- This was tested in Chrome, Firefox and Safari browsers.
- Tested manually when creating Vuepress documentation.
- Supporting UTs added/passed.