### PR TITLE
fix(fw-drag-container): fixed the drag issue in safari 

### DIFF
--- a/packages/crayons-core/src/components/drag-container/drag-container.scss
+++ b/packages/crayons-core/src/components/drag-container/drag-container.scss
@@ -1,0 +1,3 @@
+.drag-container {
+  display: block;
+}

--- a/packages/crayons-core/src/components/drag-container/drag-container.tsx
+++ b/packages/crayons-core/src/components/drag-container/drag-container.tsx
@@ -11,6 +11,7 @@ import { Draggable } from '../../utils/draggable';
 
 @Component({
   tag: 'fw-drag-container',
+  styleUrl: 'drag-container.scss',
 })
 export class DragContainer {
   @Element() host: HTMLElement;
@@ -63,6 +64,6 @@ export class DragContainer {
   }
 
   render() {
-    return <Host></Host>;
+    return <Host class='drag-container'></Host>;
   }
 }

--- a/packages/crayons-core/src/components/drag-container/readme.md
+++ b/packages/crayons-core/src/components/drag-container/readme.md
@@ -8,200 +8,144 @@ fw-drag-container is a custom component with an open shadow that acts as a wrapp
 
 ```html live
 <template>
-  <fw-drag-container>
-    <div
-      draggable="true"
-      class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-    >
-      <div class="fw-flex-grow fw-type-h5">Booking ID</div>
-      <fw-icon class="fw-flex-grow-0" name="drag"></fw-icon>
-    </div>
-    <div
-      draggable="false"
-      class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-    >
-      <div class="fw-flex-grow fw-type-h5">Customer Name</div>
-      <fw-icon class="fw-flex-grow-0" name="lock"></fw-icon>
-    </div>
-    <div
-      draggable="false"
-      class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-    >
-      <div class="fw-flex-grow fw-type-h5">Hotel</div>
-      <fw-icon class="fw-flex-grow-0" name="lock"></fw-icon>
-    </div>
-    <div
-      draggable="true"
-      class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-    >
-      <div class="fw-flex-grow fw-type-h5">Number of Rooms</div>
-      <fw-icon class="fw-flex-grow-0" name="drag"></fw-icon>
-    </div>
-    <div
-      draggable="true"
-      class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-    >
-      <div class="fw-flex-grow fw-type-h5">ID Number</div>
-      <fw-icon class="fw-flex-grow-0" name="drag"></fw-icon>
-    </div>
-    <div
-      draggable="true"
-      class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-    >
-      <div class="fw-flex-grow fw-type-h5">Payment Type</div>
-      <fw-icon class="fw-flex-grow-0" name="drag"></fw-icon>
-    </div>
-    <div
-      draggable="true"
-      class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-    >
-      <div class="fw-flex-grow fw-type-h5">Room Preference</div>
-      <fw-icon class="fw-flex-grow-0" name="drag"></fw-icon>
-    </div>
-    <div
-      draggable="true"
-      class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-    >
-      <div class="fw-flex-grow fw-type-h5">Check</div>
-      <fw-icon class="fw-flex-grow-0" name="drag"></fw-icon>
-    </div>
-  </fw-drag-container>
+  <div>
+    <fw-label value="Sort items within a container"></fw-label>
+    <fw-drag-container class="drag-container" id="defaultSort">
+      <fw-drag-item>Item 1</fw-drag-item>
+      <fw-drag-item>Item 2</fw-drag-item>
+      <fw-drag-item>Item 3</fw-drag-item>
+      <fw-drag-item
+        >Item 4 <fw-icon slot="suffix" name="bulb"></fw-icon>
+      </fw-drag-item>
+    </fw-drag-container>
+    <br />
+    <fw-label value="Pinned items within a container"></fw-label>
+    <fw-drag-container class="drag-container" id="pinnedSort">
+      <fw-drag-item pinned="top">Item 1</fw-drag-item>
+      <fw-drag-item>Item 2</fw-drag-item>
+      <fw-drag-item>Item 3</fw-drag-item>
+      <fw-drag-item>Item 4</fw-drag-item>
+      <fw-drag-item pinned="bottom">Item 5</fw-drag-item>
+    </fw-drag-container>
+  </div>
 </template>
+<style>
+  .drag-container {
+    width: 300px;
+    padding: 20px;
+    border: 1px solid black;
+  }
+  fw-drag-item {
+    margin-bottom: 8px;
+  }
+</style>
 ```
 
