### PR TITLE
feat(timepicker): replace moment-mini with date-fns

### DIFF
--- a/packages/crayons-core/src/components/datepicker/datepicker.tsx
+++ b/packages/crayons-core/src/components/datepicker/datepicker.tsx
@@ -956,7 +956,8 @@ export class Datepicker {
   };
 
   // handle cancel and popover close
-  handlePopoverClose = (_e: any) => {
+  handlePopoverClose = (e: any) => {
+    if (e.target?.tagName === 'FW-SELECT') return;
     if (this.mode === 'range') {
       // handle resetting of startDate and endDate on clicking cancel
       if (this.value) {
@@ -986,7 +987,9 @@ export class Datepicker {
             locale: this.langModule,
           }).valueOf();
         }
-      } else this.startDate = this.endDate = undefined;
+      } else if (!this.startDate && !this.endDate) {
+        this.startDate = this.endDate = undefined;
+      }
     } else {
       // handle resetting of selectedDay on clicking cancel
       if (this.value) {

--- a/packages/crayons-core/src/components/select/select.tsx
+++ b/packages/crayons-core/src/components/select/select.tsx
@@ -585,7 +585,6 @@ export class Select {
             ref={(popover) => (this.popover = popover)}
             same-width={this.sameWidth}
             placement={this.optionsPlacement}
-            onFwHide={(e) => e.stopImmediatePropagation()}
           >
             <div
               slot='popover-trigger'


### PR DESCRIPTION
- Replace moment-mini with date-fns.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
