### PR TITLE
feat(data-table): showing shimmer on initial table load

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -214,6 +214,10 @@ export namespace Components {
          */
         "setTableSettings": (columnConfig: any) => Promise<DataTableColumn[]>;
         /**
+          * shimmerCount number of shimmer rows to show during initial loading
+         */
+        "shimmerCount": number;
+        /**
           * showSettings is used to show the settings button on the table.
          */
         "showSettings": boolean;
@@ -2265,6 +2269,10 @@ declare namespace LocalJSX {
           * Rows Array of objects to be displayed in the table.
          */
         "rows"?: DataTableRow[];
+        /**
+          * shimmerCount number of shimmer rows to show during initial loading
+         */
+        "shimmerCount"?: number;
         /**
           * showSettings is used to show the settings button on the table.
          */

--- a/packages/crayons-core/src/components/data-table/data-table.e2e.ts
+++ b/packages/crayons-core/src/components/data-table/data-table.e2e.ts
@@ -528,7 +528,7 @@ describe('fw-data-table', () => {
     expect(checkboxes.length).toBe(1);
   });
 
-  it('should remove column from choose columns section in settings when drag item is remove in settings', async () => {
+  it('should remove column from choose columns section in settings when drag item is removed in settings', async () => {
     const currentData = { ...manyColumnData, showSettings: true };
     await loadDataIntoGrid(currentData);
     await page.waitForChanges();
@@ -564,5 +564,22 @@ describe('fw-data-table', () => {
       'fw-data-table >>> tbody > tr:first-child.active'
     );
     expect(selectedRow).toBeFalsy();
+  });
+
+  it('should show shimmer on initial table load', async () => {
+    const data = {
+      columns: [
+        {
+          key: 'name',
+          text: 'Name',
+        },
+      ],
+    };
+    await loadDataIntoGrid(data);
+    await page.waitForChanges();
+    const shimmer = await page.find(
+      'fw-data-table >>> tbody > tr:first-child > td:first-child > fw-skeleton'
+    );
+    expect(shimmer).toBeTruthy();
   });
 });

--- a/packages/crayons-core/src/components/data-table/data-table.scss
+++ b/packages/crayons-core/src/components/data-table/data-table.scss
@@ -153,6 +153,31 @@ div.fw-data-table-container {
           display: none;
         }
       }
+
+      tr.loading {
+        cursor: not-allowed;
+
+        td {
+          position: relative;
+          opacity: 0.65;
+
+          &::after {
+            content: '';
+            position: absolute;
+            top: 0px;
+            left: 0px;
+            bottom: 0px;
+            right: 0px;
+          }
+        }
+      }
+
+      fw-skeleton {
+        display: block;
+        height: 10px;
+        padding: 4px 0px;
+        box-sizing: content-box;
+      }
     }
 
     &.is-selectable {

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -152,7 +152,7 @@ export class DataTable {
   @State() disabledColumnHide = false;
 
   /**
-   * show shimmer on set to true when table is loading.
+   * show shimmer on set to false after intial table load.
    */
   @State() showShimmer = true;
 

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -1006,15 +1006,6 @@ export class DataTable {
 
   /**
    * private
-   * renderRowOverlay
-   * @returns {JSX.Element} render row overlay
-   */
-  renderRowOverlay(rowHeight) {
-    return <div class='row-loading' style={{ height: rowHeight }}></div>;
-  }
-
-  /**
-   * private
    * @returns {JSX.Element} table header row
    */
   renderTableHeader() {

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -1688,6 +1688,7 @@ Data table exposes couple of method to get and set column configuration.
 | `label`            | `label`              | Label attribute is not visible on screen. There for accessibility purposes.                                                                            | `string`            | `''`    |
 | `rowActions`       | --                   | To enable bulk actions on the table.                                                                                                                   | `DataTableAction[]` | `[]`    |
 | `rows`             | --                   | Rows Array of objects to be displayed in the table.                                                                                                    | `DataTableRow[]`    | `[]`    |
+| `shimmerCount`     | `shimmer-count`      | shimmerCount number of shimmer rows to show during initial loading                                                                                     | `number`            | `4`     |
 | `showSettings`     | `show-settings`      | showSettings is used to show the settings button on the table.                                                                                         | `boolean`           | `false` |
 
 
@@ -1767,21 +1768,21 @@ Type: `Promise<DataTableColumn[]>`
 ### Depends on
 
 - [fw-checkbox](../checkbox)
-- [fw-skeleton](../skeleton)
 - [fw-button](../button)
 - [fw-icon](../icon)
 - [fw-input](../input)
 - [fw-drag-container](../drag-container)
+- [fw-skeleton](../skeleton)
 
 ### Graph
 ```mermaid
 graph TD;
   fw-data-table --> fw-checkbox
-  fw-data-table --> fw-skeleton
   fw-data-table --> fw-button
   fw-data-table --> fw-icon
   fw-data-table --> fw-input
   fw-data-table --> fw-drag-container
+  fw-data-table --> fw-skeleton
   fw-checkbox --> fw-icon
   fw-icon --> fw-toast-message
   fw-toast-message --> fw-spinner

--- a/packages/crayons-core/src/utils/index.ts
+++ b/packages/crayons-core/src/utils/index.ts
@@ -259,18 +259,3 @@ export const cyclicDecrement = (value: number, maxValue: number): number => {
   value--;
   return value < 0 ? maxValue : value;
 };
-
-export const getTextNodeHeight = (textNode: HTMLElement) => {
-  let height = 0;
-  if (document.createRange) {
-    const range = document.createRange();
-    range.selectNodeContents(textNode);
-    if (range.getBoundingClientRect) {
-      const rect = range.getBoundingClientRect();
-      if (rect) {
-        height = rect.bottom - rect.top;
-      }
-    }
-  }
-  return height;
-};

--- a/packages/crayons-core/src/utils/index.ts
+++ b/packages/crayons-core/src/utils/index.ts
@@ -259,3 +259,18 @@ export const cyclicDecrement = (value: number, maxValue: number): number => {
   value--;
   return value < 0 ? maxValue : value;
 };
+
+export const getTextNodeHeight = (textNode: HTMLElement) => {
+  let height = 0;
+  if (document.createRange) {
+    const range = document.createRange();
+    range.selectNodeContents(textNode);
+    if (range.getBoundingClientRect) {
+      const rect = range.getBoundingClientRect();
+      if (rect) {
+        height = rect.bottom - rect.top;
+      }
+    }
+  }
+  return height;
+};


### PR DESCRIPTION
#### Features:
- Showing shimmer on initial table load.

#### Demo:


https://user-images.githubusercontent.com/61269786/153803016-40484f4c-e7b0-41aa-8e57-25cc1002f09e.mov

#### Steps to run vuepress documentation:
- From root of project run npm run docs:dev
- Open the link that shows up in console after running above command.
- Navigate to DataTable component in sidebar

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome, FIrefox, Safari browsers.