### PR TITLE
feat(format-date): format date using Intl.DateTimeFormat API

### DIFF
--- a/packages/crayons-core/crayons-react/index.ts
+++ b/packages/crayons-core/crayons-react/index.ts
@@ -1,2 +1,2 @@
 export * from './components';
-export { ToastController, ProgressLoaderController, registerIconLibrary, unregisterIconLibrary } from '../dist/components/index' 
+export { ToastController, ProgressLoaderController, registerIconLibrary, unregisterIconLibrary, DateFormatController} from '../dist/components/index' 

--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -376,6 +376,56 @@ export namespace Components {
     | 'TEL'
     | 'TIME';
     }
+    interface FwFormatDate {
+        /**
+          * The date/time to format. If not set, the current date and time will be used.
+         */
+        "date": Date | string;
+        /**
+          * The format for displaying the day.
+         */
+        "day": 'numeric' | '2-digit';
+        /**
+          * The format for displaying the hour.
+         */
+        "hour": 'numeric' | '2-digit';
+        /**
+          * When set, 24 hour time will always be used.
+         */
+        "hourFormat": 'auto' | '12' | '24';
+        /**
+          * The locale to use when formatting the date/time.
+         */
+        "locale": string;
+        /**
+          * The format for displaying the minute.
+         */
+        "minute": 'numeric' | '2-digit';
+        /**
+          * The format for displaying the month.
+         */
+        "month": 'numeric' | '2-digit' | 'narrow' | 'short' | 'long';
+        /**
+          * The format for displaying the second.
+         */
+        "second": 'numeric' | '2-digit';
+        /**
+          * The time zone to express the time in.
+         */
+        "timeZone": string;
+        /**
+          * The format for displaying the time.
+         */
+        "timeZoneName": 'short' | 'long';
+        /**
+          * The format for displaying the weekday.
+         */
+        "weekday": 'narrow' | 'short' | 'long';
+        /**
+          * The format for displaying the year.
+         */
+        "year": 'numeric' | '2-digit';
+    }
     interface FwFormatNumber {
         /**
           * The currency to use in currency formatting. Possible values are the `ISO 4217` currency codes, such as `USD` for the US dollar, `EUR` for the euro. If the style is "currency", the currency property must be provided.
@@ -1692,6 +1742,12 @@ declare global {
         prototype: HTMLFwFormControlElement;
         new (): HTMLFwFormControlElement;
     };
+    interface HTMLFwFormatDateElement extends Components.FwFormatDate, HTMLStencilElement {
+    }
+    var HTMLFwFormatDateElement: {
+        prototype: HTMLFwFormatDateElement;
+        new (): HTMLFwFormatDateElement;
+    };
     interface HTMLFwFormatNumberElement extends Components.FwFormatNumber, HTMLStencilElement {
     }
     var HTMLFwFormatNumberElement: {
@@ -1913,6 +1969,7 @@ declare global {
         "fw-dropdown-button": HTMLFwDropdownButtonElement;
         "fw-form": HTMLFwFormElement;
         "fw-form-control": HTMLFwFormControlElement;
+        "fw-format-date": HTMLFwFormatDateElement;
         "fw-format-number": HTMLFwFormatNumberElement;
         "fw-icon": HTMLFwIconElement;
         "fw-inline-message": HTMLFwInlineMessageElement;
@@ -2339,6 +2396,56 @@ declare namespace LocalJSX {
     | 'URL'
     | 'TEL'
     | 'TIME';
+    }
+    interface FwFormatDate {
+        /**
+          * The date/time to format. If not set, the current date and time will be used.
+         */
+        "date"?: Date | string;
+        /**
+          * The format for displaying the day.
+         */
+        "day"?: 'numeric' | '2-digit';
+        /**
+          * The format for displaying the hour.
+         */
+        "hour"?: 'numeric' | '2-digit';
+        /**
+          * When set, 24 hour time will always be used.
+         */
+        "hourFormat"?: 'auto' | '12' | '24';
+        /**
+          * The locale to use when formatting the date/time.
+         */
+        "locale"?: string;
+        /**
+          * The format for displaying the minute.
+         */
+        "minute"?: 'numeric' | '2-digit';
+        /**
+          * The format for displaying the month.
+         */
+        "month"?: 'numeric' | '2-digit' | 'narrow' | 'short' | 'long';
+        /**
+          * The format for displaying the second.
+         */
+        "second"?: 'numeric' | '2-digit';
+        /**
+          * The time zone to express the time in.
+         */
+        "timeZone"?: string;
+        /**
+          * The format for displaying the time.
+         */
+        "timeZoneName"?: 'short' | 'long';
+        /**
+          * The format for displaying the weekday.
+         */
+        "weekday"?: 'narrow' | 'short' | 'long';
+        /**
+          * The format for displaying the year.
+         */
+        "year"?: 'numeric' | '2-digit';
     }
     interface FwFormatNumber {
         /**
@@ -3642,6 +3749,7 @@ declare namespace LocalJSX {
         "fw-dropdown-button": FwDropdownButton;
         "fw-form": FwForm;
         "fw-form-control": FwFormControl;
+        "fw-format-date": FwFormatDate;
         "fw-format-number": FwFormatNumber;
         "fw-icon": FwIcon;
         "fw-inline-message": FwInlineMessage;
@@ -3698,6 +3806,7 @@ declare module "@stencil/core" {
             "fw-dropdown-button": LocalJSX.FwDropdownButton & JSXBase.HTMLAttributes<HTMLFwDropdownButtonElement>;
             "fw-form": LocalJSX.FwForm & JSXBase.HTMLAttributes<HTMLFwFormElement>;
             "fw-form-control": LocalJSX.FwFormControl & JSXBase.HTMLAttributes<HTMLFwFormControlElement>;
+            "fw-format-date": LocalJSX.FwFormatDate & JSXBase.HTMLAttributes<HTMLFwFormatDateElement>;
             "fw-format-number": LocalJSX.FwFormatNumber & JSXBase.HTMLAttributes<HTMLFwFormatNumberElement>;
             "fw-icon": LocalJSX.FwIcon & JSXBase.HTMLAttributes<HTMLFwIconElement>;
             "fw-inline-message": LocalJSX.FwInlineMessage & JSXBase.HTMLAttributes<HTMLFwInlineMessageElement>;

--- a/packages/crayons-core/src/components/format-date/format-date-util.ts
+++ b/packages/crayons-core/src/components/format-date/format-date-util.ts
@@ -1,0 +1,61 @@
+export interface dateOptions {
+  weekday?: 'narrow' | 'short' | 'long';
+
+  /** The format for displaying the year. */
+  year?: 'numeric' | '2-digit';
+
+  /** The format for displaying the month. */
+  month?: 'numeric' | '2-digit' | 'narrow' | 'short' | 'long';
+
+  /** The format for displaying the day. */
+  day?: 'numeric' | '2-digit';
+
+  /** The format for displaying the hour. */
+  hour?: 'numeric' | '2-digit';
+
+  /** The format for displaying the minute. */
+  minute?: 'numeric' | '2-digit';
+
+  /** The format for displaying the second. */
+  second?: 'numeric' | '2-digit';
+
+  /** When set, 24 hour time will always be used. */
+  hour12?: boolean;
+
+  /** The format for displaying the time. */
+  timeZoneName?: 'short' | 'long';
+
+  /** The time zone to express the time in. */
+  timeZone?: string;
+}
+
+export function formatDate(
+  {
+    date,
+    locale,
+    options,
+  }: { date: string | Date; locale: string | []; options: dateOptions } = {
+    date: new Date(),
+    locale: [],
+    options: {},
+  }
+): string {
+  const dt = new Date(date);
+  // Check for an invalid date
+  if (isNaN(dt.getMilliseconds())) {
+    return undefined;
+  }
+
+  return new Intl.DateTimeFormat(locale || [], {
+    weekday: options.weekday,
+    year: options.year,
+    month: options.month,
+    day: options.day,
+    hour: options.hour,
+    minute: options.minute,
+    second: options.second,
+    timeZoneName: options.timeZoneName,
+    timeZone: options.timeZone,
+    hour12: options.hour12,
+  }).format(dt);
+}

