### PR TITLE
fix(data-table): wrapping text in column when single word is big

### DIFF
--- a/packages/crayons-core/src/components/data-table/data-table.scss
+++ b/packages/crayons-core/src/components/data-table/data-table.scss
@@ -59,7 +59,9 @@ div.fw-data-table-container {
             min-width: 40px;
             max-width: 1000px;
             background: $grid-header-bg;
-            overflow-wrap: break-word;
+            word-wrap: break-word;
+            word-break: break-all;
+            white-space: normal;
 
             &:first-of-type {
               padding-left: 16px;
@@ -120,7 +122,9 @@ div.fw-data-table-container {
             box-sizing: border-box;
             z-index: 0;
             height: 64px;
-            overflow-wrap: break-word;
+            word-wrap: break-word;
+            word-break: break-all;
+            white-space: normal;
 
             &.data-grid-checkbox {
               text-align: center;
@@ -157,7 +161,7 @@ div.fw-data-table-container {
               margin-right: 5px;
             }
 
-            & fw-button:last-child {
+            & fw-tooltip:last-child fw-button {
               margin-right: 0px;
             }
           }
@@ -347,6 +351,7 @@ div.fw-data-table-container {
                 flex-direction: column;
                 overflow-y: auto;
                 padding-left: 5px;
+                padding-right: 5px;
 
                 div {
                   margin: 5px 0px;


### PR DESCRIPTION
<img width="1438" alt="Screenshot 2022-04-01 at 12 41 13 PM" src="https://user-images.githubusercontent.com/61269786/161213580-2753cecd-c6b3-4377-a9e6-535dd3dfa9e2.png">

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome browser.
