### PR TITLE
fix(modal): adding overflow-wrap and break word properties for longer…

### DIFF
--- a/packages/crayons-core/src/components/data-table/data-table.scss
+++ b/packages/crayons-core/src/components/data-table/data-table.scss
@@ -59,8 +59,8 @@ div.fw-data-table-container {
             min-width: 40px;
             max-width: 1000px;
             background: $grid-header-bg;
-            word-wrap: break-word;
-            word-break: break-all;
+            overflow-wrap: anywhere;
+            word-break: break-word;
             white-space: normal;
 
             &:first-of-type {
@@ -122,8 +122,8 @@ div.fw-data-table-container {
             box-sizing: border-box;
             z-index: 0;
             height: 64px;
-            word-wrap: break-word;
-            word-break: break-all;
+            overflow-wrap: anywhere;
+            word-break: break-word;
             white-space: normal;
 
             &.data-grid-checkbox {

--- a/packages/crayons-core/src/components/modal/modal.scss
+++ b/packages/crayons-core/src/components/modal/modal.scss
@@ -26,8 +26,8 @@
   z-index: 999;
   animation: 'modal-entry' 0.5s 1;
 
-  overflow-wrap: break-word;
-  word-break: break-all;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   white-space: normal;
 
   .modal-container {

--- a/packages/crayons-core/src/components/toast-message/toast-message.scss
+++ b/packages/crayons-core/src/components/toast-message/toast-message.scss
@@ -25,8 +25,8 @@
   box-shadow: 0px 2px 4px rgba(18, 52, 77, 0.06),
     0px 2px 16px rgba(18, 52, 77, 0.16);
 
-  overflow-wrap: break-word;
-  word-break: break-all;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   white-space: normal;
 
   &.success {


### PR DESCRIPTION
… text

Issue: word-break: break-all seems to break a word when content overflows. This causes even small words like 'list' to break and appear in two lines. 

Fixes: Adding overflow-wrap: anywhere; seems to solve this issue. Smaller words appear in new line. Longer words start in a new-line and breaks into multiple lines.

overflow-wrap is standardized but unsupported in Safari, so adding word-break: break-word is added as a backup as this is supported across browsers even though it is deprecated.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome, Firefox and Safari.
