### PR TITLE
fix(popover): make overlay height to 100% of parent height not 100vh and use allowDeselect in datepicker

### DIFF
--- a/packages/crayons-core/src/components/datepicker/datepicker.tsx
+++ b/packages/crayons-core/src/components/datepicker/datepicker.tsx
@@ -891,6 +891,7 @@ export class Datepicker {
                       same-width='false'
                       variant='button'
                       options-placement='bottom-start'
+                      allow-deselect='false'
                     >
                       {this.longMonthNames.map((month, i) => (
                         <fw-select-option
@@ -912,6 +913,7 @@ export class Datepicker {
                       same-width='false'
                       options-placement='bottom'
                       variant='button'
+                      allow-deselect='false'
                     >
                       {this.supportedYears.map((year, i) => (
                         <fw-select-option
@@ -983,6 +985,7 @@ export class Datepicker {
                       same-width='false'
                       options-placement='bottom-start'
                       variant='button'
+                      allow-deselect='false'
                     >
                       {this.longMonthNames.map((month, i) => (
                         <fw-select-option
@@ -1003,6 +1006,7 @@ export class Datepicker {
                       same-width='false'
                       options-placement='bottom'
                       variant='button'
+                      allow-deselect='false'
                     >
                       {this.supportedYears.map((year, i) => (
                         <fw-select-option
@@ -1025,6 +1029,7 @@ export class Datepicker {
                       same-width='false'
                       options-placement='bottom-start'
                       variant='button'
+                      allow-deselect='false'
                     >
                       {this.longMonthNames.map((month, i) => (
                         <fw-select-option
@@ -1045,6 +1050,7 @@ export class Datepicker {
                       same-width='false'
                       options-placement='bottom'
                       variant='button'
+                      allow-deselect='false'
                     >
                       {this.supportedYears.map((year, i) => (
                         <fw-select-option

--- a/packages/crayons-core/src/components/popover/popover.scss
+++ b/packages/crayons-core/src/components/popover/popover.scss
@@ -43,8 +43,8 @@
 }
 
 .overlay {
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   display: none;
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
