### PR TITLE
fix(fw-input): handle number,decimal input usecase

### DIFF
--- a/packages/crayons-core/src/components/input/input.e2e.ts
+++ b/packages/crayons-core/src/components/input/input.e2e.ts
@@ -147,10 +147,13 @@ describe('fw-input', () => {
       '<fw-input value="1" type="number" max="5"> </fw-input>'
     );
     const fwChange = await page.spyOnEvent('fwChange');
-    const element = await page.find('fw-input');
+    const element = await page.find('fw-input >>> input');
 
-    await element.click();
-    element.setProperty('value', 5);
+    await element.press('ArrowUp');
+    await element.press('ArrowUp');
+    await element.press('ArrowUp');
+    await element.press('ArrowUp');
+    await element.press('ArrowUp');
 
     await page.waitForChanges();
 

--- a/packages/crayons-core/src/components/input/input.e2e.ts
+++ b/packages/crayons-core/src/components/input/input.e2e.ts
@@ -150,7 +150,7 @@ describe('fw-input', () => {
     const element = await page.find('fw-input');
 
     await element.click();
-    await element.press('5');
+    element.setProperty('value', 5);
 
     await page.waitForChanges();
 

--- a/packages/crayons-core/src/components/input/input.e2e.ts
+++ b/packages/crayons-core/src/components/input/input.e2e.ts
@@ -150,7 +150,7 @@ describe('fw-input', () => {
     const element = await page.find('fw-input');
 
     await element.click();
-    await element.press('7');
+    await element.press('5');
 
     await page.waitForChanges();
 

--- a/packages/crayons-core/src/components/input/input.tsx
+++ b/packages/crayons-core/src/components/input/input.tsx
@@ -143,12 +143,7 @@ export class Input {
 
   private onInput = (ev: Event) => {
     const input = ev.target as HTMLInputElement | null;
-    // handle number and decimal input type
-    if (this.type === 'number') {
-      this.value = this.handleMinAndMaxCheck(input.value);
-    } else {
-      this.value = input.value || '';
-    }
+    this.value = input.value || '';
     if (this.nativeInput) {
       this.nativeInput.value = this.value;
     }
@@ -159,11 +154,6 @@ export class Input {
         value: this.nativeInput.value,
       });
   };
-  private handleMinAndMaxCheck(value) {
-    const { min = -Infinity, max = Infinity } = this;
-    value = Math.max(Number(min), Math.min(Number(max), Number(value)));
-    return value;
-  }
 
   private onFocus = () => {
     this.hasFocus = true;


### PR DESCRIPTION
Make `fw-input` work similar to native `input` element for `decimal` and `number` usecases

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
