### PR TITLE
fix(modal): display modal-title only when there is a title-text

### DIFF
--- a/packages/crayons-core/src/components/modal-title/modal-title.tsx
+++ b/packages/crayons-core/src/components/modal-title/modal-title.tsx
@@ -67,7 +67,9 @@ export class ModalTitle {
                 {this.icon !== '' ? this.renderIcon() : null}
                 <label class='title-label'>{this.titleText}</label>
               </div>
-              <label class='description'>{this.description}</label>
+              {this.description && (
+                <label class='description'>{this.description}</label>
+              )}
             </div>
           )}
         </div>

--- a/packages/crayons-core/src/components/modal/modal.tsx
+++ b/packages/crayons-core/src/components/modal/modal.tsx
@@ -393,7 +393,7 @@ export class Modal {
             </button>
           )}
           <div class='modal-container'>
-            {this.modalTitle ? '' : this.renderTitle()}
+            {this.modalTitle ? '' : this.titleText ? this.renderTitle() : ''}
             {this.modalContent ? <slot></slot> : this.renderContent()}
             {this.hideFooter ? '' : this.modalFooter ? '' : this.renderFooter()}
           </div>


### PR DESCRIPTION
Issue:
Even if title-text prop is empty, we are getting some empty space in UI for modal-header.

Fix: 
Display modal-header only if title-text prop has value in it.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome browser. 
Tested with samples in Vuepress documentation.
