### PR TITLE
feat(fw-accordion-header): added prop for different icon size

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -31,6 +31,10 @@ export namespace Components {
     }
     interface FwAccordionTitle {
         "expanded": boolean;
+        /**
+          * The size of the default icon
+         */
+        "iconSize": 'small' | 'medium' | 'large';
         "toggleState": any;
         /**
           * Truncate title on text overflow
@@ -2258,6 +2262,10 @@ declare namespace LocalJSX {
     }
     interface FwAccordionTitle {
         "expanded"?: boolean;
+        /**
+          * The size of the default icon
+         */
+        "iconSize"?: 'small' | 'medium' | 'large';
         "toggleState"?: any;
         /**
           * Truncate title on text overflow

--- a/packages/crayons-core/src/components/accordion-title/accordion-title.tsx
+++ b/packages/crayons-core/src/components/accordion-title/accordion-title.tsx
@@ -1,15 +1,26 @@
 import { Component, Prop, Element, h } from '@stencil/core';
 import { handleKeyDown } from '../../utils';
 
-const ChevronArrow = ({ expanded }) => {
-  const iconSize = 14;
+const ChevronArrow = ({ expanded, iconSize }) => {
+  let size;
+  switch (iconSize) {
+    case 'small':
+      size = 7;
+      break;
+    case 'medium':
+      size = 10;
+      break;
+    case 'large':
+      size = 14;
+      break;
+  }
   const direction = expanded ? 'up' : 'down';
 
   return (
     <fw-icon
       class='accordion-icon'
       name={`chevron-${direction}`}
-      size={iconSize}
+      size={size}
       library='system'
     />
   );
@@ -43,6 +54,11 @@ export class AccordionTitle {
    * Truncate title on text overflow
    */
   @Prop() truncateOnOverflow = true;
+
+  /**
+   * The size of the default icon
+   */
+  @Prop() iconSize: 'small' | 'medium' | 'large' = 'medium';
 
   expandedIcon: HTMLElement;
   collapsedIcon: HTMLElement;
@@ -83,7 +99,7 @@ export class AccordionTitle {
             <slot name={this.expanded ? 'expanded-icon' : 'collapsed-icon'} />
           </div>
         ) : (
-          <ChevronArrow expanded={this.expanded} />
+          <ChevronArrow expanded={this.expanded} iconSize={this.iconSize} />
         )}
       </div>
     );

--- a/packages/crayons-core/src/components/accordion-title/readme.md
+++ b/packages/crayons-core/src/components/accordion-title/readme.md
@@ -7,9 +7,10 @@ Displays the content inside the component.
 
 ## Properties
 
-| Property             | Attribute              | Description                     | Type      | Default |
-| -------------------- | ---------------------- | ------------------------------- | --------- | ------- |
-| `truncateOnOverflow` | `truncate-on-overflow` | Truncate title on text overflow | `boolean` | `true`  |
+| Property             | Attribute              | Description                     | Type                             | Default    |
+| -------------------- | ---------------------- | ------------------------------- | -------------------------------- | ---------- |
+| `iconSize`           | `icon-size`            | The size of the default icon    | `"large" \| "medium" \| "small"` | `'medium'` |
+| `truncateOnOverflow` | `truncate-on-overflow` | Truncate title on text overflow | `boolean`                        | `true`     |
 
 
 ## CSS Custom Properties

--- a/packages/crayons-core/src/components/accordion/readme.md
+++ b/packages/crayons-core/src/components/accordion/readme.md
@@ -22,6 +22,52 @@ fw-accordion displays a collapsible accordion component, which expands/collapses
 </fw-accordion>
 ```
 
+### Accordion Title icon size
+
+```html live
+<fw-accordion>
+  <fw-accordion-title icon-size="small">Header Text</fw-accordion-title>
+  <fw-accordion-body>
+    Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+    Lorem Ipsum has been the industry's standard dummy text ever since the
+    1500s, when an unknown printer took a galley of type and scrambled it to
+    make a type specimen book. It has survived not only five centuries, but also
+    the leap into electronic typesetting, remaining essentially unchanged. It
+    was popularised in the 1960s with the release of Letraset sheets containing
+    Lorem Ipsum passages, and more recently with desktop publishing software
+    like Aldus PageMaker including versions of Lorem Ipsum
+  </fw-accordion-body>
+</fw-accordion>
+<br />
+<fw-accordion>
+  <fw-accordion-title>Header Text</fw-accordion-title>
+  <fw-accordion-body>
+    Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+    Lorem Ipsum has been the industry's standard dummy text ever since the
+    1500s, when an unknown printer took a galley of type and scrambled it to
+    make a type specimen book. It has survived not only five centuries, but also
+    the leap into electronic typesetting, remaining essentially unchanged. It
+    was popularised in the 1960s with the release of Letraset sheets containing
+    Lorem Ipsum passages, and more recently with desktop publishing software
+    like Aldus PageMaker including versions of Lorem Ipsum
+  </fw-accordion-body>
+</fw-accordion>
+<br />
+<fw-accordion>
+  <fw-accordion-title icon-size="large">Header Text</fw-accordion-title>
+  <fw-accordion-body>
+    Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+    Lorem Ipsum has been the industry's standard dummy text ever since the
+    1500s, when an unknown printer took a galley of type and scrambled it to
+    make a type specimen book. It has survived not only five centuries, but also
+    the leap into electronic typesetting, remaining essentially unchanged. It
+    was popularised in the 1960s with the release of Letraset sheets containing
+    Lorem Ipsum passages, and more recently with desktop publishing software
+    like Aldus PageMaker including versions of Lorem Ipsum
+  </fw-accordion-body>
+</fw-accordion>
+```
+
 ### Accordion with custom toggle icons
 
 ```html live


### PR DESCRIPTION
## Description:

Added 3 variation of the accordion-header icon size
<img width="784" alt="Screenshot 2022-03-22 at 3 51 00 PM" src="https://user-images.githubusercontent.com/64781864/159461083-03e4bd75-1648-4164-8069-8e2d981abfb1.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
