### PR TITLE
feat(data-table): table settings input clearing on closing modal

### DIFF
--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -527,6 +527,7 @@ export class DataTable {
    */
   async resetSettings() {
     this.settingSearchText = '';
+    this.settingsInput.value = '';
     this.columnsDragSetting = [];
     this.columnsHideSetting = [];
     const modifiedColumnsDragSettings = this.orderedColumns.map((column) => {


### PR DESCRIPTION
Table settings input clearing on closing modal. 

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome.
