### PR TITLE
fix(data-table): row hover cursor fix

### DIFF
--- a/packages/crayons-core/src/components/data-table/data-table.scss
+++ b/packages/crayons-core/src/components/data-table/data-table.scss
@@ -88,7 +88,6 @@ div.fw-data-table-container {
         &:hover,
         &:focus {
           background: $grid-header-bg;
-          cursor: pointer;
         }
 
         &.active {


### PR DESCRIPTION
When hovering over a row in table, cursor should not be pointer. 

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested with examples in Vuepress documentation site.
