### PR TITLE
fix(fw-select): Modified the color of the state text based on the state

### DIFF
--- a/packages/crayons-core/src/components/select/select.scss
+++ b/packages/crayons-core/src/components/select/select.scss
@@ -19,10 +19,10 @@ $warning-color: $color-casablanca-300;
   border-color: $_color;
 
   & span.dropdown-status-icon {
-    border-color: $_color;
+    --icon-color: #{$_color};
   }
 
-  & ~ span.help-block {
+  & > span.help-block {
     color: $_color;
   }
 }
@@ -156,7 +156,6 @@ label {
 
     &.warning {
       @include stateStyle($warning-color);
-
       box-shadow: 0 0 0 1px $warning-color;
     }
   }
@@ -179,6 +178,7 @@ label {
     min-width: 20px;
     min-height: 20px;
     transition: all 0.15s;
+    --icon-color: $color-elephant-800;
   }
 
   //Help Block
@@ -194,6 +194,14 @@ label {
 
   .dropdown-status-icon.expanded {
     transform: rotate(180deg);
+  }
+
+  &.error {
+    @include stateStyle($error-color);
+  }
+
+  &.warning {
+    @include stateStyle($warning-color);
   }
 }
 

--- a/packages/crayons-core/src/components/select/select.scss
+++ b/packages/crayons-core/src/components/select/select.scss
@@ -18,10 +18,6 @@ $warning-color: $color-casablanca-300;
 @mixin stateStyle($_color) {
   border-color: $_color;
 
-  & span.dropdown-status-icon {
-    --icon-color: #{$_color};
-  }
-
   & > span.help-block {
     color: $_color;
   }

--- a/packages/crayons-core/src/components/select/select.tsx
+++ b/packages/crayons-core/src/components/select/select.tsx
@@ -563,7 +563,7 @@ export class Select {
         {/* NOTE:: aria-controls is added to div based on ARIA 1.0 but from ARIA 1.1 version this should be
         moved to the input REF- https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html */}
         <div
-          class='select-container'
+          class={{ 'select-container': true, [this.state]: true }}
           role='combobox'
           aria-controls={`${this.hostId}-listbox`}
           aria-haspopup='listbox'
@@ -652,7 +652,6 @@ export class Select {
                       >
                         <fw-icon
                           name='chevron-down'
-                          color='#264966'
                           size={8}
                           library='system'
                         ></fw-icon>


### PR DESCRIPTION
## Description:

Modified the color of the state-text to match the state color.
Normal State:
<img width="414" alt="Screenshot 2022-02-28 at 5 45 15 PM" src="https://user-images.githubusercontent.com/64781864/155982584-81fbfc1c-a7a9-4897-b867-802b74c0520a.png">
Warning State:
<img width="414" alt="Screenshot 2022-02-28 at 5 45 04 PM" src="https://user-images.githubusercontent.com/64781864/155982618-beaf1d67-5a59-4a9e-bb98-73b1ef41ceb6.png">
Error State:
<img width="414" alt="Screenshot 2022-02-28 at 5 44 48 PM" src="https://user-images.githubusercontent.com/64781864/155982650-2d9e7d93-b924-4287-ae68-26e7a6898d41.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
