### PR TITLE
fix(fw-select): prevents the dropdown from opening on option delete in multi-select

### DIFF
--- a/packages/crayons-core/src/components/tag/tag.tsx
+++ b/packages/crayons-core/src/components/tag/tag.tsx
@@ -61,7 +61,7 @@ export class Tag {
   onKeyDown(event) {
     switch (event.key) {
       case 'Backspace':
-        this.removeTag();
+        this.removeTag(event);
         event.preventDefault();
         break;
     }
@@ -72,12 +72,13 @@ export class Tag {
     this.tagContainer.focus();
   }
 
-  removeTag = (): void => {
+  removeTag = (e): void => {
     if (this.disabled || !this.closable) {
       return;
     }
     const { value, text } = this;
     this.fwClosed.emit({ value, text });
+    e.stopPropagation();
   };
 
   renderContent() {
@@ -111,7 +112,7 @@ export class Tag {
             class={`remove-btn ${this.variant} ${
               this.disabled ? 'disabled' : ''
             }`}
-            onClick={() => this.removeTag()}
+            onClick={(e) => this.removeTag(e)}
             onKeyDown={handleKeyDown(this.removeTag)}
           >
             <fw-icon name='cross' size={8} library='system'></fw-icon>


### PR DESCRIPTION
Prevents the popup from opening on deleting the tag in multi-select
Before: 
https://user-images.githubusercontent.com/64781864/159431810-3538f143-8df0-4c00-b75a-520af325ed7e.mov

After:
https://user-images.githubusercontent.com/64781864/159431798-eb115718-8e60-4252-bbe9-fc5bbc762477.mov

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
