### PR TITLE
fix(fw-select): fixed the padding issue on multi-select

### DIFF
--- a/packages/crayons-core/src/components/select/select.scss
+++ b/packages/crayons-core/src/components/select/select.scss
@@ -69,7 +69,7 @@ label {
       flex-wrap: wrap;
 
       fw-tag {
-        margin: 4px;
+        margin: 4px 4px 4px 0px;
       }
     }
 

--- a/packages/crayons-core/src/components/select/select.scss
+++ b/packages/crayons-core/src/components/select/select.scss
@@ -52,7 +52,7 @@ label {
   width: calc(100% - 10px);
   border: var(--select-border, 1px solid $input-border);
   border-radius: var(--select-border-radius, 4px);
-  padding: 4px 0 4px 10px;
+  padding-left: 10px;
   background-color: $input-bg;
   box-shadow: none;
   min-height: 22px;
@@ -64,8 +64,13 @@ label {
     flex-grow: 1;
     flex-wrap: wrap;
 
-    fw-tag {
-      margin-right: 4px;
+    .tag-container {
+      display: flex;
+      flex-wrap: wrap;
+
+      fw-tag {
+        margin: 4px;
+      }
     }
 
     input {
@@ -80,7 +85,7 @@ label {
       min-height: 22px;
       box-sizing: border-box;
       overflow: hidden;
-      padding: 0px;
+      margin: 4px 0px;
 
       &:focus {
         border: none;

--- a/packages/crayons-core/src/components/select/select.tsx
+++ b/packages/crayons-core/src/components/select/select.tsx
@@ -607,6 +607,7 @@ export class Select {
                   <div class='input-container-inner'>
                     {this.multiple && (
                       <div
+                        class='tag-container'
                         onFocus={this.focusOnTagContainer}
                         ref={(tagContainer) =>
                           (this.tagContainer = tagContainer)


### PR DESCRIPTION
## Description:

Fix the tag padding issue in case of multi-select.
<img width="447" alt="Screenshot 2022-02-09 at 11 40 33 AM" src="https://user-images.githubusercontent.com/64781864/153132558-1e295b0e-3b68-4ba7-82ef-0f4fdffcfe5d.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
