### PR TITLE
feat(fw-datepicker): added stateText prop to the datepicker

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -265,6 +265,10 @@ export namespace Components {
          */
         "state": 'normal' | 'warning' | 'error';
         /**
+          * Descriptive or instructional text displayed below the date picker box.
+         */
+        "stateText": any;
+        /**
           * Ending date of the date range that is preselected in the calendar, if mode is range. Must be a date earlier than the max-date value and valid ISO date format.
          */
         "toDate": string;
@@ -2295,6 +2299,10 @@ declare namespace LocalJSX {
           * Theme based on which the input of the datepicker is styled.
          */
         "state"?: 'normal' | 'warning' | 'error';
+        /**
+          * Descriptive or instructional text displayed below the date picker box.
+         */
+        "stateText"?: any;
         /**
           * Ending date of the date range that is preselected in the calendar, if mode is range. Must be a date earlier than the max-date value and valid ISO date format.
          */

--- a/packages/crayons-core/src/components/datepicker/datepicker.scss
+++ b/packages/crayons-core/src/components/datepicker/datepicker.scss
@@ -275,25 +275,27 @@
 }
 
 .icon-calendar {
-  transform: translateX(calc(-100%));
   display: flex;
-  align-self: stretch;
-  background-color: $color-smoke-50;
-  margin: 4px -4px;
-  border-radius: 4px;
+  align-items: center;
+  align-content: stretch;
+  margin: 4px 0px;
 
   .separator {
     border-left-width: 1px;
     border-left-style: solid;
-    transform: translateX(-4px);
-    margin: 2px 0;
+    height: 20px;
+    margin: 0px 4px;
   }
 }
 
 .date-icon {
   display: flex;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
   align-items: center;
-  padding: 0 7px;
+  justify-content: center;
+  background-color: $color-smoke-50;
 }
 
 .range-date-input {

--- a/packages/crayons-core/src/components/datepicker/datepicker.scss
+++ b/packages/crayons-core/src/components/datepicker/datepicker.scss
@@ -277,7 +277,6 @@
 .icon-calendar {
   display: flex;
   align-items: center;
-  align-content: stretch;
   margin: 4px 0px;
 
   .separator {

--- a/packages/crayons-core/src/components/datepicker/datepicker.tsx
+++ b/packages/crayons-core/src/components/datepicker/datepicker.tsx
@@ -109,6 +109,11 @@ export class Datepicker {
   @Prop() readonly = false;
 
   /**
+   * Descriptive or instructional text displayed below the date picker box.
+   */
+  @Prop() stateText;
+
+  /**
    *   Triggered when the update button clicked
    */
   @Event() fwChange: EventEmitter;
@@ -907,22 +912,28 @@ export class Datepicker {
             onFwBlur={this.onBlur}
             ref={(el) => (this.nativeInput = el)}
             state={this.state}
+            stateText={this.stateText}
             readonly={this.readonly}
-          ></fw-input>
-          <div class='icon-calendar'>
-            <div
-              class='separator'
-              style={{
-                borderLeftColor: this.state === 'error' ? '#d72d30' : '#ebeff3',
-              }}
-            ></div>
-            <fw-icon
-              onClick={() => (this.showDatePicker = true)}
-              name='calendar'
-              class='date-icon'
-              style={{ '--icon-color': this.state === 'error' && '#d72d30' }}
-            ></fw-icon>
-          </div>
+          >
+            <div class='icon-calendar' slot='input-suffix'>
+              <div
+                class='separator'
+                style={{
+                  borderLeftColor:
+                    this.state === 'error' ? '#d72d30' : '#ebeff3',
+                }}
+              ></div>
+              <span class='date-icon'>
+                <fw-icon
+                  onClick={() => (this.showDatePicker = true)}
+                  name='calendar'
+                  style={{
+                    '--icon-color': this.state === 'error' && '#d72d30',
+                  }}
+                ></fw-icon>
+              </span>
+            </div>
+          </fw-input>
         </div>
         {this.showSingleDatePicker() ? (
           <div class='datepicker' slot='popover-content'>


### PR DESCRIPTION
## Description:
- Added stateText prop and passed it to the fw-input.
- Moved the calendar icon inside the fw-input as slot.
<img width="414" alt="Screenshot 2022-03-01 at 12 53 51 PM" src="https://user-images.githubusercontent.com/64781864/156124263-aefb11f2-7485-4543-881c-bd0bb7f84d40.png">


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
