### PR TITLE
fix(data-table): isloading as mutable property

### DIFF
--- a/packages/crayons-core/src/components/data-table/data-table.scss
+++ b/packages/crayons-core/src/components/data-table/data-table.scss
@@ -100,6 +100,10 @@ div.fw-data-table-container {
           background: $grid-row-active;
         }
 
+        &:last-child {
+          border-bottom: 0px;
+        }
+
         td {
           color: $grid-row-txt-color;
           font-size: $grid-row-txt-size;

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -104,7 +104,7 @@ export class DataTable {
   /**
    * To disable table during async operations
    */
-  @Prop() isLoading = false;
+  @Prop({ mutable: true, reflect: true }) isLoading = false;
 
   /**
    * orderedColumns Maintains a collection of ordered columns.


### PR DESCRIPTION
- Making isLoading property for table as a mutable property.
- Removing table last row border as datatable generally does not have a border on its own.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
