### PR TITLE
fix(data-table): adding localStorage permissions check before using it

### DIFF
--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -47,7 +47,14 @@ const TABLE_POPPER_CONFIG: any = {
   ],
 };
 
-const localStorage = window.localStorage;
+let localStorage = null;
+try {
+  if (window.localStorage) {
+    localStorage = window.localStorage;
+  }
+} catch (error) {
+  console.warn('Cannot save table settings to localStorage');
+}
 
 @Component({
   tag: 'fw-data-table',


### PR DESCRIPTION
## Issue:
When localStorage permission is not available to the document where data-table is used, currently the document is throwing an error.

## Fix:
Adding a try catch before accessing the window.localStorage. If permission is not available, we show a warning saying that settings cannot be saved. 

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)

