### PR TITLE
fix(fw-button): added disabled border for secondary button

### DIFF
--- a/packages/crayons-core/src/components/button-group/readme.md
+++ b/packages/crayons-core/src/components/button-group/readme.md
@@ -1,24 +1,34 @@
 # Button Group (fw-button-group)
+
 Button groups can be used to group related buttons into sections.
+
 ## Demo
-``` html live
+
+```html live
 <section>
-<fw-button-group label="Test">
-    <fw-button>Replace</fw-button>
-    <fw-button>Modify</fw-button>
-    <fw-button>Cancel</fw-button>
+  <fw-button-group label="Test">
+    <fw-button color="secondary">Replace</fw-button>
+    <fw-button color="secondary">Modify</fw-button>
+    <fw-button color="secondary">Cancel</fw-button>
   </fw-button-group>
-  </section>
-  <br/>
+</section>
+<br />
 
 <section>
-    <fw-button-group label="Test">
-    <fw-button id="b1" size="icon" color="secondary"><fw-icon name="reply" color="black" ></fw-icon> </fw-button>
-    <fw-button id="b2" size="icon" color="secondary"><fw-icon name="chat-online" color="black" ></fw-icon> </fw-button>
-    <fw-button id="b3" size="icon" color="secondary"><fw-icon name="more-horizontal" color="black" ></fw-icon> </fw-button>
+  <fw-button-group label="Test">
+    <fw-button id="b1" size="icon" color="secondary"
+      ><fw-icon name="reply" color="black"></fw-icon>
+    </fw-button>
+    <fw-button id="b2" size="icon" color="secondary"
+      ><fw-icon name="chat-online" color="black"></fw-icon>
+    </fw-button>
+    <fw-button id="b3" size="icon" color="secondary"
+      ><fw-icon name="more-horizontal" color="black"></fw-icon>
+    </fw-button>
   </fw-button-group>
 </section>
 ```
+
 ## Usage
 
 <code-group>
@@ -26,9 +36,9 @@ Button groups can be used to group related buttons into sections.
 ```html
 <section>
 <fw-button-group label="Test">
-    <fw-button>Replace</fw-button>
-    <fw-button>Modify</fw-button>
-    <fw-button>Cancel</fw-button>
+    <fw-button color="secondary">Replace</fw-button>
+    <fw-button color="secondary">Modify</fw-button>
+    <fw-button color="secondary">Cancel</fw-button>
   </fw-button-group>
   </section>
 <br/>
