### PR TITLE
fix(file-uploader): font weight on remove link on files list updated

### DIFF
--- a/packages/crayons-core/src/components/file-uploader/file/file-uploader-file.scss
+++ b/packages/crayons-core/src/components/file-uploader/file/file-uploader-file.scss
@@ -29,7 +29,7 @@
 
     &-remove {
       text-decoration: none;
-      font-weight: 400;
+      font-weight: 600;
       color: $color-azure-800;
       margin-top: 5px;
       font-size: 12px;


### PR DESCRIPTION
In File uploader component, Increasing the font-weight for remove link in files list on designer's suggestion.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome.
