### PR TITLE
fix(data-table): removing popper instance once table is removed from dom

### DIFF
--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -241,6 +241,10 @@ export class DataTable {
     }
   }
 
+  disconnectedCallback() {
+    this.popperInstance?.destroy();
+  }
+
   /**
    * keyDownHandler
    * @param event


### PR DESCRIPTION
Issue:
When Datatable is removed from DOM, popperInstance was not destroyed. Popper instance was firing forUpdates on page actions like resize on an element that was not available in DOM.

Fix:
Destroy popperInstance on disconnectedCallback.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome browser.
