### PR TITLE
fix(fw-pagination): end value not updated on total prop change

### DIFF
--- a/packages/crayons-core/src/components/pagination/pagination.tsx
+++ b/packages/crayons-core/src/components/pagination/pagination.tsx
@@ -86,6 +86,11 @@ export class Pagination {
     this.end = this.getEndRecord();
   }
 
+  @Watch('total')
+  handleTotal() {
+    this.end = this.getEndRecord();
+  }
+
   componentWillLoad() {
     this.page = Math.min(this.page, this.getLastPage());
     this.start = this.getStartRecord();


### PR DESCRIPTION
## Description:

The end value was not updated properly for the change in the total prop. This happens during the search scenario where the total is dynamically updated.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
