### PR TITLE
fix(skeleton): removing margin-bottom when skeleton count is 1

### DIFF
--- a/packages/crayons-core/src/components/skeleton/readme.md
+++ b/packages/crayons-core/src/components/skeleton/readme.md
@@ -225,7 +225,7 @@ function App() {
 | `--skeleton-background`    | Skeleton background: Default: #cfd7df                                                     |
 | `--skeleton-border-radius` | Skeleton border-radius: Default: 999px for the text, 50% for the circle, 0px for the rect |
 | `--skeleton-height`        | Skeleton height: Default: 16px for the text and rect, 32px for the circle                 |
-| `--skeleton-margin-bottom` | Skeleton margin-bottom: Default: 8px                                                      |
+| `--skeleton-margin-bottom` | Skeleton margin-bottom: Default: 8px/0px(when count is 1)                                 |
 | `--skeleton-width`         | Skeleton width: Default: 100% for the text and rect, 32px for the circle                  |
 
 

--- a/packages/crayons-core/src/components/skeleton/skeleton.scss
+++ b/packages/crayons-core/src/components/skeleton/skeleton.scss
@@ -1,7 +1,7 @@
 /**
  * @prop --skeleton-height: Skeleton height: Default: 16px for the text and rect, 32px for the circle
  * @prop --skeleton-width: Skeleton width: Default: 100% for the text and rect, 32px for the circle
- * @prop --skeleton-margin-bottom: Skeleton margin-bottom: Default: 8px
+ * @prop --skeleton-margin-bottom: Skeleton margin-bottom: Default: 8px/0px(when count is 1)
  * @prop --skeleton-border-radius: Skeleton border-radius: Default: 999px for the text, 50% for the circle, 0px for the rect
  * @prop --skeleton-background: Skeleton background: Default: #cfd7df
  * @prop --sheen-color: Skeleton Sheen effect color: Default: #b1bdc8
@@ -34,6 +34,10 @@
 
   &.rect {
     border-radius: var(--skeleton-border-radius, 0px);
+  }
+
+  &.only {
+    margin-bottom: var(--skeleton-margin-bottom, 0px);
   }
 
   // stylelint-disable a11y/media-prefers-reduced-motion

--- a/packages/crayons-core/src/components/skeleton/skeleton.tsx
+++ b/packages/crayons-core/src/components/skeleton/skeleton.tsx
@@ -111,6 +111,7 @@ export class Skeleton {
                 skeleton: true,
                 pulse: this.effect === 'pulse',
                 sheen: this.effect === 'sheen',
+                only: this.count === 1,
               }}
               aria-busy='true'
               aria-live='polite'


### PR DESCRIPTION
When skeleton count is 1, we won't need a margin bottom in most cases. If there is a margin, we are having to reset it unnecessarily when using in other components like table. This PR remove margin bottom if the skeleton count is 1.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome browser.
