### PR TITLE
feat(data-table): adding a column lock configuration to data table

### DIFF
--- a/packages/crayons-core/src/components/data-table/data-table.e2e.ts
+++ b/packages/crayons-core/src/components/data-table/data-table.e2e.ts
@@ -507,6 +507,26 @@ describe('fw-data-table', () => {
     expect(columns.length).toBe(1);
   });
 
+  it('should not be able to hide locked columns', async () => {
+    const currentData = { ...manyColumnData, showSettings: true };
+    currentData.columns[0].lock = true;
+    await loadDataIntoGrid(currentData);
+    await page.waitForChanges();
+    const settingsButton = await page.find(
+      'fw-data-table >>> .table-settings-button'
+    );
+    settingsButton.click();
+    await page.waitForChanges();
+    const firstCheckbox = await page.find('fw-data-table >>> fw-checkbox');
+    const applySettings = await page.find('fw-data-table >>> #apply-settings');
+    firstCheckbox.click();
+    await page.waitForChanges();
+    applySettings.click();
+    await page.waitForChanges();
+    const columns = await page.findAll('fw-data-table >>> th:not(.hidden)');
+    expect(columns.length).toBe(2);
+  });
+
   it('should display only columns that include text from search box in column list in settings container', async () => {
     const currentData = { ...manyColumnData, showSettings: true };
     await loadDataIntoGrid(currentData);

--- a/packages/crayons-core/src/components/data-table/data-table.scss
+++ b/packages/crayons-core/src/components/data-table/data-table.scss
@@ -225,7 +225,6 @@ div.fw-data-table-container {
 
     .table-settings-container {
       position: relative;
-      z-index: 99;
       display: flex;
       flex-direction: column;
       align-items: flex-end;
@@ -254,6 +253,7 @@ div.fw-data-table-container {
       }
 
       .table-settings-options {
+        z-index: 99;
         width: 500px;
         box-sizing: border-box;
         background: $color-milk;
@@ -386,6 +386,11 @@ div.fw-data-table-container {
                   }
                 }
 
+                .table-settings-drag-item-icon.non-drag:hover,
+                .table-settings-drag-item-icon.non-drag:focus {
+                  cursor: default;
+                }
+
                 .table-settings-drag-item-close {
                   background: $color-milk;
                   border: 0px;
@@ -401,6 +406,11 @@ div.fw-data-table-container {
                   text-overflow: ellipsis;
                   overflow: hidden;
                   white-space: nowrap;
+
+                  &:hover,
+                  &:focus {
+                    cursor: default;
+                  }
                 }
               }
             }

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -1003,6 +1003,103 @@ To hide certain columns, we can pass the 'hide' property set to true in the colu
 </code-block>
 </code-group>
 
+## Column lock
+
+We can lock column using 'lock' in column's configuration. 
+
+```html live
+  <fw-data-table id="datatable-51" label="Data table 51" show-settings="true">
+  </fw-data-table>
+
+  <script type="application/javascript">
+    var data = {
+      columns: [{
+        "key": "name",
+        "text": "Name",
+        "lock": true
+      }, {
+        "key": "role",
+        "text": "Role"
+      }],
+      rows: [{
+        "id": "0001",
+        "name": "Alexander Goodman",
+        "role": "Member"
+      }]
+    }
+
+    var datatable51 = document.getElementById('datatable-51');
+    datatable51.columns = data.columns;
+    datatable51.rows = data.rows;
+  </script>
+```
+
+<code-group>
+<code-block title="HTML">
+
+```html
+  <fw-data-table id="datatable-51" label="Data table 51" show-settings="true">
+  </fw-data-table>
+```
+
+```javascript
+  var data = {
+    columns: [{
+      "key": "name",
+      "text": "Name",
+      "lock": true
+    }, {
+      "key": "role",
+      "text": "Role"
+    }],
+    rows: [{
+      "id": "0001",
+      "name": "Alexander Goodman",
+      "role": "Member"
+    }]
+  }
+
+  var datatable51 = document.getElementById('datatable-51');
+  datatable51.columns = data.columns;
+  datatable51.rows = data.rows;
+```
+
+</code-block>
+
+<code-block title="React">
+
+```jsx
+  import React from "react";
+  import ReactDOM from "react-dom";
+  import { FwDataTable } from "@freshworks/crayons/react";
+  function App() {
+
+    var data = {
+      columns: [{
+        "key": "name",
+        "text": "Name",
+        "lock": true
+      }, {
+        "key": "role",
+        "text": "Role"
+      }],
+      rows: [{
+        "id": "0001",
+        "name": "Alexander Goodman",
+        "role": "Member"
+      }]
+    }
+
+    return (
+      <FwDataTable columns={data.columns} rows={data.rows} label="Data Table 51" showSettings>
+      </FwDataTable>
+    );
+  }
+```
+
+</code-block>
+</code-group>
+
 ## Column width
 
 We can pass width for every column using 'widthProperties' in column's configuration. Every column has a minimum width of 40px and maximum width of 1000px by default. We can override min/max width for every column using the 'widthProperties' too.

--- a/packages/crayons-core/src/utils/types.ts
+++ b/packages/crayons-core/src/utils/types.ts
@@ -64,6 +64,7 @@ export type DataTableColumn = {
   variant?: string;
   position?: number;
   hide?: boolean;
+  lock?: boolean;
   widthProperties?: WidthStyles;
   textAlign?: 'left' | 'center' | 'right';
   hasFocusableComponent?: boolean;


### PR DESCRIPTION
## Feature in this PR:
Added lock column configuration.

<img width="901" alt="Screenshot 2022-03-04 at 11 19 52 AM" src="https://user-images.githubusercontent.com/61269786/156711184-c6b33582-f296-4d4e-90ea-a7572735dee4.png">

```html
<fw-data-table id="datatable-1" label="Data table 1" show-settings="true">
</fw-data-table>
<script type="application/javascript">
  var datatable1 = document.getElementById('datatable-1');
  datatable1.columns = [{
      "key": "name",
      "text": "Name",
      "lock": true
    }];
  datatable1.rows = [{
      "id": "0001",
      "name": "Alexander Goodman"
    }];
</script>
```

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested with Chrome browser.
