### PR TITLE
fix(modal): hideFooter prop working for custom footer

### DIFF
--- a/packages/crayons-core/src/components/modal/modal.e2e.ts
+++ b/packages/crayons-core/src/components/modal/modal.e2e.ts
@@ -46,9 +46,17 @@ describe('fw-modal', () => {
       '<fw-modal is-open hide-footer="true">Hello world</fw-modal>'
     );
     await page.waitForChanges();
-    const footer = await page.find('fw-modal >>> fw-modal-footer');
     await page.waitForChanges();
-    expect(footer).toBe(null);
+    const displayFooter = await page.evaluate(
+      (component, selector) => {
+        const cmpEl = document.querySelector(component);
+        const footer = cmpEl.shadowRoot.querySelector(selector);
+        return footer.style.display;
+      },
+      'fw-modal',
+      'fw-modal-footer'
+    );
+    expect(displayFooter).toEqual('none');
   });
 
   it('should open slider variant of modal when prop slider is passed to the component', async () => {

--- a/packages/crayons-core/src/components/modal/modal.tsx
+++ b/packages/crayons-core/src/components/modal/modal.tsx
@@ -173,8 +173,7 @@ export class Modal {
       this.modalContent = this.el.querySelector('fw-modal-content');
     }
     if (this.hideFooter && this.modalFooter) {
-      // Removes footer when footer is added by composition.
-      this.modalFooter.parentNode.removeChild(this.modalFooter);
+      this.modalFooter.style.display = 'none';
     }
     if (!this.modalContent && (this.modalTitle || this.modalFooter)) {
       /**
@@ -200,6 +199,17 @@ export class Modal {
       document.body.style.overflow = 'hidden';
       this.addAccesibilityEvents();
       this.fwOpen.emit();
+    }
+  }
+
+  @Watch('hideFooter')
+  footerVisibilityChange(hideFooter: boolean) {
+    if (this.modalFooter) {
+      if (hideFooter) {
+        this.modalFooter.style.display = 'none';
+      } else {
+        this.modalFooter.style.display = 'block';
+      }
     }
   }
 
@@ -359,6 +369,7 @@ export class Modal {
         submitColor={this.submitColor}
         submit={this.submit.bind(this)}
         close={this.close.bind(this)}
+        style={{ display: this.hideFooter ? 'none' : 'block' }}
       ></fw-modal-footer>
     );
   }
@@ -400,7 +411,7 @@ export class Modal {
           <div class='modal-container'>
             {this.modalTitle ? '' : this.titleText ? this.renderTitle() : ''}
             {this.modalContent ? <slot></slot> : this.renderContent()}
-            {this.hideFooter ? '' : this.modalFooter ? '' : this.renderFooter()}
+            {this.modalFooter ? '' : this.renderFooter()}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Issue:
Custom footer does not respond to changes in 'hideFooter' prop.

Fix:
We are using css display instead of removing the element from DOM. This enables to show to element when 'hideFooter' is set to true.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome browser.
