### PR TITLE
feat(fw-input): Added slots and modified styles for fw-input based on DSM

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -404,56 +404,6 @@ export namespace Components {
         /**
           * The date/time to format. If not set, the current date and time will be used.
          */
-        "date": Date | string;
-        /**
-          * The format for displaying the day.
-         */
-        "day": 'numeric' | '2-digit';
-        /**
-          * The format for displaying the hour.
-         */
-        "hour": 'numeric' | '2-digit';
-        /**
-          * When set, 24 hour time will always be used.
-         */
-        "hourFormat": 'auto' | '12' | '24';
-        /**
-          * The locale to use when formatting the date/time.
-         */
-        "locale": string;
-        /**
-          * The format for displaying the minute.
-         */
-        "minute": 'numeric' | '2-digit';
-        /**
-          * The format for displaying the month.
-         */
-        "month": 'numeric' | '2-digit' | 'narrow' | 'short' | 'long';
-        /**
-          * The format for displaying the second.
-         */
-        "second": 'numeric' | '2-digit';
-        /**
-          * The time zone to express the time in.
-         */
-        "timeZone": string;
-        /**
-          * The format for displaying the time.
-         */
-        "timeZoneName": 'short' | 'long';
-        /**
-          * The format for displaying the weekday.
-         */
-        "weekday": 'narrow' | 'short' | 'long';
-        /**
-          * The format for displaying the year.
-         */
-        "year": 'numeric' | '2-digit';
-    }
-    interface FwFormatDate {
-        /**
-          * The date/time to format. If not set, the current date and time will be used.
-         */
         "date": Date | string | number;
         /**
           * The format for displaying the day.
@@ -2496,56 +2446,6 @@ declare namespace LocalJSX {
     | 'TEL'
     | 'TIME'
     | 'RELATIONSHIP';
-    }
-    interface FwFormatDate {
-        /**
-          * The date/time to format. If not set, the current date and time will be used.
-         */
-        "date"?: Date | string;
-        /**
-          * The format for displaying the day.
-         */
-        "day"?: 'numeric' | '2-digit';
-        /**
-          * The format for displaying the hour.
-         */
-        "hour"?: 'numeric' | '2-digit';
-        /**
-          * When set, 24 hour time will always be used.
-         */
-        "hourFormat"?: 'auto' | '12' | '24';
-        /**
-          * The locale to use when formatting the date/time.
-         */
-        "locale"?: string;
-        /**
-          * The format for displaying the minute.
-         */
-        "minute"?: 'numeric' | '2-digit';
-        /**
-          * The format for displaying the month.
-         */
-        "month"?: 'numeric' | '2-digit' | 'narrow' | 'short' | 'long';
-        /**
-          * The format for displaying the second.
-         */
-        "second"?: 'numeric' | '2-digit';
-        /**
-          * The time zone to express the time in.
-         */
-        "timeZone"?: string;
-        /**
-          * The format for displaying the time.
-         */
-        "timeZoneName"?: 'short' | 'long';
-        /**
-          * The format for displaying the weekday.
-         */
-        "weekday"?: 'narrow' | 'short' | 'long';
-        /**
-          * The format for displaying the year.
-         */
-        "year"?: 'numeric' | '2-digit';
     }
     interface FwFormatDate {
         /**

--- a/packages/crayons-core/src/components/input/input.scss
+++ b/packages/crayons-core/src/components/input/input.scss
@@ -1,3 +1,8 @@
+/**
+  @prop --fw-input-label-color: Color of the label.
+  @prop --fw-input-hint-color: Color of the hint.
+*/
+
 $label-font: $font-stack-sans !default;
 $placeholder-color: $muted-secondary;
 $help-color: $muted-secondary;
@@ -43,7 +48,7 @@ $input-color: $app-primary-black;
 // Label Style
 label {
   font-size: 12px;
-  color: $label-default;
+  color: var(--fw-input-label-color, $label-default);
   font-weight: $font-weight-600;
   margin-bottom: 4px;
   padding-left: 2px;
@@ -193,7 +198,7 @@ label {
     line-height: 20px;
     margin-top: 4px;
     margin-bottom: 0;
-    color: $help-color;
+    color: var(--fw-input-hint-color, $help-color);
     position: inherit;
     display: block;
     padding-left: 2px;

--- a/packages/crayons-core/src/components/input/input.scss
+++ b/packages/crayons-core/src/components/input/input.scss
@@ -152,11 +152,12 @@ label {
   //Help Block
   & + .help-block {
     font-family: $label-font;
-    font-size: 11px;
-    margin-top: 3px;
+    font-size: 12px;
+    line-height: 20px;
+    margin-top: 4px;
+    margin-bottom: 0;
     color: $help-color;
     position: inherit;
-    margin-bottom: 0;
     display: block;
     padding-left: 2px;
     -webkit-font-smoothing: antialiased;

--- a/packages/crayons-core/src/components/input/input.scss
+++ b/packages/crayons-core/src/components/input/input.scss
@@ -22,6 +22,10 @@ $input-color: $app-primary-black;
   box-sizing: border-box;
 }
 
+:host {
+  display: block;
+}
+
 @mixin stateStyle($_color) {
   border-color: $_color;
 

--- a/packages/crayons-core/src/components/input/input.scss
+++ b/packages/crayons-core/src/components/input/input.scss
@@ -18,16 +18,15 @@ $input-color: $app-primary-black;
 }
 
 @mixin stateStyle($_color) {
-  & > input {
-    border-color: $_color;
-  }
+  border-color: $_color;
 
-  & > input:focus {
+  &.has-focus {
     box-shadow: none;
     border-color: $_color;
   }
 
-  & > input:hover {
+  &:hover,
+  &:focus {
     border-color: $_color;
   }
 
@@ -65,69 +64,107 @@ label {
 
 // Input Container Style
 .input-container-inner {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   width: 100%;
+  border: 1px solid $input-border;
   position: relative;
+  border-radius: 4px;
 
-  input {
-    width: 100%;
-    border: 0;
-    border: 1px solid $input-border;
-    margin: 0 0;
-    border-radius: 4px;
-    padding: 6px 12px;
-    resize: none;
-    background-color: $app-light-bg;
-    box-shadow: none;
-    min-height: 24px;
-    font-size: 14px;
-    font-weight: $font-weight-semibold;
-    letter-spacing: 0;
-    line-height: 20px;
-    color: $input-color;
-    box-sizing: border-box;
-    cursor: text;
-    display: inline-block;
-    font-family: inherit;
+  &.error {
+    @include stateStyle($error-color);
+  }
 
-    @media (prefers-reduced-motion) {
-      /* stylelint-disable */
-      &:hover {
-        transition: none;
+  &.warning {
+    @include stateStyle($warning-message-marker);
+  }
+
+  .inner-container {
+    display: flex;
+    flex-grow: 1;
+    flex-wrap: wrap;
+
+    .input__label {
+      flex: 1 1 auto;
+      display: flex;
+      align-items: center;
+
+      input {
+        width: 100%;
+        padding: 6px 0px;
+        resize: none;
+        border: none;
+        outline: none;
+        background-color: $app-light-bg;
+        box-shadow: none;
+        min-height: 24px;
+        font-size: 14px;
+        font-weight: $font-weight-semibold;
+        letter-spacing: 0;
+        line-height: 20px;
+        color: $input-color;
+        box-sizing: border-box;
+        cursor: text;
+        display: inline-block;
+        font-family: inherit;
+
+        &[disabled] {
+          font-weight: $font-weight-default;
+          color: $disabled-color;
+          background-color: $input-disabled-bg;
+          pointer-events: none;
+        }
       }
     }
-    &:hover {
-      border: 1px $input-hover-color solid;
-      transition: 0.2s linear;
-    }
 
-    &:focus {
-      outline: none;
-      background: $input-bg;
-      background-color: $app-light-bg;
-      border: 1px solid transparent;
-      box-shadow: 0 0 0 2px $input-focus-color;
-    }
+    .input__prefix {
+      display: flex;
+      align-items: center;
+      margin-left: 8px;
+      margin-right: 4px;
 
-    &[disabled] {
-      font-weight: $font-weight-default;
-      color: $disabled-color;
-      background-color: $input-disabled-bg;
-      border-style: solid;
-      pointer-events: none;
-
-      &:hover,
-      &:focus {
-        border: 1px solid $input-border;
+      &.hasContent {
+        margin-right: 8px;
       }
     }
   }
 
+  .input__suffix {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    margin-right: 8px;
+  }
+
+  @media (prefers-reduced-motion) {
+    /* stylelint-disable */
+    &:hover {
+      transition: none;
+    }
+  }
+  &:hover {
+    border: 1px $input-hover-color solid;
+    transition: 0.2s linear;
+  }
+
+  &.has-focus {
+    outline: none;
+    background: $input-bg;
+    background-color: $app-light-bg;
+    border: 1px solid transparent;
+    box-shadow: 0 0 0 2px $input-focus-color;
+  }
+
+  &.disabled {
+    font-weight: $font-weight-default;
+    color: $disabled-color;
+    background-color: $input-disabled-bg;
+    border-style: solid;
+    pointer-events: none;
+  }
+
   // Clear button
   .clear-button {
-    position: absolute;
-    right: 8px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -163,14 +200,6 @@ label {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
-
-  &.error {
-    @include stateStyle($error-color);
-  }
-
-  &.warning {
-    @include stateStyle($warning-message-marker);
-  }
 }
 
 ::-webkit-input-placeholder {
@@ -191,44 +220,4 @@ label {
 :-moz-placeholder {
   color: $muted-secondary;
   font-weight: $font-weight-default;
-}
-
-.icon {
-  position: absolute;
-  left: 3px;
-  width: 16px;
-  height: 16px;
-  display: flex;
-  justify-content: center;
-  -ms-flex-pack: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-
-  &.left {
-    left: 8px;
-  }
-
-  &.right {
-    left: auto;
-    right: 8px;
-  }
-}
-
-.left-icon {
-  input {
-    padding-left: 32px;
-  }
-}
-
-.right-icon {
-  input {
-    padding-right: 32px;
-  }
-}
-
-.has-value {
-  input {
-    padding-right: 32px;
-  }
 }

--- a/packages/crayons-core/src/components/input/input.scss
+++ b/packages/crayons-core/src/components/input/input.scss
@@ -1,8 +1,3 @@
-/**
-  @prop --input-container-margin-bottom: Bottom margin for the input container
-  @prop --input-margin-bottom: Bottom margin for the input
-  @prop --input-margin-top: Top margin for the input
-**/
 $label-font: $font-stack-sans !default;
 $placeholder-color: $muted-secondary;
 $help-color: $muted-secondary;
@@ -42,7 +37,6 @@ $input-color: $app-primary-black;
 }
 
 .input-container {
-  margin-bottom: var(--input-container-margin-bottom, 0px);
   width: inherit;
   height: inherit;
 }
@@ -52,9 +46,9 @@ label {
   font-size: 12px;
   color: $label-default;
   font-weight: $font-weight-600;
-  margin-bottom: 0;
-  padding-bottom: 4px;
+  margin-bottom: 4px;
   padding-left: 2px;
+  line-height: 20px;
   display: block;
 
   &.required::after {
@@ -71,7 +65,8 @@ label {
 
 // Input Container Style
 .input-container-inner {
-  display: block;
+  display: flex;
+  align-items: center;
   width: 100%;
   position: relative;
 
@@ -80,15 +75,13 @@ label {
     border: 0;
     border: 1px solid $input-border;
     margin: 0 0;
-    margin-top: var(--input-margin-top, 5px);
-    margin-bottom: var(--input-margin-bottom, 0px);
     border-radius: 4px;
-    padding: 4px 12px 5px;
+    padding: 6px 12px;
     resize: none;
     background-color: $app-light-bg;
     box-shadow: none;
     min-height: 24px;
-    font-size: 12px;
+    font-size: 14px;
     font-weight: $font-weight-semibold;
     letter-spacing: 0;
     line-height: 20px;
@@ -118,6 +111,7 @@ label {
     }
 
     &[disabled] {
+      font-weight: $font-weight-default;
       color: $disabled-color;
       background-color: $input-disabled-bg;
       border-style: solid;
@@ -132,7 +126,6 @@ label {
 
   // Clear button
   .clear-button {
-    top: 12px;
     position: absolute;
     right: 8px;
     display: flex;
@@ -181,23 +174,26 @@ label {
 
 ::-webkit-input-placeholder {
   color: $muted-secondary;
+  font-weight: $font-weight-default;
 }
 
 ::-moz-placeholder {
   color: $muted-secondary;
+  font-weight: $font-weight-default;
 }
 
 :-ms-input-placeholder {
   color: $muted-secondary;
+  font-weight: $font-weight-default;
 }
 
 :-moz-placeholder {
   color: $muted-secondary;
+  font-weight: $font-weight-default;
 }
 
 .icon {
   position: absolute;
-  top: 12px;
   left: 3px;
   width: 16px;
   height: 16px;

--- a/packages/crayons-core/src/components/input/input.tsx
+++ b/packages/crayons-core/src/components/input/input.tsx
@@ -297,6 +297,7 @@ export class Input {
                 <fw-icon
                   class='clear-img'
                   name='cross'
+                  size={8}
                   library='system'
                 ></fw-icon>
               </div>

--- a/packages/crayons-core/src/components/input/input.tsx
+++ b/packages/crayons-core/src/components/input/input.tsx
@@ -232,7 +232,7 @@ export class Input {
         }}
       >
         <div class='input-container'>
-          {this.label !== '' ? (
+          {this.label !== '' && (
             <label
               class={{
                 required: this.required,
@@ -240,8 +240,6 @@ export class Input {
             >
               {this.label}
             </label>
-          ) : (
-            ''
           )}
           <div
             class={{
@@ -276,17 +274,13 @@ export class Input {
               aria-invalid={this.state === 'error'}
               aria-describedby={`hint-${this.name} error-${this.name}`}
             />
-            {this.iconLeft !== undefined ? (
+            {this.iconLeft !== undefined && (
               <fw-icon class='icon left' name={this.iconLeft}></fw-icon>
-            ) : (
-              ''
             )}
-            {this.iconRight !== undefined ? (
+            {this.iconRight !== undefined && (
               <fw-icon class='icon right' name={this.iconRight}></fw-icon>
-            ) : (
-              ''
             )}
-            {this.showClearButton() ? (
+            {this.showClearButton() && (
               <div
                 class='clear-button'
                 role='button'
@@ -301,16 +295,12 @@ export class Input {
                   library='system'
                 ></fw-icon>
               </div>
-            ) : (
-              ''
             )}
           </div>
-          {this.stateText !== '' ? (
+          {this.stateText !== '' && (
             <span class='help-block' id={`hint-${this.name}`}>
               {this.stateText}
             </span>
-          ) : (
-            ''
           )}
         </div>
       </Host>

--- a/packages/crayons-core/src/components/input/input.tsx
+++ b/packages/crayons-core/src/components/input/input.tsx
@@ -24,6 +24,7 @@ export class Input {
   private nativeInput?: HTMLInputElement;
 
   @State() hasFocus = false;
+  @State() hasPrefix = false;
   /**
    * Label displayed on the interface, for the component.
    */
@@ -218,6 +219,35 @@ export class Input {
     }
   }
 
+  renderClearButton() {
+    return (
+      <div
+        class='clear-button'
+        role='button'
+        tabindex='0'
+        onClick={(e) => this.clearTextInput(e)}
+        onKeyDown={handleKeyDown(this.clearTextInput)}
+      >
+        <fw-icon
+          class='clear-img'
+          name='cross'
+          size={8}
+          library='system'
+        ></fw-icon>
+      </div>
+    );
+  }
+
+  renderIcon(iconName) {
+    return <fw-icon name={iconName}></fw-icon>;
+  }
+
+  componentWillLoad() {
+    console.log(this.host.querySelector('[slot="input-prefix"]'));
+    this.hasPrefix =
+      !!this.host.querySelector('[slot="input-prefix"]') || !!this.iconLeft;
+  }
+
   render() {
     const { host, name, value } = this;
 
@@ -231,7 +261,11 @@ export class Input {
           'has-focus': this.hasFocus,
         }}
       >
-        <div class='input-container'>
+        <div
+          class={{
+            'input-container': true,
+          }}
+        >
           {this.label !== '' && (
             <label
               class={{
@@ -244,58 +278,48 @@ export class Input {
           <div
             class={{
               'input-container-inner': true,
+              'has-focus': this.hasFocus,
+              'disabled': this.disabled,
               [this.state]: true,
-              'left-icon': this.iconLeft !== undefined,
-              'right-icon': this.iconRight !== undefined,
-              'has-value': this.showClearButton(),
             }}
           >
-            <input
-              ref={(input) => {
-                this.nativeInput = input;
-              }}
-              id={this.name}
-              autoComplete={this.autocomplete}
-              disabled={this.disabled}
-              name={this.name}
-              placeholder={this.placeholder || ''}
-              minLength={this.minlength}
-              maxLength={this.maxlength}
-              min={this.min}
-              max={this.max}
-              readOnly={this.readonly}
-              required={this.required}
-              step={this.step}
-              type={this.type}
-              value={this.value}
-              onInput={this.onInput}
-              onBlur={this.onBlur}
-              onFocus={this.onFocus}
-              aria-invalid={this.state === 'error'}
-              aria-describedby={`hint-${this.name} error-${this.name}`}
-            />
-            {this.iconLeft !== undefined && (
-              <fw-icon class='icon left' name={this.iconLeft}></fw-icon>
-            )}
-            {this.iconRight !== undefined && (
-              <fw-icon class='icon right' name={this.iconRight}></fw-icon>
-            )}
-            {this.showClearButton() && (
-              <div
-                class='clear-button'
-                role='button'
-                tabindex='0'
-                onClick={(e) => this.clearTextInput(e)}
-                onKeyDown={handleKeyDown(this.clearTextInput)}
-              >
-                <fw-icon
-                  class='clear-img'
-                  name='cross'
-                  size={8}
-                  library='system'
-                ></fw-icon>
+            <div class='inner-container'>
+              <div class={{ input__prefix: true, hasContent: this.hasPrefix }}>
+                {this.iconLeft && this.renderIcon(this.iconLeft)}
+                <slot name='input-prefix' />
               </div>
-            )}
+              <div class='input__label'>
+                <input
+                  ref={(input) => {
+                    this.nativeInput = input;
+                  }}
+                  id={this.name}
+                  autoComplete={this.autocomplete}
+                  disabled={this.disabled}
+                  name={this.name}
+                  placeholder={this.placeholder || ''}
+                  minLength={this.minlength}
+                  maxLength={this.maxlength}
+                  min={this.min}
+                  max={this.max}
+                  readOnly={this.readonly}
+                  required={this.required}
+                  step={this.step}
+                  type={this.type}
+                  value={this.value}
+                  onInput={this.onInput}
+                  onBlur={this.onBlur}
+                  onFocus={this.onFocus}
+                  aria-invalid={this.state === 'error'}
+                  aria-describedby={`hint-${this.name} error-${this.name}`}
+                />
+                {this.showClearButton() && this.renderClearButton()}
+              </div>
+            </div>
+            <div class='input__suffix'>
+              {this.iconRight && this.renderIcon(this.iconRight)}
+              <slot name='input-suffix' />
+            </div>
           </div>
           {this.stateText !== '' && (
             <span class='help-block' id={`hint-${this.name}`}>

--- a/packages/crayons-core/src/components/input/readme.md
+++ b/packages/crayons-core/src/components/input/readme.md
@@ -1,5 +1,6 @@
 # Input (fw-input)
-fw-input displays a single-line input box on the user interface and enables assigning a value to it. 
+
+fw-input displays a single-line input box on the user interface and enables assigning a value to it.
 
 ## Demo
 
@@ -13,40 +14,48 @@ You can use Input component for handling `Text`, `Number`, `Decimal` user input.
   state="warning"
   placeholder="Enter your official name"
   required
-  clear-input>
+  clear-input
+>
 </fw-input>
 <fw-input
   label="Password"
   state-text="Password is incorrect"
   state="error"
   required
-  clear-input>
+  clear-input
+>
 </fw-input>
 <fw-input
   label="Verification Code"
-placeholder="Enter the verification code sent to the registered email address"
+  placeholder="Enter the verification code sent to the registered email address"
   state="normal"
-  clear-input>
+  clear-input
+>
 </fw-input>
-<fw-input
-  label="Deprecated Field"
-  disabled
-  state="normal"
-  clear-input>
+<fw-input label="Deprecated Field" disabled state="normal" clear-input>
 </fw-input>
 <fw-input
   label="Do Not Modify"
   value="Not applicable"
   readonly
   state="normal"
-  clear-input>
+  clear-input
+>
 </fw-input>
 <fw-input value="123" type="number" label="Number Input"></fw-input>
-<fw-input type="number" min="0" max="10" label="Number Input with min and max"></fw-input>
-<fw-input value="3.001" type="number" step="0.1" max="5"
-label="Decimal Input with step and max"
+<fw-input
+  type="number"
+  min="0"
+  max="10"
+  label="Number Input with min and max"
 ></fw-input>
-
+<fw-input
+  value="3.001"
+  type="number"
+  step="0.1"
+  max="5"
+  label="Decimal Input with step and max"
+></fw-input>
 ```
 
 ## Usage
@@ -149,6 +158,61 @@ function App() {
 </code-block>
 </code-group>
 
+### Slots
+
+Slots can be used to create complex use cases.
+
+```html live
+<template>
+  <div>
+    <fw-input value="Searching..." icon-left="search" clear-input>
+      <fw-spinner slot="input-suffix" size="small"></fw-spinner>
+    </fw-input>
+
+    <fw-input placeholder="DD/MM/YYYY">
+      <div slot="input-suffix" class="calenderContainer">
+        <span class="separator"></span>
+        <fw-icon name="calendar" size="16"></fw-icon>
+      </div>
+    </fw-input>
+    <fw-input placeholder="Type to search">
+      <div slot="input-prefix" class="tagContainer">
+        <fw-tag text="Option 1"></fw-tag>
+        <fw-tag text="Option 2"></fw-tag>
+      </div>
+      <fw-icon slot="input-suffix" name="chevron-down" size="8"></fw-icon>
+    </fw-input>
+  </div>
+</template>
+<style>
+  fw-input {
+    margin: 12px;
+  }
+
+  .calenderContainer {
+    display: flex;
+    align-items: center;
+  }
+
+  .separator {
+    background-color: #cfd7df;
+    width: 1px;
+    height: 20px;
+    margin-right: 4px;
+  }
+
+  .tagContainer {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    margin: 4px;
+  }
+
+  fw-tag {
+    margin: 0 4px;
+  }
+</style>
+```
 
 <!-- Auto Generated Below -->
 

--- a/packages/crayons-core/src/components/input/readme.md
+++ b/packages/crayons-core/src/components/input/readme.md
@@ -203,15 +203,6 @@ Type: `Promise<void>`
 
 
 
-## CSS Custom Properties
-
-| Name                              | Description                           |
-| --------------------------------- | ------------------------------------- |
-| `--input-container-margin-bottom` | Bottom margin for the input container |
-| `--input-margin-bottom`           | Bottom margin for the input           |
-| `--input-margin-top`              | Top margin for the input              |
-
-
 ## Dependencies
 
 ### Used by

--- a/packages/crayons-core/src/components/input/readme.md
+++ b/packages/crayons-core/src/components/input/readme.md
@@ -267,6 +267,14 @@ Type: `Promise<void>`
 
 
 
+## CSS Custom Properties
+
+| Name                     | Description         |
+| ------------------------ | ------------------- |
+| `--fw-input-hint-color`  | Color of the hint.  |
+| `--fw-input-label-color` | Color of the label. |
+
+
 ## Dependencies
 
 ### Used by

--- a/styles/_theme.scss
+++ b/styles/_theme.scss
@@ -608,7 +608,7 @@ $symbol-today: #239cff;
 $symbol-yesterday: #dadfe3;
 
 $input-bottom-border: #eaf0ef;
-$input-disabled-bg: #f5f7f9;
+$input-disabled-bg: #f7f9fa;
 $input-disabled-color: #92a2b1;
 
 $amber-color: #ffad1e;


### PR DESCRIPTION
- changed the disabled background-color to #f7f9fa 
- removed the bottom spacing on the input and increase the font-size to 14px
- reduced the size of the close icon to 8px
- changed the font-weight for the disabled state and placeholder
- exposed css variables to change the normal state font color of label and hint
- modified fw-input as a block element so that consuming component can add their margin or padding
- Added slots to create custom input as shown below

<img width="621" alt="Screenshot 2022-02-04 at 4 52 19 PM" src="https://user-images.githubusercontent.com/64781864/152524201-6b9e438e-e048-49ca-b013-2b2de5720a34.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