--- a/packages/crayons-core/src/components/format-date/format-date-util.ts
+++ b/packages/crayons-core/src/components/format-date/format-date-util.ts
@@ -34,7 +34,11 @@ export function formatDate(
     date,
     locale,
     options,
-  }: { date: string | Date; locale: string | []; options: dateOptions } = {
+  }: {
+    date: string | Date | number;
+    locale: string | [];
+    options: dateOptions;
+  } = {
     date: new Date(),
     locale: [],
     options: {},

--- a/packages/crayons-core/src/components/format-date/format-date.e2e.ts
+++ b/packages/crayons-core/src/components/format-date/format-date.e2e.ts
@@ -1,0 +1,74 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('fw-format-date', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<fw-format-date></fw-format-date>');
+    const element = await page.find('fw-format-date');
+    expect(element).toHaveClass('hydrated');
+  });
+  it('should render date based on locale', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<fw-format-date date="2022-01-27" locale="en-US"></fw-format-date>'
+    );
+    const element = await page.find('fw-format-date');
+    expect(element.shadowRoot).toEqualText('1/27/2022');
+  });
+  it('should render long month and day and year numeric', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<fw-format-date date="2022-01-27" month="long" day="numeric" year="numeric"></fw-format-date>'
+    );
+    const element = await page.find('fw-format-date');
+    expect(element.shadowRoot).toEqualText('January 27, 2022');
+  });
+  it('should render month only', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<fw-format-date date="2022-01-27" month="long"></fw-format-date>'
+    );
+    const element = await page.find('fw-format-date');
+    expect(element.shadowRoot).toEqualText('January');
+  });
+  it('should render year only', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<fw-format-date date="2022-01-27" year="numeric"></fw-format-date>'
+    );
+    const element = await page.find('fw-format-date');
+    expect(element.shadowRoot).toEqualText('2022');
+  });
+  it('should render weekday only', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<fw-format-date date="2022-01-27" weekday="long"></fw-format-date>'
+    );
+    const element = await page.find('fw-format-date');
+    expect(element.shadowRoot).toEqualText('Thursday');
+  });
+  it('should render 12 hour format ', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<fw-format-date date="2020-07-15T17:30:00+05:30" hour="numeric" minute="numeric" hour-format="12"></fw-format-date>'
+    );
+    const element = await page.find('fw-format-date');
+    expect(element.shadowRoot).toEqualText('5:30 PM');
+  });
+  it('should render 24 hour format ', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<fw-format-date date="2020-07-15T17:30:00+05:30" hour="numeric" minute="numeric" hour-format="24"></fw-format-date>'
+    );
+    const element = await page.find('fw-format-date');
+    expect(element.shadowRoot).toEqualText('17:30');
+  });
+});