-Demo for dragging items from one container to another container
+Demo for dragging items from one container to another container.
 
 ```html live
-<span>Retain the original drag element on drop</span>
 <template>
-  <div class="fw-flex flex-container-border fw-justify-around">
-    <fw-drag-container
-      id="source-field-copy"
-      sortable="false"
-      class="fw-b-1 fw-b-solid"
-    >
-      <div
-        draggable="true"
-        class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-      >
-        <div class="fw-flex-grow fw-type-h5">Input field</div>
-        <fw-icon class="fw-flex-grow-0" name="drag"></fw-icon>
-      </div>
-      <div
-        draggable="true"
-        class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-      >
-        <div class="fw-flex-grow fw-type-h5">Select field</div>
-        <fw-icon class="fw-flex-grow-0" name="drag"></fw-icon>
-      </div>
-      <div
-        draggable=""
-        class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-      >
-        <div class="fw-flex-grow fw-type-h5">Decimal field</div>
-        <fw-icon class="fw-flex-grow-0" name="drag"></fw-icon>
-      </div>
-      <div
-        draggable="true"
-        class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-      >
-        <div class="fw-flex-grow fw-type-h5">Date & Time field</div>
-        <fw-icon class="fw-flex-grow-0" name="drag"></fw-icon>
-      </div>
-      <div
-        draggable="true"
-        class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-      >
-        <div class="fw-flex-grow fw-type-h5">Button</div>
-        <fw-icon class="fw-flex-grow-0" name="drag"></fw-icon>
-      </div>
-    </fw-drag-container>
+  <div>
+    <fw-label value="Copying items from on container to another"></fw-label>
+    <fw-label
+      value="Item 1-5 are allows to be sorted with Item 6-9 but not the other way around."
+    ></fw-label>
+    <div class="container">
+      <fw-drag-container class="drag-container" sortable="false" id="from">
+        <fw-drag-item>Item 1</fw-drag-item>
+        <fw-drag-item>Item 2</fw-drag-item>
+        <fw-drag-item>Item 3</fw-drag-item>
+        <fw-drag-item>Item 4</fw-drag-item>
+        <fw-drag-item>Item 5</fw-drag-item>
+      </fw-drag-container>
 
-    <fw-drag-container
-      accept-from="source-field-copy"
-      add-on-drop="true"
-      class="fw-b-1 fw-b-solid fw-b-casablanca-100"
-    >
-      <div
-        draggable="true"
-        class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
+      <fw-drag-container
+        class="drag-container"
+        id="to"
+        accept-from="from"
+        placeholder-class="placeholder"
       >
-        <div class="fw-flex-grow fw-type-h5">Input field</div>
-        <fw-icon class="fw-flex-grow-0" name="drag"></fw-icon>
-      </div>
-    </fw-drag-container>
+        <fw-drag-item>Item 6</fw-drag-item>
+        <fw-drag-item>Item 7</fw-drag-item>
+        <fw-drag-item>Item 8</fw-drag-item>
+        <fw-drag-item>Item 9</fw-drag-item>
+      </fw-drag-container>
+    </div>
+    <fw-label value="Moving items from on container to another"></fw-label>
+    <fw-label
+      value="Item 1-5 are allows to be sorted with Item 6-9 but not the other way around."
+    ></fw-label>
+    <div class="container">
+      <fw-drag-container class="drag-container" sortable="false" id="moveFrom">
+        <fw-drag-item>Item 1</fw-drag-item>
+        <fw-drag-item>Item 2</fw-drag-item>
+        <fw-drag-item>Item 3</fw-drag-item>
+        <fw-drag-item>Item 4</fw-drag-item>
+        <fw-drag-item>Item 5</fw-drag-item>
+      </fw-drag-container>
+
+      <fw-drag-container
+        class="drag-container"
+        id="moveTo"
+        accept-from="moveFrom"
+        placeholder-class="placeholder"
+        copy="false"
+      >
+        <fw-drag-item>Item 6</fw-drag-item>
+        <fw-drag-item>Item 7</fw-drag-item>
+        <fw-drag-item>Item 8</fw-drag-item>
+        <fw-drag-item>Item 9</fw-drag-item>
+      </fw-drag-container>
+    </div>
   </div>
 </template>
+<style>
+  .container {
+    width: 400px;
+    padding: 20px;
+    border: 1px solid black;
+    display: flex;
+    justify-content: space-between;
+  }
+  .drag-container {
+    width: 150px;
+    padding: 20px;
+    border: 1px solid black;
+  }
+  fw-drag-item {
+    margin-bottom: 8px;
+  }
+  .placeholder {
+    width: 150px;
+    background-color: blueviolet;
+    height: 5px;
+  }
+</style>
+```
 
