### PR TITLE
feat(list-options): applying event standardisation for list-options as well

### DIFF
--- a/packages/crayons-core/src/components/options-list/list-options.tsx
+++ b/packages/crayons-core/src/components/options-list/list-options.tsx
@@ -256,7 +256,7 @@ export class ListOptions {
       }
       this.fwChange.emit({
         value: newValue,
-        selectedOptions: this.selectedOptionsState,
+        meta: { selectedOptions: this.selectedOptionsState },
       });
       this.isInternalValueChange = false;
     }

--- a/packages/crayons-core/src/components/select/select.tsx
+++ b/packages/crayons-core/src/components/select/select.tsx
@@ -242,7 +242,7 @@ export class Select {
   @Listen('fwChange')
   fwSelectedHandler(selectedItem) {
     if (selectedItem.composedPath()[0].tagName === 'FW-LIST-OPTIONS') {
-      this.selectedOptionsState = selectedItem.detail.selectedOptions;
+      this.selectedOptionsState = selectedItem.detail?.meta?.selectedOptions;
       this.value = selectedItem.detail.value;
       this.renderInput();
       if (!this.multiple || this.variant === 'mail') {


### PR DESCRIPTION
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)

Comparsion with the `next` branch event conventions
| Component |  Before | After |
| ------------ | ------------- | ------------- | 
| fw-list-options | fwChange.emit({ value, selectedOptions })  | fwChange.emit({ value, meta: { selectedOptions } })  |

** BREAKING CHANGES **
`fw-list-options` : selectedOptions field will now be part of meta field in the event detail for fwChange. Now it can be accessed using event.detail.meta.selectedOptions instead of event.detail.selectedOptions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
