### PR TITLE
fix(data-table): fw-tooltip on hovering over data-table row action buttons

### DIFF
--- a/packages/crayons-core/src/components/data-table/data-table.e2e.ts
+++ b/packages/crayons-core/src/components/data-table/data-table.e2e.ts
@@ -301,7 +301,7 @@ describe('fw-data-table', () => {
       'fw-data-table >>> thead > tr > th:last-child'
     );
     const actionButton = await page.find(
-      'fw-data-table >>> tbody > tr > td.row-actions > fw-button'
+      'fw-data-table >>> tbody > tr > td.row-actions fw-button'
     );
     expect(actionColumn.innerText).toEqual('Actions');
     expect(actionButton).toBeTruthy();
@@ -344,7 +344,7 @@ describe('fw-data-table', () => {
     );
     await page.waitForChanges();
     const actionButton = await page.find(
-      'fw-data-table >>> tbody > tr > td.row-actions > fw-button'
+      'fw-data-table >>> tbody > tr > td.row-actions fw-button'
     );
     actionButton.click();
     await page.waitForChanges();

--- a/packages/crayons-core/src/components/data-table/data-table.scss
+++ b/packages/crayons-core/src/components/data-table/data-table.scss
@@ -26,7 +26,7 @@ div.fw-data-table-container {
 
   div.fw-data-table-scrollable {
     position: relative;
-    display: inline-block;
+    display: block;
     width: 100%;
     height: 100%;
     overflow: auto;

--- a/packages/crayons-core/src/components/data-table/data-table.scss
+++ b/packages/crayons-core/src/components/data-table/data-table.scss
@@ -118,6 +118,7 @@ div.fw-data-table-container {
             text-overflow: ellipsis;
             box-sizing: border-box;
             z-index: 0;
+            height: 64px;
 
             &.data-grid-checkbox {
               text-align: center;
@@ -150,7 +151,7 @@ div.fw-data-table-container {
             width: 1px;
             white-space: nowrap;
 
-            & > fw-button {
+            & fw-button {
               margin-right: 5px;
             }
           }

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -1194,33 +1194,34 @@ export class DataTable {
                         ? 'icon-small'
                         : 'small';
                       actionTemplate = (
-                        <fw-button
-                          tabIndex={0}
-                          size={buttonSize}
-                          color='secondary'
-                          onKeyUp={(event) =>
-                            (event.code === 'Space' ||
-                              event.code === 'Enter') &&
-                            this.performRowAction(action, row)
-                          }
-                          onClick={() => this.performRowAction(action, row)}
-                          title={action.name}
-                          aria-label={action.name}
-                        >
-                          {action.iconName ? (
-                            <fw-icon
-                              name={action.iconName}
-                              library={
-                                action.iconLibrary
-                                  ? action.iconLibrary
-                                  : 'crayons'
-                              }
-                              size={10}
-                            ></fw-icon>
-                          ) : (
-                            action.name
-                          )}
-                        </fw-button>
+                        <fw-tooltip content={action.name} distance='5'>
+                          <fw-button
+                            tabIndex={0}
+                            size={buttonSize}
+                            color='secondary'
+                            onKeyUp={(event) =>
+                              (event.code === 'Space' ||
+                                event.code === 'Enter') &&
+                              this.performRowAction(action, row)
+                            }
+                            onClick={() => this.performRowAction(action, row)}
+                            aria-label={action.name}
+                          >
+                            {action.iconName ? (
+                              <fw-icon
+                                name={action.iconName}
+                                library={
+                                  action.iconLibrary
+                                    ? action.iconLibrary
+                                    : 'crayons'
+                                }
+                                size={10}
+                              ></fw-icon>
+                            ) : (
+                              action.name
+                            )}
+                          </fw-button>
+                        </fw-tooltip>
                       );
                     }
                     return actionTemplate;

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -605,13 +605,28 @@ export class DataTable {
     let nextFocusElement = null;
     switch (eventCode) {
       case 'ArrowRight':
-        if (currentElement.nextElementSibling) {
+        if (currentElement.parentElement.nodeName === 'FW-TOOLTIP') {
+          if (currentElement.parentElement.nextElementSibling) {
+            nextFocusElement =
+              currentElement.parentElement.nextElementSibling.children[0];
+          } else {
+            cellFocusChange = true;
+          }
+        } else if (currentElement.nextElementSibling) {
           nextFocusElement = currentElement.nextElementSibling as any;
         } else {
           cellFocusChange = true;
         }
         break;
       case 'ArrowLeft':
+        if (currentElement.parentElement.nodeName === 'FW-TOOLTIP') {
+          if (currentElement.parentElement.previousElementSibling) {
+            nextFocusElement =
+              currentElement.parentElement.previousElementSibling.children[0];
+          } else {
+            cellFocusChange = true;
+          }
+        }
         if (currentElement.previousElementSibling) {
           nextFocusElement = currentElement.previousElementSibling as any;
         } else {
@@ -771,6 +786,9 @@ export class DataTable {
         default:
           childElement = cell.children[0];
           break;
+      }
+      if (childElement.nodeName === 'FW-TOOLTIP') {
+        childElement = childElement.children[0];
       }
       childElement.setAttribute('tabIndex', '0');
       childElement.focus();

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -1771,6 +1771,7 @@ Type: `Promise<DataTableColumn[]>`
 - [fw-custom-cell-user](./custom-cells/user)
 - [fw-custom-cell-icon](./custom-cells/icon)
 - [fw-checkbox](../checkbox)
+- [fw-tooltip](../tooltip)
 - [fw-button](../button)
 - [fw-icon](../icon)
 - [fw-input](../input)
@@ -1784,6 +1785,7 @@ graph TD;
   fw-data-table --> fw-custom-cell-user
   fw-data-table --> fw-custom-cell-icon
   fw-data-table --> fw-checkbox
+  fw-data-table --> fw-tooltip
   fw-data-table --> fw-button
   fw-data-table --> fw-icon
   fw-data-table --> fw-input
@@ -1795,6 +1797,7 @@ graph TD;
   fw-toast-message --> fw-spinner
   fw-toast-message --> fw-icon
   fw-checkbox --> fw-icon
+  fw-tooltip --> fw-popover
   fw-button --> fw-spinner
   fw-button --> fw-icon
   fw-input --> fw-icon

--- a/packages/crayons-core/src/components/modal/modal.scss
+++ b/packages/crayons-core/src/components/modal/modal.scss
@@ -143,7 +143,7 @@
 
 @keyframes modal-entry-right {
   0% {
-    transform: translateX(calc(100% - 590px));
+    transform: translateX(calc(100% - 520px));
   }
 
   100% {

--- a/packages/crayons-core/src/components/tooltip/readme.md
+++ b/packages/crayons-core/src/components/tooltip/readme.md
@@ -380,6 +380,10 @@ promise that resolves to true
 
 ## Dependencies
 
+### Used by
+
+ - [fw-data-table](../data-table)
+
 ### Depends on
 
 - [fw-popover](../popover)
@@ -388,6 +392,7 @@ promise that resolves to true
 ```mermaid
 graph TD;
   fw-tooltip --> fw-popover
+  fw-data-table --> fw-tooltip
   style fw-tooltip fill:#f9f,stroke:#333,stroke-width:4px
 ```
 


### PR DESCRIPTION
Fixes in this PR:
These are fixes suggested by design team. doc: https://docs.google.com/spreadsheets/d/1f8kTSWK2eTkAKCnW6-03ptRpqC2YigSe0gcdfuKwFTI/edit?usp=sharing
- Table row min height to 64px.
- Modal slider slide-in animation improved as suggested by design team.
- Changed from default tooltip to fw-tooltip inside DataTable.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Fixes were individually tested in Chrome browser.
