### PR TITLE
fix(data-table): checkbox breaking word for overflowing text

### DIFF
--- a/packages/crayons-core/src/components/data-table/data-table.scss
+++ b/packages/crayons-core/src/components/data-table/data-table.scss
@@ -59,6 +59,7 @@ div.fw-data-table-container {
             min-width: 40px;
             max-width: 1000px;
             background: $grid-header-bg;
+            overflow-wrap: break-word;
 
             &:first-of-type {
               padding-left: 16px;
@@ -119,6 +120,7 @@ div.fw-data-table-container {
             box-sizing: border-box;
             z-index: 0;
             height: 64px;
+            overflow-wrap: break-word;
 
             &.data-grid-checkbox {
               text-align: center;
@@ -314,6 +316,7 @@ div.fw-data-table-container {
             display: flex;
             flex-direction: column;
             flex-grow: 1;
+            width: 220px;
 
             .table-settings-content-title {
               box-sizing: border-box;
@@ -339,6 +342,11 @@ div.fw-data-table-container {
 
                 div {
                   margin: 5px 0px;
+
+                  fw-checkbox {
+                    width: 100%;
+                    overflow-wrap: break-word;
+                  }
                 }
               }
             }


### PR DESCRIPTION
Issue:
Checkbox text when it has a longer word, does not wrap as expected.

Fix: 
Adding 'overflow-wrap: break-word' property to get results as expected.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome, Firefox, Safari browsers.
