### PR TITLE
fix(data-table): adding cell variants as dependency to table

### DIFF
--- a/packages/crayons-core/src/components/data-table/custom-cells/anchor/readme.md
+++ b/packages/crayons-core/src/components/data-table/custom-cells/anchor/readme.md
@@ -13,6 +13,19 @@
 | `text`   | `text`    |             | `string` | `''`    |
 
 
+## Dependencies
+
+### Used by
+
+ - [fw-data-table](../..)
+
+### Graph
+```mermaid
+graph TD;
+  fw-data-table --> fw-custom-cell-anchor
+  style fw-custom-cell-anchor fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 Built with ❤ at Freshworks

--- a/packages/crayons-core/src/components/data-table/custom-cells/icon/readme.md
+++ b/packages/crayons-core/src/components/data-table/custom-cells/icon/readme.md
@@ -17,6 +17,10 @@
 
 ## Dependencies
 
+### Used by
+
+ - [fw-data-table](../..)
+
 ### Depends on
 
 - [fw-icon](../../../icon)
@@ -28,6 +32,7 @@ graph TD;
   fw-icon --> fw-toast-message
   fw-toast-message --> fw-spinner
   fw-toast-message --> fw-icon
+  fw-data-table --> fw-custom-cell-icon
   style fw-custom-cell-icon fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/crayons-core/src/components/data-table/custom-cells/user/readme.md
+++ b/packages/crayons-core/src/components/data-table/custom-cells/user/readme.md
@@ -17,6 +17,10 @@
 
 ## Dependencies
 
+### Used by
+
+ - [fw-data-table](../..)
+
 ### Depends on
 
 - [fw-avatar](../../../avatar)
@@ -25,6 +29,7 @@
 ```mermaid
 graph TD;
   fw-custom-cell-user --> fw-avatar
+  fw-data-table --> fw-custom-cell-user
   style fw-custom-cell-user fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -994,11 +994,14 @@ export class DataTable {
    */
   renderPredefinedVariant(columnVariant: string, cellValue: any) {
     let template: JSX.Element;
-    if (PREDEFINED_VARIANTS_META[columnVariant]) {
-      template = this.renderWebComponent(
-        PREDEFINED_VARIANTS_META[columnVariant].componentName,
-        cellValue
-      );
+    if (columnVariant === 'anchor') {
+      template = <fw-custom-cell-anchor {...cellValue}></fw-custom-cell-anchor>;
+    } else if (columnVariant === 'user') {
+      template = <fw-custom-cell-user {...cellValue}></fw-custom-cell-user>;
+    } else if (columnVariant === 'icon') {
+      template = <fw-custom-cell-icon {...cellValue}></fw-custom-cell-icon>;
+    } else {
+      template = null;
     }
     return template;
   }

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -1767,6 +1767,9 @@ Type: `Promise<DataTableColumn[]>`
 
 ### Depends on
 
+- [fw-custom-cell-anchor](./custom-cells/anchor)
+- [fw-custom-cell-user](./custom-cells/user)
+- [fw-custom-cell-icon](./custom-cells/icon)
 - [fw-checkbox](../checkbox)
 - [fw-button](../button)
 - [fw-icon](../icon)
@@ -1777,16 +1780,21 @@ Type: `Promise<DataTableColumn[]>`
 ### Graph
 ```mermaid
 graph TD;
+  fw-data-table --> fw-custom-cell-anchor
+  fw-data-table --> fw-custom-cell-user
+  fw-data-table --> fw-custom-cell-icon
   fw-data-table --> fw-checkbox
   fw-data-table --> fw-button
   fw-data-table --> fw-icon
   fw-data-table --> fw-input
   fw-data-table --> fw-drag-container
   fw-data-table --> fw-skeleton
-  fw-checkbox --> fw-icon
+  fw-custom-cell-user --> fw-avatar
+  fw-custom-cell-icon --> fw-icon
   fw-icon --> fw-toast-message
   fw-toast-message --> fw-spinner
   fw-toast-message --> fw-icon
+  fw-checkbox --> fw-icon
   fw-button --> fw-spinner
   fw-button --> fw-icon
   fw-input --> fw-icon


### PR DESCRIPTION
Issue: 
Cell variant components appear empty in data-table cell in CO UI staging environment.

Fix: 
This was happening due to stencil not picking up cell variants as dependency for data-table as we are loading them dynamically. In the fix, the components are loaded based on variant name. 

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested by verifying the variants in vuepress docs in chrome browser.