-<span>Remove the drag element on drop</span>
+`fwDrop` event will be emitted during a successful drop event, and can be used to detect the dropped item.
 
-<template>
-  <div class="fw-flex flex-container-border fw-justify-around">
-    <fw-drag-container
-      id="source-field-move"
-      sortable="false"
-      class="fw-b-1 fw-b-solid"
-    >
-      <div
-        draggable="true"
-        class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-      >
-        <div class="fw-flex-grow fw-type-h5">Input field</div>
-        <fw-icon class="fw-flex-grow-0" name="drag"></fw-icon>
-      </div>
-      <div
-        draggable=""
-        class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-      >
-        <div class="fw-flex-grow fw-type-h5">Select field</div>
-        <fw-icon class="fw-flex-grow-0" name="drag"></fw-icon>
-      </div>
-      <div
-        draggable=""
-        class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-      >
-        <div class="fw-flex-grow fw-type-h5">Decimal field</div>
-        <fw-icon class="fw-flex-grow-0" name="drag"></fw-icon>
-      </div>
-      <div
-        draggable="true"
-        class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-      >
-        <div class="fw-flex-grow fw-type-h5">Date & Time field</div>
-        <fw-icon class="fw-flex-grow-0" name="drag"></fw-icon>
-      </div>
-      <div
-        draggable="true"
-        class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-      >
-        <div class="fw-flex-grow fw-type-h5">Button</div>
-        <fw-icon class="fw-flex-grow-0" name="drag"></fw-icon>
-      </div>
-    </fw-drag-container>
-
-    <fw-drag-container
-      id="drop-move"
-      accept-from="source-field-move"
-      add-on-drop="true"
-      copy="false"
-      class="fw-b-1 fw-b-solid fw-b-casablanca-100"
-    >
-      <div
-        draggable="true"
-        class="fw-card-1 fw-p-24 fw-flex fw-flex-row fw-content-center"
-      >
-        <div class="fw-flex-grow fw-type-h5">Input field</div>
-        <fw-icon class="fw-flex-grow-0" name="drag"></fw-icon>
-      </div>
-    </fw-drag-container>
-  </div>
-</template>
+```html live
+<fw-drag-container id="drop">
+  <fw-drag-item>Item 1</fw-drag-item>
+  <fw-drag-item>Item 2</fw-drag-item>
+  <fw-drag-item>Item 3</fw-drag-item>
+  <fw-drag-item>Item 4</fw-drag-item>
+  <fw-drag-item>Item 5</fw-drag-item>
+</fw-drag-container>
 <script type="application/javascript">
-  var drop = document.getElementById('drop-move');
+  var drop = document.getElementById('drop');
   drop.addEventListener('fwDrop', (e) => {
     console.log(e.detail);
   });
 </script>
+```
+
+```javascript
+var drop = document.getElementById('drop');
+drop.addEventListener('fwDrop', (e) => {
+  console.log(e.detail);
+});
 ```
 
 <!-- Auto Generated Below -->

