### PR TITLE
fix: standardized height of all input elements to 32px

### DIFF
--- a/packages/crayons-core/src/components/datepicker/datepicker.scss
+++ b/packages/crayons-core/src/components/datepicker/datepicker.scss
@@ -1,4 +1,5 @@
 :host {
+  display: block;
   position: relative;
   --icon-size: 14px;
 

--- a/packages/crayons-core/src/components/input/input.scss
+++ b/packages/crayons-core/src/components/input/input.scss
@@ -103,7 +103,7 @@ label {
 
       input {
         width: 100%;
-        padding: 6px 0px;
+        padding: 5px 0px;
         resize: none;
         border: none;
         outline: none;

--- a/packages/crayons-core/src/components/select/select.scss
+++ b/packages/crayons-core/src/components/select/select.scss
@@ -6,7 +6,7 @@
 
 $label-font: $font-stack;
 $input-bg: $color-milk;
-$help-color: $color-smoke-300;
+$help-color: $muted-secondary;
 $error-color: $color-persimmon-800;
 $input-color: $color-elephant-900;
 $input-disabled-bg: $color-smoke-25;
@@ -30,7 +30,7 @@ $warning-color: $color-casablanca-300;
 label {
   font-size: $font-size-12;
   font-weight: $font-weight-600;
-  color: $color-elephant-900;
+  color: $color-smoke-700;
   margin-bottom: 0;
   line-height: 20px;
   padding-bottom: 4px;
@@ -183,7 +183,8 @@ label {
   //Help Block
   .help-block {
     font-size: $font-size-12;
-    margin-top: 3px;
+    margin-top: 4px;
+    line-height: 20px;
     color: $help-color;
     position: inherit;
     margin-bottom: 0;

--- a/packages/crayons-core/src/components/select/select.scss
+++ b/packages/crayons-core/src/components/select/select.scss
@@ -22,6 +22,9 @@ $warning-color: $color-casablanca-300;
     color: $_color;
   }
 }
+:host {
+  display: block;
+}
 
 // Label Style
 label {
@@ -53,7 +56,7 @@ label {
   background-color: $input-bg;
   box-shadow: none;
   min-height: 22px;
-  display: inline-flex;
+  display: flex;
   align-items: center;
 
   .input-container-inner {
@@ -168,7 +171,7 @@ label {
   }
 
   .dropdown-status-icon {
-    display: inline-flex;
+    display: flex;
     align-items: center;
     justify-content: center;
     min-width: 20px;


### PR DESCRIPTION
## Description:
 Standardised the height of fw-input, fw-select, fw-datepicker to 32px.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
