### PR TITLE
fix(tooltip): updating tooltip radius, modal close button styling

### DIFF
--- a/packages/crayons-core/src/components/button/button.tsx
+++ b/packages/crayons-core/src/components/button/button.tsx
@@ -122,7 +122,7 @@ export class Button {
     const modal: any = document.querySelector(
       `fw-modal#${this.modalTriggerId}`
     );
-    modal.open();
+    modal?.open();
   }
 
   private async fakeSubmit(event: Event) {

--- a/packages/crayons-core/src/components/modal/modal.scss
+++ b/packages/crayons-core/src/components/modal/modal.scss
@@ -86,25 +86,36 @@
     animation: 'modal-entry-right' 0.5s 1;
 
     .close-btn {
-      height: 40px;
-      width: 40px;
+      height: 24px;
+      width: 24px;
+      box-sizing: border-box;
       top: 0px;
       right: 600px;
       background-color: $color-elephant-900;
       border-radius: 2px 0px 0px 2px;
+      padding: 0px;
+      margin: 0px;
+      line-height: 24px;
+      text-align: center;
 
       &:hover,
       &:focus,
       &:focus-visible {
         background-color: $color-elephant-900;
         border-radius: 2px 0px 0px 2px;
-        border: 0px;
+        border-color: $color-elephant-900;
+        outline: 0px;
       }
 
       &:focus,
       &:focus-visible {
         border: 1px solid $color-azure-800;
         box-shadow: $color-azure-800 0px 0px 0px 1px;
+      }
+
+      fw-icon {
+        height: 12px;
+        width: 12px;
       }
     }
 

--- a/packages/crayons-core/src/components/popover/popover.scss
+++ b/packages/crayons-core/src/components/popover/popover.scss
@@ -3,6 +3,7 @@
   @prop --popover-max-width: Maximum width of the popover content.
   @prop --popover-min-height: Minimum height of the popover content.
   @prop --popover-max-height: Maximum height of the popover content.
+  @prop --popover-border-radius: border radius of the popover content.
 */
 
 .popper-content {
@@ -16,7 +17,7 @@
   overflow-x: hidden;
   overscroll-behavior-y: contain;
   margin: 0px;
-  border-radius: 8px;
+  border-radius: var(--popover-border-radius, 8px);
   border: 1px solid $app-border-secondary;
   position: absolute;
   background: $popover-background;

--- a/packages/crayons-core/src/components/popover/popover.tsx
+++ b/packages/crayons-core/src/components/popover/popover.tsx
@@ -196,7 +196,10 @@ export class Popover {
          * popovercontent might trigger mouseLeave callback of triggerRef during transition.
          * This condition avoids flicker that might happen because of the mentioned case.
          */
-        if (!event.relatedTarget.matches('*[slot="popover-content"]')) {
+        if (
+          event.relatedTarget === null ||
+          !event.relatedTarget.matches('*[slot="popover-content"]')
+        ) {
           this.hide();
         }
       });

--- a/packages/crayons-core/src/components/popover/readme.md
+++ b/packages/crayons-core/src/components/popover/readme.md
@@ -578,12 +578,13 @@ Type: `Promise<void>`
 
 ## CSS Custom Properties
 
-| Name                   | Description                            |
-| ---------------------- | -------------------------------------- |
-| `--popover-max-height` | Maximum height of the popover content. |
-| `--popover-max-width`  | Maximum width of the popover content.  |
-| `--popover-min-height` | Minimum height of the popover content. |
-| `--popover-min-width`  | Minimum width of the popover content.  |
+| Name                      | Description                            |
+| ------------------------- | -------------------------------------- |
+| `--popover-border-radius` | border radius of the popover content.  |
+| `--popover-max-height`    | Maximum height of the popover content. |
+| `--popover-max-width`     | Maximum width of the popover content.  |
+| `--popover-min-height`    | Minimum height of the popover content. |
+| `--popover-min-width`     | Minimum width of the popover content.  |
 
 
 ## Dependencies

--- a/packages/crayons-core/src/components/tooltip/tooltip.scss
+++ b/packages/crayons-core/src/components/tooltip/tooltip.scss
@@ -1,8 +1,13 @@
+:host {
+  --popover-border-radius: 4px;
+}
+
 .tooltip {
   color: $color-milk;
   background: $color-elephant-900;
   border-radius: 4px;
   font-size: 12px;
+  font-weight: 600;
   line-height: 18px;
   padding: 6px 8px;
   max-width: 236px;


### PR DESCRIPTION
#### Fixes as part of this PR:

- Tooltip radius, font-weight fixes.
- Modal slider button from 40px to 24px as per DSM.
- Popover error on window change.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome, Firefox, Safari browsers.