--- a/packages/crayons-core/src/components/drag-item/drag-item.scss
+++ b/packages/crayons-core/src/components/drag-item/drag-item.scss
@@ -1,3 +1,7 @@
+:host {
+  display: block;
+}
+
 .drag-item {
   display: flex;
   background: #ffffff;

--- a/packages/crayons-core/src/components/drag-item/drag-item.scss
+++ b/packages/crayons-core/src/components/drag-item/drag-item.scss
@@ -31,9 +31,11 @@
   .drag-icon {
     padding-right: 12px;
 
-    &:hover,
-    &:focus {
-      cursor: grab;
+    &.drag {
+      &:hover,
+      &:focus {
+        cursor: grab;
+      }
     }
   }
 }

--- a/packages/crayons-core/src/components/drag-item/drag-item.scss
+++ b/packages/crayons-core/src/components/drag-item/drag-item.scss
@@ -6,19 +6,19 @@
   border-radius: 4px;
   padding: 8px 12px;
   align-items: center;
-  margin-bottom: 10px;
+  margin: 8px 0px;
 
-  &#{&}__label {
+  .drag-item__label {
     flex: 1 1 auto;
   }
 
-  &#{&}__prefix {
+  .drag-item__prefix {
     flex: 0 0 auto;
     display: flex;
     align-items: center;
   }
 
-  &#{&}__suffix {
+  .drag-item__suffix {
     flex: 0 0 auto;
     display: flex;
     align-items: center;

--- a/packages/crayons-core/src/components/drag-item/drag-item.tsx
+++ b/packages/crayons-core/src/components/drag-item/drag-item.tsx
@@ -55,11 +55,11 @@ export class DragItem {
           }}
           draggable={this.draggable}
         >
-          {this.showDragIcon && !this.pinned && (
+          {this.showDragIcon && (
             <span class='drag-item__prefix'>
               <fw-icon
-                class='drag-icon'
-                name='drag'
+                class={{ 'drag-icon': true, 'drag': !this.pinned }}
+                name={!this.pinned ? 'drag' : 'lock'}
                 ref={(dragIcon) => (this.dragIcon = dragIcon)}
               ></fw-icon>
             </span>

--- a/packages/crayons-core/src/utils/draggable.ts
+++ b/packages/crayons-core/src/utils/draggable.ts
@@ -31,10 +31,7 @@ export class Draggable {
 
       let newElement;
       // dragging inside the same container, so no need to add placeholder
-      if (
-        draggingElement.parentElement.id === this.dragContainer.id ||
-        !this.options.copy
-      ) {
+      if (draggingElement.parentElement.id === this.dragContainer.id) {
         newElement = draggingElement;
       } else {
         this.placeholder ||= this.createPlaceholder(draggingElement);
@@ -116,13 +113,10 @@ export class Draggable {
   // Both dragend and drop need to used as the drop will be fired only on the container on which the drag is dropped
   // and no on the container where drag is originated.
   private onDragEnd = (e) => {
-    if (!this.dropped) {
+    if (!this.dropped || placeholders.length > 0) {
       // The drag element is dropped outside the drag container
       this.addElement(dragElement, this.nextSibling);
-      placeholders.forEach((placeholder) => {
-        placeholder.remove();
-      });
-      placeholders = [];
+      this.removePlaceholder();
     }
     this.resetData(e);
   };
@@ -137,7 +131,9 @@ export class Draggable {
     const droppedIndex = [...this.dragContainer.children].indexOf(newElement);
     if (this.placeholder) {
       if (this.options.addOnDrop) {
-        const clone = cloneNodeWithEvents(dragElement, true, true);
+        const clone = this.options.copy
+          ? cloneNodeWithEvents(dragElement, true, true)
+          : dragElement;
         this.placeholder.replaceWith(clone);
       } else {
         this.removePlaceholder();
@@ -217,10 +213,11 @@ export class Draggable {
     return placeholder;
   }
 
-  removePlaceholder(element?) {
-    const removeElement = element || this.placeholder;
-    this.dragContainer.contains(removeElement) &&
-      this.dragContainer.removeChild(removeElement);
+  removePlaceholder() {
+    placeholders.forEach((placeholder) => {
+      placeholder.remove();
+    });
+    placeholders = [];
   }
 
   addElement(newElement, nextElement) {


### PR DESCRIPTION
## CHANGES
- Fixed the drag and drop not working properly in safari browser
- Converted fw-drag-container and fw-drag-item to a block element
- Added placeholder when the copy prop is set false
- Fixed the CSS issue in fw-drag-item
- Added lock icon to pinned fw-drag-item

## Root Cause & Solution
In dragLeave event the fromElement and relatedTarget value is null in safari, this triggers the
dragContainer's leave logic thus removing the placeholder/drag element. To fix this  the logic to
remove the placeholder / drag element is moved from dragLeave event to dragEnd event.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