--- a/packages/crayons-core/src/components/format-date/format-date.stories.mdx
+++ b/packages/crayons-core/src/components/format-date/format-date.stories.mdx
@@ -1,0 +1,51 @@
+import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+
+# FormatDate
+
+<Meta
+  title='FormatDate'
+  component='fw-format-date'
+/>
+
+## Props 
+
+<Props of="fw-format-date"/>
+
+## Usage
+
+### Date Formatting options
+<Preview>
+  <Story name='date-formats'>
+  {() => `<fw-format-date></fw-format-date><br/>
+            <fw-format-date weekday="long"></fw-format-date><br>
+            <fw-format-date month="long"></fw-format-date><br>
+            <fw-format-date year="numeric"></fw-format-date><br>
+            `}
+  </Story>
+</Preview>
+
+
+### Hour Format options
+<Preview>
+  <Story name='hour-formats'>
+    {
+      () => `<fw-format-date hour="numeric"
+  minute="numeric"
+  hour-format="12"></fw-format-date><br>
+  <fw-format-date hour="numeric"
+  minute="numeric"
+  hour-format="24"></fw-format-date><br/>`
+    }
+  </Story>
+</Preview>
+
+
+### Locale Format options
+<Preview>
+  <Story name='locale-formats'>
+    {
+      () => `<fw-format-date locale='en-US'></fw-format-date><br>
+      <fw-format-date locale='en-GB'></fw-format-date><br>`
+    }
+  </Story>
+</Preview>

