### PR TITLE
fix(modal): reduce line height of description in modal to support multiline.

### DIFF
--- a/packages/crayons-core/src/components/modal-title/modal-title.scss
+++ b/packages/crayons-core/src/components/modal-title/modal-title.scss
@@ -52,7 +52,8 @@
         font-size: $font-size-14;
         font-weight: $font-weight-default;
         color: $color-smoke-700;
-        line-height: 32px;
+        line-height: 20px;
+        padding: 6px 0px;
       }
     }
   }


### PR DESCRIPTION
Fix modal description line height issue.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested with sample in Vuepress docs.
