### PR TITLE
fix(fw-select): handled the empty text scenario in dynamic select

### DIFF
--- a/packages/crayons-core/src/components/options-list/list-options.tsx
+++ b/packages/crayons-core/src/components/options-list/list-options.tsx
@@ -35,7 +35,7 @@ export class ListOptions {
       const filteredValue =
         value !== ''
           ? dataSource.filter((option) =>
-              option.text.toLowerCase().includes(value)
+              option.text.toLowerCase().includes(value.toLowerCase())
             )
           : dataSource;
       resolve(filteredValue);
@@ -295,15 +295,23 @@ export class ListOptions {
     (filterText) => {
       this.isLoading = true;
       this.fwLoading.emit({ isLoading: this.isLoading });
-      this.search(filterText, this.selectOptions).then((options) => {
+      if (filterText) {
+        this.search(filterText, this.selectOptions).then((options) => {
+          this.filteredOptions =
+            options?.length > 0
+              ? this.serializeData(options)
+              : [{ text: this.notFoundText, disabled: true }];
+          this.isLoading = false;
+          this.fwLoading.emit({ isLoading: this.isLoading });
+        });
+      } else {
         this.filteredOptions =
-          options?.length > 0
-            ? this.serializeData(options)
-            : [{ text: this.notFoundText, disabled: true }];
-
+          this.selectOptions?.length > 0
+            ? this.selectOptions
+            : [{ text: this.noDataText, disabled: true }];
         this.isLoading = false;
         this.fwLoading.emit({ isLoading: this.isLoading });
-      });
+      }
     },
     this,
     this.debounceTimer

--- a/packages/crayons-core/src/components/select/select.tsx
+++ b/packages/crayons-core/src/components/select/select.tsx
@@ -417,8 +417,8 @@ export class Select {
   }
 
   onInput() {
+    this.searchValue = this.selectInput.value;
     if (this.selectInput.value) {
-      this.searchValue = this.selectInput.value.toLowerCase();
       this.variant !== 'mail' && this.openDropdown();
     } else {
       this.variant === 'mail' && this.closeDropdown();


### PR DESCRIPTION
## Description:
When the user searches for a value and removes the searched value the popup will have the last showed options, it won't reset the filter and show 'notFoundText' instead of 'noDataText' - Fixed this issue
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
