### PR TITLE
fix(fw-drag-container): fixed the insertElement issue on Drop

### DIFF
--- a/packages/crayons-core/src/utils/draggable.ts
+++ b/packages/crayons-core/src/utils/draggable.ts
@@ -113,7 +113,7 @@ export class Draggable {
   // Both dragend and drop need to used as the drop will be fired only on the container on which the drag is dropped
   // and no on the container where drag is originated.
   private onDragEnd = (e) => {
-    if (!this.dropped || placeholders.length > 0) {
+    if ((!this.dropped || placeholders.length > 0) && dragElement) {
       // The drag element is dropped outside the drag container
       this.addElement(dragElement, this.nextSibling);
       this.removePlaceholder();

--- a/packages/crayons-core/src/utils/draggable.ts
+++ b/packages/crayons-core/src/utils/draggable.ts
@@ -2,7 +2,7 @@ import { debounce, cloneNodeWithEvents } from './index';
 
 //Global Variables
 let dragElement;
-let placeholders = [];
+const placeholders = [];
 const DEFAULT_OPTIONS = {
   sortable: false,
   acceptFrom: '',
@@ -217,7 +217,7 @@ export class Draggable {
     placeholders.forEach((placeholder) => {
       placeholder.remove();
     });
-    placeholders = [];
+    // TODO: better way of removing the this.placeholder
   }
 
   addElement(newElement, nextElement) {


### PR DESCRIPTION
Fixed the issue where adding a drag element to another container throws error during Drop Event.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