@@ -66,8 +76,6 @@ function App() {
 ```
 </code-block>
 </code-group>
-
-
 
 <!-- Auto Generated Below -->
 

--- a/packages/crayons-core/src/components/button/button.scss
+++ b/packages/crayons-core/src/components/button/button.scss
@@ -88,6 +88,8 @@ $input-height-mini: 16px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    display: flex;
+    align-items: center;
   }
 
   &:active:not(.fw-btn--loading) {

--- a/packages/crayons-core/src/components/button/button.scss
+++ b/packages/crayons-core/src/components/button/button.scss
@@ -20,6 +20,7 @@ $btn-secondary-bg-dark: $color-smoke-25;
 $btn-secondary-border: $border-color;
 $btn-secondary-border-active: $color-smoke-50;
 $btn-secondary-disabled-bg: $color-smoke-50;
+$btn-secondary-disabled-bg-dark: $color-smoke-100;
 $btn-secondary-disabled-color: $color-smoke-300;
 
 $btn-danger-color: $color-milk;
@@ -158,7 +159,7 @@ $input-height-mini: 16px;
     &.disabled,
     &[disabled] {
       background: $btn-secondary-disabled-bg;
-      border-color: $btn-secondary-disabled-bg;
+      border-color: $btn-secondary-disabled-bg-dark;
       color: $btn-secondary-disabled-color;
     }
   }

--- a/packages/crayons-core/src/components/button/readme.md
+++ b/packages/crayons-core/src/components/button/readme.md
@@ -18,7 +18,6 @@ fw-button displays a button on the user interface and enables performing specifi
 
 <section>
   <fw-label value="Try sizes"></fw-label>
-  <fw-button size="mini" color="secondary"> Mini </fw-button>
   <fw-button size="small"> Small </fw-button>
   <fw-button> Default </fw-button>
 </section>
@@ -27,10 +26,10 @@ fw-button displays a button on the user interface and enables performing specifi
 <section>
   <fw-label value="Try icon buttons"></fw-label>
   <fw-button size="icon"
-    ><fw-icon name="agent" color="white"></fw-icon>
+    ><fw-icon name="agent" size="20" color="white"></fw-icon>
   </fw-button>
   <fw-button size="icon" color="secondary"
-    ><fw-icon name="phone"></fw-icon>
+    ><fw-icon name="phone" size="20"></fw-icon>
   </fw-button>
 </section>
 <br />
@@ -38,12 +37,12 @@ fw-button displays a button on the user interface and enables performing specifi
 <section>
   <fw-label value="Caret with icon"></fw-label>
   <fw-button show-caret-icon>
-    <fw-icon name="calendar-time" slot="before-label"></fw-icon>
+    <fw-icon name="calendar-time" size="16" slot="before-label"></fw-icon>
     Select date
   </fw-button>
 
   <fw-button color="link" show-caret-icon>
-    <fw-icon name="calendar-time" slot="before-label"></fw-icon>
+    <fw-icon name="calendar-time" size="16" slot="before-label"></fw-icon>
     Select date
   </fw-button>
 </section>
@@ -69,21 +68,13 @@ fw-button displays a button on the user interface and enables performing specifi
     value="Try icon + text buttons Buttons with before-label and after-label"
   ></fw-label>
   <fw-button color="secondary">
-    <fw-icon slot="before-label" name="delete"></fw-icon>
+    <fw-icon slot="before-label" size="16" name="delete"></fw-icon>
     <span>Delete</span>
   </fw-button>
   <fw-button color="primary">
     <span>Copy</span>
-    <fw-icon name="code" slot="after-label"></fw-icon>
+    <fw-icon name="code" size="16" slot="after-label"></fw-icon>
   </fw-button>
-</section>
-<br />
-
-<section>
-  <fw-label value="Try full length"></fw-label>
-  <fw-button color="secondary" size="small" style="display: block;"
-    >Span full-width</fw-button
-  >
 </section>
 <br />
 ```
@@ -106,7 +97,6 @@ fw-button displays a button on the user interface and enables performing specifi
 
 <section>
   <fw-label value="Try sizes"></fw-label>
-  <fw-button size="mini" color="secondary"> Mini </fw-button>
   <fw-button size="small"> Small </fw-button>
   <fw-button> Default </fw-button>
 </section>
@@ -115,10 +105,10 @@ fw-button displays a button on the user interface and enables performing specifi
 <section>
   <fw-label value="Try icon buttons"></fw-label>
   <fw-button size="icon"
-    ><fw-icon name="agent" color="white" ></fw-icon>
+    ><fw-icon name="agent" size="20" color="white"></fw-icon>
   </fw-button>
   <fw-button size="icon" color="secondary"
-    ><fw-icon name="phone" ></fw-icon>
+    ><fw-icon name="phone" size="20"></fw-icon>
   </fw-button>
 </section>
 <br />
@@ -126,12 +116,12 @@ fw-button displays a button on the user interface and enables performing specifi
 <section>
   <fw-label value="Caret with icon"></fw-label>
   <fw-button show-caret-icon>
-    <fw-icon name="calendar-time" slot="before-label" ></fw-icon>
+    <fw-icon name="calendar-time" size="16" slot="before-label"></fw-icon>
     Select date
   </fw-button>
 
   <fw-button color="link" show-caret-icon>
-    <fw-icon name="calendar-time" slot="before-label" ></fw-icon>
+    <fw-icon name="calendar-time" size="16" slot="before-label"></fw-icon>
     Select date
   </fw-button>
 </section>
@@ -151,24 +141,19 @@ fw-button displays a button on the user interface and enables performing specifi
   <fw-button disabled color="secondary"> OK </fw-button>
   <fw-button disabled color="danger"> Don't Click </fw-button>
 </section>
-<br />
 
 <section>
-  <fw-label value="Try icon + text buttons Buttons with before-label and after-label"></fw-label>
+  <fw-label
+    value="Try icon + text buttons Buttons with before-label and after-label"
+  ></fw-label>
   <fw-button color="secondary">
-    <fw-icon slot="before-label" name="delete" ></fw-icon>
+    <fw-icon slot="before-label" size="16" name="delete"></fw-icon>
     <span>Delete</span>
   </fw-button>
   <fw-button color="primary">
     <span>Copy</span>
-    <fw-icon name="code" slot="after-label" ></fw-icon>
+    <fw-icon name="code" size="16" slot="after-label"></fw-icon>
   </fw-button>
-</section>
-<br />
-
-<section>
-  <fw-label value="Try full length"></fw-label>
-  <fw-button color="secondary" size="small" style="display: block;">Span full-width</fw-button>
 </section>
 ```
 </code-block>

--- a/packages/crayons-core/src/components/input/input.scss
+++ b/packages/crayons-core/src/components/input/input.scss
@@ -138,15 +138,14 @@ $warning-color: $color-casablanca-300;
   }
   &:hover {
     border: 1px $input-hover-color solid;
-    transition: 0.2s linear;
   }
 
   &.has-focus {
     outline: none;
     background: $input-bg;
     background-color: $app-light-bg;
-    border: 1px solid transparent;
-    box-shadow: 0 0 0 2px $input-focus-color;
+    border: 1px solid $input-focus-color;
+    box-shadow: 0 0 0 1px $input-focus-color;
   }
 
   &.disabled {


### PR DESCRIPTION
## Description:
added disabled border for secondary button

<img width="1205" alt="Screenshot 2022-03-31 at 11 37 18 AM" src="https://user-images.githubusercontent.com/64781864/161010384-8ed72610-7cdc-4bf3-9f71-09744e98f2d1.png">

vertical aligned the icons button

<img width="1205" alt="Screenshot 2022-03-31 at 12 03 52 PM" src="https://user-images.githubusercontent.com/64781864/161010382-25763f0d-2e6d-4c33-b97f-0791bde35073.png">

replace primary with secondary buttons based on UX suggestion

<img width="867" alt="Screenshot 2022-03-31 at 12 33 51 PM" src="https://user-images.githubusercontent.com/64781864/161010356-753cd53b-e2ff-4a0c-a5c6-5ac14730b9ae.png">

Based on the UX suggestion modified icon size and removed min, full width buttons from docs

<img width="867" alt="Screenshot 2022-03-31 at 12 21 40 PM" src="https://user-images.githubusercontent.com/64781864/161010369-a177392a-31d9-4d77-97ed-5b31717f95fc.png">

Removed focus animation for input

https://user-images.githubusercontent.com/64781864/161011004-eb3134ca-4b68-4a11-9dea-e238d2cb9224.mov


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