--- a/packages/crayons-core/src/components/format-date/format-date.tsx
+++ b/packages/crayons-core/src/components/format-date/format-date.tsx
@@ -1,0 +1,74 @@
+import { Component, Prop } from '@stencil/core';
+import { formatDate } from './format-date-util';
+
+@Component({
+  tag: 'fw-format-date',
+  shadow: true,
+})
+export class FormatDate {
+  /** The date/time to format. If not set, the current date and time will be used. */
+  @Prop() date: Date | string = new Date();
+
+  /** The locale to use when formatting the date/time. */
+  @Prop() locale: string;
+
+  /** The format for displaying the weekday. */
+  @Prop() weekday: 'narrow' | 'short' | 'long';
+
+  /** The format for displaying the year. */
+  @Prop() year: 'numeric' | '2-digit';
+
+  /** The format for displaying the month. */
+  @Prop() month: 'numeric' | '2-digit' | 'narrow' | 'short' | 'long';
+
+  /** The format for displaying the day. */
+  @Prop() day: 'numeric' | '2-digit';
+
+  /** The format for displaying the hour. */
+  @Prop() hour: 'numeric' | '2-digit';
+
+  /** The format for displaying the minute. */
+  @Prop() minute: 'numeric' | '2-digit';
+
+  /** The format for displaying the second. */
+  @Prop() second: 'numeric' | '2-digit';
+
+  /** When set, 24 hour time will always be used. */
+  @Prop() hourFormat: 'auto' | '12' | '24' = 'auto';
+
+  /** The format for displaying the time. */
+  @Prop() timeZoneName: 'short' | 'long';
+
+  /** The time zone to express the time in. */
+  @Prop() timeZone: string;
+
+  render(): string {
+    const date = new Date(this.date);
+    const hour12 =
+      this.hourFormat === 'auto' ? undefined : this.hourFormat === '12';
+
+    // Check if the given date is invalid.
+    if (isNaN(date.getMilliseconds())) {
+      console.error(`Invalid date ${this.date}`);
+      return;
+    }
+    {
+      return formatDate({
+        date: date,
+        locale: this.locale,
+        options: {
+          weekday: this.weekday,
+          year: this.year,
+          month: this.month,
+          day: this.day,
+          hour: this.hour,
+          minute: this.minute,
+          second: this.second,
+          timeZoneName: this.timeZoneName,
+          timeZone: this.timeZone,
+          hour12: hour12,
+        },
+      });
+    }
+  }
+}

