### PR TITLE
fix(toast): breaking longer word to fit into the toast container

### DIFF
--- a/packages/crayons-core/src/components/modal/modal.scss
+++ b/packages/crayons-core/src/components/modal/modal.scss
@@ -26,6 +26,10 @@
   z-index: 999;
   animation: 'modal-entry' 0.5s 1;
 
+  overflow-wrap: break-word;
+  word-break: break-all;
+  white-space: normal;
+
   .modal-container {
     position: relative;
     width: 100%;

--- a/packages/crayons-core/src/components/toast-message/toast-message.scss
+++ b/packages/crayons-core/src/components/toast-message/toast-message.scss
@@ -25,6 +25,10 @@
   box-shadow: 0px 2px 4px rgba(18, 52, 77, 0.06),
     0px 2px 16px rgba(18, 52, 77, 0.16);
 
+  overflow-wrap: break-word;
+  word-break: break-all;
+  white-space: normal;
+
   &.success {
     border-top: 5px solid $color-jungle-500;
   }


### PR DESCRIPTION
Issue:
Longer word makes toast message go out of the toast container.

Fix:
Breaking the longer word to fit in the container.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome.
