### PR TITLE
fix(data-table): removing extra space from last rowActions button

### DIFF
--- a/packages/crayons-core/src/components/data-table/data-table.scss
+++ b/packages/crayons-core/src/components/data-table/data-table.scss
@@ -156,6 +156,10 @@ div.fw-data-table-container {
             & fw-button {
               margin-right: 5px;
             }
+
+            & fw-button:last-child {
+              margin-right: 0px;
+            }
           }
 
           td.hidden {


### PR DESCRIPTION
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome.
