### PR TITLE
feat(data-table): adding style to the loading state of table

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -190,7 +190,7 @@ export namespace Components {
           * @param state to load table or not
           * @returns isLoading current state
          */
-        "loadTable": (state: boolean) => Promise<boolean>;
+        "loadTable": (state?: boolean) => Promise<boolean>;
         /**
           * To enable bulk actions on the table.
          */

--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -210,9 +210,17 @@ export namespace Components {
          */
         "setTableSettings": (columnConfig: any) => Promise<DataTableColumn[]>;
         /**
+          * shimmerCount number of shimmer rows to show during initial loading
+         */
+        "shimmerCount": number;
+        /**
           * showSettings is used to show the settings button on the table.
          */
         "showSettings": boolean;
+        /**
+          * showShimmer show shimmer on loading
+         */
+        "showShimmer": boolean;
     }
     interface FwDatepicker {
         /**
@@ -2258,9 +2266,17 @@ declare namespace LocalJSX {
          */
         "rows"?: DataTableRow[];
         /**
+          * shimmerCount number of shimmer rows to show during initial loading
+         */
+        "shimmerCount"?: number;
+        /**
           * showSettings is used to show the settings button on the table.
          */
         "showSettings"?: boolean;
+        /**
+          * showShimmer show shimmer on loading
+         */
+        "showShimmer"?: boolean;
     }
     interface FwDatepicker {
         /**

--- a/packages/crayons-core/src/components/data-table/data-table.e2e.ts
+++ b/packages/crayons-core/src/components/data-table/data-table.e2e.ts
@@ -547,4 +547,39 @@ describe('fw-data-table', () => {
     );
     expect(checkboxes.length).toBe(1);
   });
+
+  it('should disable table on calling loadTable', async () => {
+    const currentData = { ...manyColumnData, isSelectable: true };
+    await loadDataIntoGrid(currentData);
+    await page.waitForChanges();
+    const dataTable = await page.find('fw-data-table');
+    await dataTable.callMethod('loadTable');
+    await page.waitForChanges();
+    const checkbox = await page.find(
+      'fw-data-table >>> tbody > tr:first-child > td:first-child'
+    );
+    checkbox.click();
+    await page.waitForChanges();
+    const selectedRow = await page.find(
+      'fw-data-table >>> tbody > tr:first-child.active'
+    );
+    expect(selectedRow).toBeFalsy();
+  });
+
+  it('should show shimmer in rows when showShimmer prop is set to true and calling loadTable', async () => {
+    const currentData = {
+      ...manyColumnData,
+      isSelectable: true,
+      showShimmer: true,
+    };
+    await loadDataIntoGrid(currentData);
+    await page.waitForChanges();
+    const dataTable = await page.find('fw-data-table');
+    await dataTable.callMethod('loadTable');
+    await page.waitForChanges();
+    const shimmer = await page.find(
+      'fw-data-table >>> tbody > tr:first-child > td:first-child > fw-skeleton'
+    );
+    expect(shimmer).toBeTruthy();
+  });
 });

--- a/packages/crayons-core/src/components/data-table/data-table.scss
+++ b/packages/crayons-core/src/components/data-table/data-table.scss
@@ -1,3 +1,7 @@
+:host {
+  display: block;
+}
+
 div.fw-data-table-container {
   $grid-header-bg: $color-smoke-25;
   $grid-body-bg: $color-milk;
@@ -384,7 +388,7 @@ div.fw-data-table-container {
       z-index: 95;
     }
   }
-  
+
   &.loading {
     opacity: 0.65;
   }

--- a/packages/crayons-core/src/components/data-table/data-table.scss
+++ b/packages/crayons-core/src/components/data-table/data-table.scss
@@ -384,6 +384,10 @@ div.fw-data-table-container {
       z-index: 95;
     }
   }
+  
+  &.loading {
+    opacity: 0.65;
+  }
 }
 
 @keyframes appear {

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -365,7 +365,7 @@ export class DataTable {
    * @returns isLoading current state
    */
   @Method()
-  async loadTable(state: boolean) {
+  async loadTable(state = true) {
     this.isLoading = state;
     return this.isLoading;
   }
@@ -1430,7 +1430,10 @@ export class DataTable {
   render() {
     return (
       <div
-        class='fw-data-table-container'
+        class={{
+          'fw-data-table-container': true,
+          'loading': this.isLoading,
+        }}
         ref={(el) => (this.tableContainer = el)}
       >
         <table

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -100,6 +100,16 @@ export class DataTable {
    * If set to `true`, make sure `id` attribute is also set to the `data-table`
    */
   @Prop() autoSaveSettings = false;
+  
+  /**
+   * shimmerCount number of shimmer rows to show during initial loading
+   */
+  @Prop() shimmerCount = 4;
+
+  /**
+   * showShimmer show shimmer on loading
+   */
+  @Prop() showShimmer = false;
 
   /**
    * orderedColumns Maintains a collection of ordered columns.
@@ -1423,6 +1433,45 @@ export class DataTable {
       </div>
     );
   }
+  
+  /**
+   * private
+   * @returns table body shimmer
+   */
+  renderTableShimmer() {
+    const shimmerTemplate = [];
+    let columnsLength = this.orderedColumns.length;
+    columnsLength = this.isSelectable ? columnsLength + 1 : columnsLength;
+    columnsLength =
+      this.rowActions && this.rowActions.length
+        ? columnsLength + 1
+        : columnsLength;
+    const shimmerCount = this.rows.length || this.shimmerCount;
+    for (let index = 1; index <= shimmerCount; index++) {
+      if (columnsLength === 0) {
+        shimmerTemplate.push(
+          <tr>
+            <td>
+              <fw-skeleton height='20px' variant='rect'></fw-skeleton>
+            </td>
+          </tr>
+        );
+      } else {
+        shimmerTemplate.push(
+          <tr>
+            {[...Array(columnsLength).keys()].map(() => {
+              return (
+                <td>
+                  <fw-skeleton height='20px' variant='rect'></fw-skeleton>
+                </td>
+              );
+            })}
+          </tr>
+        );
+      }
+    }
+    return shimmerTemplate;
+  }
 
   /**
    * render method
@@ -1443,7 +1492,11 @@ export class DataTable {
           aria-label={this.label}
         >
           <thead>{this.renderTableHeader()}</thead>
-          <tbody>{this.renderTableBody()}</tbody>
+          <tbody>
+            {this.showShimmer && this.isLoading
+              ? this.renderTableShimmer()
+              : this.renderTableBody()}
+          </tbody>
         </table>
         {this.showSettings && this.renderTableSettings()}
         {this.isLoading && <div class='fw-data-table--loading'></div>}

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -100,7 +100,7 @@ export class DataTable {
    * If set to `true`, make sure `id` attribute is also set to the `data-table`
    */
   @Prop() autoSaveSettings = false;
-  
+
   /**
    * shimmerCount number of shimmer rows to show during initial loading
    */
@@ -1433,14 +1433,16 @@ export class DataTable {
       </div>
     );
   }
-  
+
   /**
    * private
    * @returns table body shimmer
    */
   renderTableShimmer() {
     const shimmerTemplate = [];
-    let columnsLength = this.orderedColumns.length;
+    let columnsLength = this.orderedColumns.filter(
+      (column) => !column.hide
+    ).length;
     columnsLength = this.isSelectable ? columnsLength + 1 : columnsLength;
     columnsLength =
       this.rowActions && this.rowActions.length

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -1448,7 +1448,7 @@ We can load a table using the 'loadTable' method available on the table. To show
       <span class="fw-ml-8">Load table</span>
     </span>
     <br><br>
-    <fw-data-table id="datatable-9"  is-selectable="true" is-all-selectable="true" show-shimmer-on-load="true" label="Data table 9">
+    <fw-data-table id="datatable-9"  is-selectable="true" is-all-selectable="true" label="Data table 9">
     </fw-data-table>
   </div>
 
@@ -1521,7 +1521,7 @@ We can load a table using the 'loadTable' method available on the table. To show
       <span class="fw-ml-8">Load table</span>
     </span>
     <br><br>
-    <fw-data-table id="datatable-9"  is-selectable="true" is-all-selectable="true" show-shimmer-on-load="true" label="Data table 9">
+    <fw-data-table id="datatable-9"  is-selectable="true" is-all-selectable="true" label="Data table 9">
     </fw-data-table>
   </div>
 ```
@@ -1645,7 +1645,7 @@ We can load a table using the 'loadTable' method available on the table. To show
     return (
       <>
         <FwToggle onFwChange={toggle}></FwToggle><br></br>
-        <FwDataTable columns={data.columns} rows={data.rows} rowActions={data.rowActions} isSelectable showShimmerOnLoad label="Data Table 2" ref={dataTable}>
+        <FwDataTable columns={data.columns} rows={data.rows} rowActions={data.rowActions} isSelectable label="Data Table 2" ref={dataTable}>
         </FwDataTable>
       </>
     );

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -1512,7 +1512,7 @@ Type: `Promise<{}>`
 
 columnConfig object
 
-### `loadTable(state: boolean) => Promise<boolean>`
+### `loadTable(state?: boolean) => Promise<boolean>`
 
 loadTable - Method to call when we want to change table loading state
 

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -1469,7 +1469,9 @@ Data table exposes couple of method to get and set column configuration.
 | `label`            | `label`              | Label attribute is not visible on screen. There for accessibility purposes.                                                                            | `string`            | `''`    |
 | `rowActions`       | --                   | To enable bulk actions on the table.                                                                                                                   | `DataTableAction[]` | `[]`    |
 | `rows`             | --                   | Rows Array of objects to be displayed in the table.                                                                                                    | `DataTableRow[]`    | `[]`    |
+| `shimmerCount`     | `shimmer-count`      | shimmerCount number of shimmer rows to show during initial loading                                                                                     | `number`            | `4`     |
 | `showSettings`     | `show-settings`      | showSettings is used to show the settings button on the table.                                                                                         | `boolean`           | `false` |
+| `showShimmer`      | `show-shimmer`       | showShimmer show shimmer on loading                                                                                                                    | `boolean`           | `false` |
 
 
 ## Events

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -1435,6 +1435,226 @@ Table settings help with reordering and hide/show of columns. To enable table se
 </code-block>
 </code-group>
 
+## Loading table
+
+We can load a table using the 'loadTable' method available on the table. To show shimmer for rows on load set 'showShimmer' prop to true. If rows is empty, shimmer will be shown for 4 rows. To modify this use the 'shimmerCount' value.
+
+*Note: Show shimmer only on page load. On subsequent table loads, disable shimmer and show normal loading state.*
+
+```html live
+  <div style="width: 590px;">
+     <span>
+      <fw-toggle id="toggle-table" size="medium"></fw-toggle>
+      <span class="fw-ml-8">Load table</span>
+    </span>
+    <br><br>
+    <fw-data-table id="datatable-9"  is-selectable="true" is-all-selectable="true" show-shimmer-on-load="true" label="Data table 9">
+    </fw-data-table>
+  </div>
+
+  <script type="application/javascript">
+    var data = {
+      columns: [{
+        "key": "name",
+        "text": "Name",
+        "widthProperties": {
+          "width": "200px"
+        }
+      }, {
+        "key": "role",
+        "text": "Role",
+        "widthProperties": {
+          "width": "200px"
+        }
+      }],
+      rows: [{
+        "id": "0001",
+        "name": "Alexander Goodman",
+        "role": "Member"
+      }],
+      rowActions: [{
+        "name": "Alert",
+        "handler": (rowData) => {
+          window.alert(rowData.name);
+        }
+      }, {
+        "name": "Delete",
+        "handler": async (rowData) => {
+          let deletePromise = new Promise((resolve, reject) => {
+            const dataTable = document.querySelector('#datatable-4');
+            setTimeout(() => {
+              if (dataTable) {
+                dataTable.rows = dataTable.rows.filter((row) => (row.id !== rowData.id));
+                resolve();
+              } else {
+                reject();
+              }
+            }, 3000); 
+          });
+          await deletePromise;
+        },
+        "hideForRowIds": ["0003"]
+      }],
+      actionsColumn: { "width": "150px" }
+    }
+
+    var datatable9 = document.getElementById('datatable-9');
+    datatable9.columns = data.columns;
+    datatable9.rows = data.rows;
+    datatable9.rowActions = data.rowActions;
+    datatable9.actionsColumnProperties = data.actionsColumn;
+
+    var toggle = document.getElementById('toggle-table');
+    toggle.addEventListener('fwChange', (event) => {
+        datatable9.loadTable(event.detail.checked);
+    });
+  </script>
+```
+
+<code-group>
+<code-block title="HTML">
+
+```html
+  <div style="width: 590px;">
+     <span>
+      <fw-toggle id="toggle-table" size="medium"></fw-toggle>
+      <span class="fw-ml-8">Load table</span>
+    </span>
+    <br><br>
+    <fw-data-table id="datatable-9"  is-selectable="true" is-all-selectable="true" show-shimmer-on-load="true" label="Data table 9">
+    </fw-data-table>
+  </div>
+```
+
+```javascript
+  var data = {
+    columns: [{
+      "key": "name",
+      "text": "Name",
+      "widthProperties": {
+        "width": "300px"
+      }
+    }, {
+      "key": "role",
+      "text": "Role",
+      "widthProperties": {
+        "width": "300px"
+      }
+    }],
+    rows: [{
+      "id": "0001",
+      "name": "Alexander Goodman",
+      "role": "Member"
+    }],
+    rowActions: [{
+      "name": "Alert",
+      "handler": (rowData) => {
+        window.alert(rowData.name);
+      }
+    }, {
+      "name": "Delete",
+      "handler": async (rowData) => {
+        let deletePromise = new Promise((resolve, reject) => {
+          const dataTable = document.querySelector('#datatable-4');
+          setTimeout(() => {
+            if (dataTable) {
+              dataTable.rows = dataTable.rows.filter((row) => (row.id !== rowData.id));
+              resolve();
+            } else {
+              reject();
+            }
+          }, 3000); 
+        });
+        await deletePromise;
+      },
+      "hideForRowIds": ["0003"]
+    }]
+  }
+
+  var datatable9 = document.getElementById('datatable-9');
+  datatable9.columns = data.columns;
+  datatable9.rows = data.rows;
+  datatable9.rowActions = data.rowActions;
+
+  var toggle = document.getElementById('toggle-table');
+  toggle.addEventListener('fwChange', (event) => {
+      datatable9.loadTable(event.detail.checked);
+  });
+```
+
+</code-block>
+
+<code-block title="React">
+
+```jsx
+  import React, { useRef } from "react";
+  import ReactDOM from "react-dom";
+  import { FwDataTable } from "@freshworks/crayons/react";
+  function App() {
+
+    var dataTable = useRef(null);
+
+    var toggle = (event) => {
+      dataTable.current.loadTable(event.detail.checked);
+    }
+
+    var data = {
+      columns: [{
+        "key": "name",
+        "text": "Name",
+        "widthProperties": {
+          "width": "300px"
+        }
+      }, {
+        "key": "role",
+        "text": "Role",
+        "widthProperties": {
+          "width": "300px"
+        }
+      }],
+      rows: [{
+        "id": "0001",
+        "name": "Alexander Goodman",
+        "role": "Member"
+      }],
+      rowActions: [{
+        "name": "Alert",
+        "handler": (rowData) => {
+          window.alert(rowData.name);
+        }
+      }, {
+        "name": "Delete",
+        "handler": async (rowData) => {
+          let deletePromise = new Promise((resolve, reject) => {
+            const dataTable = document.querySelector('#datatable-4');
+            setTimeout(() => {
+              if (dataTable) {
+                dataTable.rows = dataTable.rows.filter((row) => (row.id !== rowData.id));
+                resolve();
+              } else {
+                reject();
+              }
+            }, 3000); 
+          });
+          await deletePromise;
+        },
+        "hideForRowIds": ["0003"]
+      }]
+    }
+
+    return (
+      <>
+        <FwToggle onFwChange={toggle}></FwToggle><br></br>
+        <FwDataTable columns={data.columns} rows={data.rows} rowActions={data.rowActions} isSelectable showShimmerOnLoad label="Data Table 2" ref={dataTable}>
+        </FwDataTable>
+      </>
+    );
+  }
+```
+
+</code-block>
+</code-group>
+
 
 ## Saving column configuration
 


### PR DESCRIPTION
#### Features for data-table in this PR.

- Changed some styling on table loading state. Added opacity on the table when loading to represent disabled state.
- Added show-shimmer and shimmer-count props to show shimmer on initial page load.


https://user-images.githubusercontent.com/61269786/153393450-3e54f009-18aa-4d68-addc-a78f7493c18a.mov

#### Steps to run vuepress documentation:
- From root of project run npm run docs:dev
- Open the link that shows up in console after running above command.
- Navigate to DataTable component in sidebar

#### Known issues:
- Styling for table shimmer is not yet finalised. 



## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
- Tested in Chrome, Firefox and Safari browsers.
- Tested with other samples in Vuepress data-table configuration.