### PR TITLE
fix(checkbox): handle checkbox label alignment if spanned multiple lines

### DIFF
--- a/packages/crayons-core/src/components/checkbox/checkbox.scss
+++ b/packages/crayons-core/src/components/checkbox/checkbox.scss
@@ -106,6 +106,8 @@ input[type='checkbox'] {
 
     #label {
       padding-left: 22px;
+      box-decoration-break: clone;
+      -webkit-box-decoration-break: clone;
 
       &.required::after {
         content: '*';


### PR DESCRIPTION
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Reference: https://developer.mozilla.org/en-US/docs/Web/CSS/box-decoration-break