--- a/packages/crayons-core/src/components/format-date/format-date.tsx
+++ b/packages/crayons-core/src/components/format-date/format-date.tsx
@@ -7,7 +7,7 @@ import { formatDate } from './format-date-util';
 })
 export class FormatDate {
   /** The date/time to format. If not set, the current date and time will be used. */
-  @Prop() date: Date | string = new Date();
+  @Prop() date: Date | string | number = new Date();
 
   /** The locale to use when formatting the date/time. */
   @Prop() locale: string;

--- a/packages/crayons-core/src/components/format-date/readme.md
+++ b/packages/crayons-core/src/components/format-date/readme.md
@@ -216,7 +216,7 @@ interface dateOptions {
 
 | Property       | Attribute        | Description                                                                  | Type                                                      | Default      |
 | -------------- | ---------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------- | ------------ |
-| `date`         | `date`           | The date/time to format. If not set, the current date and time will be used. | `Date \| string`                                          | `new Date()` |
+| `date`         | `date`           | The date/time to format. If not set, the current date and time will be used. | `Date \| number \| string`                                | `new Date()` |
 | `day`          | `day`            | The format for displaying the day.                                           | `"2-digit" \| "numeric"`                                  | `undefined`  |
 | `hour`         | `hour`           | The format for displaying the hour.                                          | `"2-digit" \| "numeric"`                                  | `undefined`  |
 | `hourFormat`   | `hour-format`    | When set, 24 hour time will always be used.                                  | `"12" \| "24" \| "auto"`                                  | `'auto'`     |

--- a/packages/crayons-core/src/components/format-date/readme.md
+++ b/packages/crayons-core/src/components/format-date/readme.md
@@ -16,7 +16,7 @@ When using strings, avoid ambiguous dates such as `05/04/2021` which can be inte
 <fw-format-date month="long" day="numeric" year="numeric"></fw-format-date>
 ```
 
-<label><strong>Formatting options</strong></label>
+<strong>Formatting options</strong>
 
 ```html live
 <!-- Format Time -->
@@ -35,7 +35,7 @@ When using strings, avoid ambiguous dates such as `05/04/2021` which can be inte
 <fw-format-date></fw-format-date>
 ```
 
-<label><strong>Hour Format</strong></label>
+<strong>Hour Format</strong>
 
 ```html live
 <div>
@@ -56,7 +56,7 @@ When using strings, avoid ambiguous dates such as `05/04/2021` which can be inte
 </div>
 ```
 
-<label><strong>Locale</strong></label>
+<strong>Locale</strong>
 
 ```html live
 <div>

--- a/packages/crayons-core/src/components/format-date/readme.md
+++ b/packages/crayons-core/src/components/format-date/readme.md
@@ -1,0 +1,234 @@
+# Format Date (fw-format-date)
+
+Formats a date/time using the specified locale and options.
+
+The `date` attribute determines the date/time to use when formatting. It must be a string that [`Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse) can interpret or a [`Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) object set via JavaScript. By default current date/time is used.
+
+When using strings, avoid ambiguous dates such as `05/04/2021` which can be interpreted as May 4 or April 5 depending on the user's browser and locale. Instead, always use a valid [ISO 8601 date time string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#Date_Time_String_Format) to ensure the date will be parsed correctly.
+
+`Localization` is handled by the browser's [`Intl.DateTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat).
+
+## Demo
+
+```html live
+<fw-format-date date="2021-11-30T09:17:00-04:00"></fw-format-date><br />
+
+<fw-format-date month="long" day="numeric" year="numeric"></fw-format-date>
+```
+
+<label><strong>Formatting options</strong></label>
+
+```html live
+<!-- Format Time -->
+<fw-format-date hour="numeric" minute="numeric"></fw-format-date><br />
+
+<!-- Format weekday -->
+<fw-format-date weekday="long"></fw-format-date><br />
+
+<!-- Format month -->
+<fw-format-date month="long"></fw-format-date><br />
+
+<!-- Format year -->
+<fw-format-date year="numeric"></fw-format-date><br />
+
+<!-- No formatting options -->
+<fw-format-date></fw-format-date>
+```
+
+<label><strong>Hour Format</strong></label>
+
+```html live
+<div>
+  <strong>12 hour format</strong><br />
+  <fw-format-date
+    hour="numeric"
+    minute="numeric"
+    hour-format="12"
+  ></fw-format-date>
+</div>
+<div>
+  <strong>24 hour format</strong><br />
+  <fw-format-date
+    hour="numeric"
+    minute="numeric"
+    hour-format="24"
+  ></fw-format-date>
+</div>
+```
+
+<label><strong>Locale</strong></label>
+
+```html live
+<div>
+  <strong>English</strong><br /><fw-format-date locale="en-US"></fw-format-date>
+</div>
+<div>
+  <strong>Great Britain</strong><br /><fw-format-date
+    locale="en-GB"
+  ></fw-format-date>
+</div>
+```
+
+## Usage
+
+<code-group>
+<code-block title="HTML">
+```html
+<fw-format-date date="2021-11-30T09:17:00-04:00"></fw-format-date><br/>
+ 
+<fw-format-date month="long" day="numeric" year="numeric"></fw-format-date><br/>
+
+<label>Formatting options</label><br/>
+
+<!-- Format Time -->
+
+<fw-format-date hour="numeric" minute="numeric"></fw-format-date><br/>
+
+<!-- Format weekday -->
+
+<fw-format-date weekday="long"></fw-format-date><br/>
+
+<!-- Format month -->
+
+<fw-format-date month="long"></fw-format-date><br/>
+
+<!-- Format year -->
+
+<fw-format-date year="numeric"></fw-format-date><br/>
+
+<!-- No formatting options -->
+
+<fw-format-date></fw-format-date><br/>
+
+<label>12 Hour Format</label><br/>
+<fw-format-date hour="numeric" minute="numeric" hour-format="12"></fw-format-date><br/>
+<label> 24 Hour Format</label><br/>
+<fw-format-date hour="numeric" minute="numeric" hour-format="24"></fw-format-date><br/>
+
+<label>Locale</label><br/>
+English: <fw-format-date locale="en-US"></fw-format-date><br/>
+Great Britain: <fw-format-date locale="en-GB"></fw-format-date>
+
+````
+</code-block>
+
+<code-block title="React">
+```jsx
+import React from "react";
+import { FwFormatDate } from "@freshworks/crayons/react";
+
+function App() {
+
+  return (<div>
+    <FwFormatDate date="2021-11-30T09:17:00-04:00"></FwFormatDate><br/>
+
+    <FwFormatDate month="long" day="numeric" year="numeric"></FwFormatDate><br/>
+
+    <label>Formatting Options</label><br/>
+
+    {/* Format time */}
+    <FwFormatDate hour="numeric" minute="numeric"></FwFormatDate><br/>
+
+    {/* Format weekday */}
+    <FwFormatDate weekday="long"></FwFormatDate><br/>
+
+    {/* Format month */}
+    <FwFormatDate month="long"></FwFormatDate><br/>
+
+    {/* Format year */}
+    <FwFormatDate year="numeric"></FwFormatDate><br/>
+
+    {/* No formatting options */}
+    <FwFormatDate></FwFormatDate><br/>
+
+    <label>12 Hour Format</label><br/>
+    <FwFormatDate hour="numeric" minute="numeric" hour-format="12"></FwFormatDate><br/>
+    <label>24 Hour Format</label><br/>
+    <FwFormatDate hour="numeric" minute="numeric" hour-format="24"></FwFormatDate><br/>
+
+    <label>Locale</label><br/>
+    English: <FwFormatDate locale="en-US"></FwFormatDate><br/>
+    Great Britain: <FwFormatDate locale="en-GB"></FwFormatDate><br/>
+
+  </div >);
+}
+
+export default App;
+
+````
+
+</code-block>
+</code-group>
+
+### DateFormatController
+
+You can use `DateFormatController` to format date by passing the below set of [DateFormatOptions](#dateformatoptions).
+
+```js
+Javascript - import { DateFormatController } from "@freshworks/crayons"
+React - import { DateFormatController } from "@freshworks/crayons/react"
+
+ const formattedDate= DateFormatController({
+     date: // defaults to current date
+     locale: // defaults to browser's default locale
+    //...Date Format Options
+ });
+```
+
+#### DateFormatOptions
+
+```js
+interface dateOptions {
+  weekday?: 'narrow' | 'short' | 'long';
+
+  /** The format for displaying the year. */
+  year?: 'numeric' | '2-digit';
+
+  /** The format for displaying the month. */
+  month?: 'numeric' | '2-digit' | 'narrow' | 'short' | 'long';
+
+  /** The format for displaying the day. */
+  day?: 'numeric' | '2-digit';
+
+  /** The format for displaying the hour. */
+  hour?: 'numeric' | '2-digit';
+
+  /** The format for displaying the minute. */
+  minute?: 'numeric' | '2-digit';
+
+  /** The format for displaying the second. */
+  second?: 'numeric' | '2-digit';
+
+  /** When set, 12 hour time will be used. */
+  hour12?: boolean;
+
+  /** The format for displaying the time. */
+  timeZoneName?: 'short' | 'long';
+
+  /** The time zone to express the time in. */
+  timeZone?: string;
+}
+```
+
+<!-- Auto Generated Below -->
+
+## Properties
+
+| Property       | Attribute        | Description                                                                  | Type                                                      | Default      |
+| -------------- | ---------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------- | ------------ |
+| `date`         | `date`           | The date/time to format. If not set, the current date and time will be used. | `Date \| string`                                          | `new Date()` |
+| `day`          | `day`            | The format for displaying the day.                                           | `"2-digit" \| "numeric"`                                  | `undefined`  |
+| `hour`         | `hour`           | The format for displaying the hour.                                          | `"2-digit" \| "numeric"`                                  | `undefined`  |
+| `hourFormat`   | `hour-format`    | When set, 24 hour time will always be used.                                  | `"12" \| "24" \| "auto"`                                  | `'auto'`     |
+| `locale`       | `locale`         | The locale to use when formatting the date/time.                             | `string`                                                  | `undefined`  |
+| `minute`       | `minute`         | The format for displaying the minute.                                        | `"2-digit" \| "numeric"`                                  | `undefined`  |
+| `month`        | `month`          | The format for displaying the month.                                         | `"2-digit" \| "long" \| "narrow" \| "numeric" \| "short"` | `undefined`  |
+| `second`       | `second`         | The format for displaying the second.                                        | `"2-digit" \| "numeric"`                                  | `undefined`  |
+| `timeZone`     | `time-zone`      | The time zone to express the time in.                                        | `string`                                                  | `undefined`  |
+| `timeZoneName` | `time-zone-name` | The format for displaying the time.                                          | `"long" \| "short"`                                       | `undefined`  |
+| `weekday`      | `weekday`        | The format for displaying the weekday.                                       | `"long" \| "narrow" \| "short"`                           | `undefined`  |
+| `year`         | `year`           | The format for displaying the year.                                          | `"2-digit" \| "numeric"`                                  | `undefined`  |
+
+---
+
+Built with ❤ at Freshworks

--- a/packages/crayons-core/src/global/crayons.ts
+++ b/packages/crayons-core/src/global/crayons.ts
@@ -13,6 +13,11 @@ import {
   ProgressLoaderOptions,
 } from '../components/progress-loader/progress-loader-util';
 
+import {
+  dateOptions,
+  formatDate,
+} from '../components/format-date/format-date-util';
+
 export function ToastController(
   config: ToastOptions = { position: 'top-center' }
 ): ToastResult {
@@ -31,6 +36,19 @@ export function ProgressLoaderController(
   return createProgressLoaderContainer(config);
 }
 
+export function DateFormatController(
+  {
+    date,
+    locale,
+    options,
+  }: { date: string | Date; locale: string | []; options: dateOptions } = {
+    date: new Date(),
+    locale: [],
+    options: {},
+  }
+): string {
+  return formatDate({ date, locale, options });
+}
 export {
   registerIconLibrary,
   unregisterIconLibrary,

--- a/packages/crayons-core/src/global/crayons.ts
+++ b/packages/crayons-core/src/global/crayons.ts
@@ -41,7 +41,11 @@ export function DateFormatController(
     date,
     locale,
     options,
-  }: { date: string | Date; locale: string | []; options: dateOptions } = {
+  }: {
+    date: string | Date | number;
+    locale: string | [];
+    options: dateOptions;
+  } = {
     date: new Date(),
     locale: [],
     options: {},

--- a/packages/crayons-core/src/index.ts
+++ b/packages/crayons-core/src/index.ts
@@ -5,4 +5,5 @@ export {
   ProgressLoaderController,
   registerIconLibrary,
   unregisterIconLibrary,
+  DateFormatController,
 } from './global/crayons';


### PR DESCRIPTION
- Adding `format-date` web component to enable date formatting based on locale.
- Exposing a controller `DateFormatController` to call format date as a method.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
