### PR TITLE
feat(data-table): adding src prop to custom-cell-icon

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -154,6 +154,7 @@ export namespace Components {
         "library": string;
         "name": string;
         "size": number;
+        "src": any;
     }
     interface FwCustomCellUser {
         "alt": string;
@@ -2429,6 +2430,7 @@ declare namespace LocalJSX {
         "library"?: string;
         "name"?: string;
         "size"?: number;
+        "src"?: any;
     }
     interface FwCustomCellUser {
         "alt"?: string;

--- a/packages/crayons-core/src/components/data-table/custom-cells/icon/custom-cell-icon.tsx
+++ b/packages/crayons-core/src/components/data-table/custom-cells/icon/custom-cell-icon.tsx
@@ -13,6 +13,8 @@ export class CustomCellUser {
 
   @Prop() library = 'crayons';
 
+  @Prop() src = null;
+
   render() {
     return (
       <fw-icon
@@ -20,6 +22,7 @@ export class CustomCellUser {
         size={this.size}
         color={this.color}
         library={this.library}
+        src={this.src}
       ></fw-icon>
     );
   }

--- a/packages/crayons-core/src/components/data-table/custom-cells/icon/readme.md
+++ b/packages/crayons-core/src/components/data-table/custom-cells/icon/readme.md
@@ -13,6 +13,7 @@
 | `library` | `library` |             | `string` | `'crayons'` |
 | `name`    | `name`    |             | `string` | `''`        |
 | `size`    | `size`    |             | `number` | `18`        |
+| `src`     | `src`     |             | `any`    | `null`      |
 
 
 ## Dependencies


### PR DESCRIPTION
Able to pass a src directly to custom template icon variant.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome browser.
