### PR TITLE
feat(tabs): adding necessary css variables to theme tabs

### DIFF
--- a/packages/crayons-core/src/components/tab/tab.scss
+++ b/packages/crayons-core/src/components/tab/tab.scss
@@ -3,24 +3,30 @@
   white-space: nowrap;
   cursor: pointer;
   align-items: center;
-  padding: 10px 8px;
+  padding: var(--fw-tab-padding-tb, 10px) var(--fw-tab-padding-lr, 8px);
   line-height: 20px;
-  color: $color-smoke-700;
+  color: var(--fw-tab-color, $palette-secondary-700);
   font-size: $font-size-14;
-  font-weight: $font-weight-400;
-  margin: 0 4px;
+  font-weight: var(--fw-tab-weight, $font-weight-400);
+  margin: var(--fw-tab-margin-tb, 0px) var(--fw-tab-margin-lr, 4px);
+  border-radius: var(--fw-tab-top-radius, 0px) var(--fw-tab-top-radius, 0px) 0px
+    0px;
+  background: var(--fw-tab-background, transparent);
+  padding-bottom: var(--fw-tab-padding-tb, 8px);
+  border-bottom: 2px solid var(--fw-tab-border, transparent);
 
   /* stylelint-disable */
   &:hover:not(.disabled) {
-    padding-bottom: 8px;
-    border-bottom: 2px solid $color-smoke-300;
+    padding-bottom: var(--fw-tab-padding-tb, 8px);
+    border-bottom: 2px solid var(--fw-tab-border-hover, $palette-secondary-300);
   }
 
   &.active:not(.disabled) {
-    padding-bottom: 8px;
-    border-bottom: 2px solid $color-azure-800;
-    color: $color-azure-800;
-    font-weight: $font-weight-600;
+    padding-bottom: var(--fw-tab-padding-tb, 8px);
+    border-bottom: 2px solid var(--fw-tab-border-active, $palette-info-500);
+    color: var(--fw-tab-color-active, $palette-info-500);
+    font-weight: var(--fw-tab-weight-active, $font-weight-600);
+    background: var(--fw-tab-background-active, transparent);
   }
 
   &.disabled {

--- a/packages/crayons-core/src/components/tab/tab.scss
+++ b/packages/crayons-core/src/components/tab/tab.scss
@@ -1,3 +1,20 @@
+/**
+  @prop --fw-tab-padding-tb: padding top/bottom for tab item.
+  @prop --fw-tab-padding-lr: padding left/right for the tab item.
+  @prop --fw-tab-color: color of the text inside tab.
+  @prop --fw-tab-weight: font weight of the text inside tab.
+  @prop --fw-tab-weight-active: font weight of the text inside tab when tab is active.
+  @prop --fw-tab-margin-tb: margin top/bottom of the tab item.
+  @prop --fw-tab-margin-lr: margin left-right of the tab item.
+  @prop --fw-tab-top-radius: top left/right radius of the tab item.
+  @prop --fw-tab-background: background color of the tab item.
+  @prop --fw-tab-background-active: background of the tab item when tab is active.
+  @prop --fw-tab-border-color: border color of the tab item.
+  @prop --fw-tab-border-color-hover: border color of the tab item on hover.
+  @prop --fw-tab-border-color-active: border color of the tab item when tab is active.
+  @prop --fw-tab-color-active: color of the text inside tab when tab is active.
+*/
+
 .tab {
   display: inline-flex;
   white-space: nowrap;
@@ -13,17 +30,17 @@
     0px;
   background: var(--fw-tab-background, transparent);
   padding-bottom: var(--fw-tab-padding-tb, 8px);
-  border-bottom: 2px solid var(--fw-tab-border, transparent);
+  border-bottom: 2px solid var(--fw-tab-border-color, transparent);
 
   /* stylelint-disable */
   &:hover:not(.disabled) {
     padding-bottom: var(--fw-tab-padding-tb, 8px);
-    border-bottom: 2px solid var(--fw-tab-border-hover, $palette-secondary-300);
+    border-bottom: 2px solid var(--fw-tab-border-color-hover, $palette-secondary-300);
   }
 
   &.active:not(.disabled) {
     padding-bottom: var(--fw-tab-padding-tb, 8px);
-    border-bottom: 2px solid var(--fw-tab-border-active, $palette-info-500);
+    border-bottom: 2px solid var(--fw-tab-border-color-active, $palette-info-500);
     color: var(--fw-tab-color-active, $palette-info-500);
     font-weight: var(--fw-tab-weight-active, $font-weight-600);
     background: var(--fw-tab-background-active, transparent);

--- a/packages/crayons-core/src/components/tabs/tabs.scss
+++ b/packages/crayons-core/src/components/tabs/tabs.scss
@@ -1,8 +1,15 @@
 /**
   @prop --fw-tabs-width: width of the tab container.
   @prop --fw-tabs-height: height of the tab container.
-  @prop --fw-tabs-margin-lr: left margin for the tab items
-  @prop --fw-tabs-padding-lr: left padding for the tab items
+  @prop --fw-tabs-margin-l: left margin for the tab items
+  @prop --fw-tabs-margin-r: right margin for the tab items
+  @prop --fw-tabs-padding-left: left padding for the tab items
+  @prop --fw-tabs-padding-right: right padding for the tab items
+  @prop --fw-tabs-border-width: width of border separating tabs and the tab panel.
+  @prop --fw-tabs-border-color: color of border separating tabs and the tab panel.
+  @prop --fw-tabs-box-background: box variant background color.
+  @prop --fw-tabs-box-border-width: box variant tabs container border width.
+  @prop --fw-tabs-box-border-color: box variant tabs container border color.
 */
 
 .tabs {
@@ -13,10 +20,10 @@
 
   &__items__nav {
     padding: 0;
-    padding-left: var(--fw-tabs-padding-lr, 12px);
-    padding-right: var(--fw-tabs-padding-lr, 12px);
-    margin-left: var(--fw-tabs-margin-lr, 0);
-    margin-right: var(--fw-tabs-margin-lr, 0);
+    padding-left: var(--fw-tabs-padding-left, 12px);
+    padding-right: var(--fw-tabs-padding-right, 12px);
+    margin-left: var(--fw-tabs-margin-l, 0);
+    margin-right: var(--fw-tabs-margin-r, 0);
     display: flex;
     border-bottom: var(--fw-tabs-border-width, 1px) solid
       var(--fw-tabs-border-color, $palette-secondary-50);

--- a/packages/crayons-core/src/components/tabs/tabs.scss
+++ b/packages/crayons-core/src/components/tabs/tabs.scss
@@ -1,10 +1,8 @@
 /**
   @prop --fw-tabs-width: width of the tab container.
   @prop --fw-tabs-height: height of the tab container.
-  @prop --fw-tabs-margin-l: left margin for the tab items
-  @prop --fw-tabs-margin-r: right margin for the tab items
-  @prop --fw-tabs-padding-left: left padding for the tab items
-  @prop --fw-tabs-padding-right: right padding for the tab items
+  @prop --fw-tabs-margin-lr: left margin for the tab items
+  @prop --fw-tabs-padding-lr: left padding for the tab items
 */
 
 .tabs {
@@ -15,18 +13,20 @@
 
   &__items__nav {
     padding: 0;
-    padding-left: var(--fw-tabs-padding-left, 12px);
-    padding-right: var(--fw-tabs-padding-right, 12px);
-    margin-left: var(--fw-tabs-margin-l, 0);
-    margin-right: var(--fw-tabs-margin-r, 0);
+    padding-left: var(--fw-tabs-padding-lr, 12px);
+    padding-right: var(--fw-tabs-padding-lr, 12px);
+    margin-left: var(--fw-tabs-margin-lr, 0);
+    margin-right: var(--fw-tabs-margin-lr, 0);
     display: flex;
-    border-bottom: 1px solid $color-smoke-50;
+    border-bottom: var(--fw-tabs-border-width, 1px) solid
+      var(--fw-tabs-border-color, $palette-secondary-50);
     overflow-x: auto;
     overflow-y: hidden;
 
     &__box {
-      background-color: $app-header-bg-secondary;
-      border: 1px solid $color-smoke-50;
+      background-color: var(--fw-tabs-box-background, $app-header-bg-secondary);
+      border: var(--fw-tabs-box-border-width, 1px) solid
+        var(--fw-tabs-box-border-color, $palette-secondary-50);
       box-sizing: border-box;
       border-radius: $radius;
     }

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1,5 +1,6 @@
 @import 'variables';
 @import 'theme';
+@import 'theme.base';
 
 :host {
   font-family: $font-stack;


### PR DESCRIPTION
Current Implementation:
<img width="561" alt="Screenshot 2022-04-05 at 11 13 44 AM" src="https://user-images.githubusercontent.com/61269786/161686822-759b8bc7-8389-4a19-a2bd-f9cf3e8b82be.png">

After theming:
<img width="609" alt="Screenshot 2022-04-05 at 11 14 10 AM" src="https://user-images.githubusercontent.com/61269786/161686847-16f53909-3a8c-4033-8e79-3eec39cb2519.png">

Code:
```
body {
        --fw-tabs-padding-lr: 0px;
        --fw-tabs-border-width: 0px;
        --fw-tab-top-radius: 8px;
        --fw-tab-margin-lr: 0px;
        --fw-tab-padding-tb: 9px;
        --fw-tab-padding-lr: 10px;
        --fw-tab-border: #FFF;
        --fw-tab-border-hover: #FFF;
        --fw-tab-border-active: #EBEFF3;
        --fw-tab-color: #576C7D;
        --fw-tab-color-active: #384551;
        --fw-tab-background: #FFF;
        --fw-tab-background-active: #EBEFF3;
        --fw-tab-weight: 500;
        --fw-tab-weight-active: 500;
      }
```

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome.
