### PR TITLE
feat(data-table): retaining width for select column

### DIFF
--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -168,6 +168,11 @@ export class DataTable {
   @State() showShimmer = true;
 
   /**
+   * width of the columns is auto calculated as table width is lesser than container width.
+   */
+  @State() ifAutoCalculatedWidth = false;
+
+  /**
    * fwSelectionChange Emits this event when row is selected/unselected.
    */
   @Event() fwSelectionChange: EventEmitter;
@@ -200,6 +205,10 @@ export class DataTable {
   settings: HTMLElement = null;
 
   tableContainer: HTMLElement = null;
+
+  selectColumnHeader: HTMLElement = null;
+
+  lastColumnHeader: HTMLElement = null;
 
   /**
    * componentWillLoad lifecycle event
@@ -238,6 +247,19 @@ export class DataTable {
   componentDidRender() {
     if (this.renderPromiseResolve) {
       this.renderPromiseResolve();
+      this.renderPromiseResolve = null;
+    }
+    /**
+     * Hack to override table behaviour of expanding columns when total column with lesser than container width.
+     * Idea is to remove the width on the last column so that it occupies the rest of the space.
+     */
+    if (this.selectColumnHeader) {
+      if (
+        parseInt(window.getComputedStyle(this.selectColumnHeader).width) > 40 &&
+        !this.ifAutoCalculatedWidth
+      ) {
+        this.ifAutoCalculatedWidth = true;
+      }
     }
   }
 
@@ -592,6 +614,7 @@ export class DataTable {
       }
     }
     this.toggleSettings(false);
+    this.ifAutoCalculatedWidth = false;
   }
 
   /**
@@ -1111,10 +1134,19 @@ export class DataTable {
     const selectAllChecked =
       this.rows.length &&
       this.rows.every((row) => this.selected.includes(row.id));
+    const visibleColumns = this.orderedColumns.filter(
+      (column) => !column.hide && column.variant !== 'paragraph'
+    );
+    const lastVisibleColumnKey = visibleColumns[visibleColumns.length - 1]?.key;
     return this.orderedColumns.filter((column) => !column.hide).length ? (
       <tr role='row'>
         {this.orderedColumns.length && this.isSelectable && (
-          <th key='isSelectable' aria-colindex={1} style={{ width: '40px' }}>
+          <th
+            ref={(el) => (this.selectColumnHeader = el)}
+            key='isSelectable'
+            aria-colindex={1}
+            style={{ width: '40px' }}
+          >
             {this.isAllSelectable && (
               <fw-checkbox
                 id='select-all'
@@ -1140,9 +1172,19 @@ export class DataTable {
           }
           const headerStyles = Object.assign(
             {},
-            column.widthProperties ? column.widthProperties : {},
+            column.widthProperties &&
+              !(
+                column.key === lastVisibleColumnKey &&
+                this.ifAutoCalculatedWidth
+              )
+              ? column.widthProperties
+              : {},
             textAlign ? { textAlign } : {}
           );
+          const optionalAttrs: any = {};
+          if (column.key === lastVisibleColumnKey) {
+            optionalAttrs.ref = (el) => (this.lastColumnHeader = el);
+          }
           return (
             <th
               role='columnheader'
@@ -1152,6 +1194,7 @@ export class DataTable {
               }
               class={{ hidden: column.hide }}
               style={headerStyles}
+              {...optionalAttrs}
             >
               {column.text}
             </th>


### PR DESCRIPTION
Issue:
When width of columns is lesser than container space, table tends to auto computed width of columns to fit container. This is causing select column (with a fixed width in design) to expand too. 

Fix:
After render, check if select column width is auto computed. If so, manually remove last column width so that last column alone occupies entire table width.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome.
