### PR TITLE
feat(data-table): adding collections variant to data table

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -153,6 +153,10 @@ export namespace Components {
         "href": string;
         "text": string;
     }
+    interface FwCustomCellCollection {
+        "collection": any[];
+        "show": number;
+    }
     interface FwCustomCellIcon {
         "color": string;
         "library": string;
@@ -1925,6 +1929,12 @@ declare global {
         prototype: HTMLFwCustomCellAnchorElement;
         new (): HTMLFwCustomCellAnchorElement;
     };
+    interface HTMLFwCustomCellCollectionElement extends Components.FwCustomCellCollection, HTMLStencilElement {
+    }
+    var HTMLFwCustomCellCollectionElement: {
+        prototype: HTMLFwCustomCellCollectionElement;
+        new (): HTMLFwCustomCellCollectionElement;
+    };
     interface HTMLFwCustomCellIconElement extends Components.FwCustomCellIcon, HTMLStencilElement {
     }
     var HTMLFwCustomCellIconElement: {
@@ -2216,6 +2226,7 @@ declare global {
         "fw-button-group": HTMLFwButtonGroupElement;
         "fw-checkbox": HTMLFwCheckboxElement;
         "fw-custom-cell-anchor": HTMLFwCustomCellAnchorElement;
+        "fw-custom-cell-collection": HTMLFwCustomCellCollectionElement;
         "fw-custom-cell-icon": HTMLFwCustomCellIconElement;
         "fw-custom-cell-paragraph": HTMLFwCustomCellParagraphElement;
         "fw-custom-cell-user": HTMLFwCustomCellUserElement;
@@ -2426,6 +2437,10 @@ declare namespace LocalJSX {
     interface FwCustomCellAnchor {
         "href"?: string;
         "text"?: string;
+    }
+    interface FwCustomCellCollection {
+        "collection"?: any[];
+        "show"?: number;
     }
     interface FwCustomCellIcon {
         "color"?: string;
@@ -4206,6 +4221,7 @@ declare namespace LocalJSX {
         "fw-button-group": FwButtonGroup;
         "fw-checkbox": FwCheckbox;
         "fw-custom-cell-anchor": FwCustomCellAnchor;
+        "fw-custom-cell-collection": FwCustomCellCollection;
         "fw-custom-cell-icon": FwCustomCellIcon;
         "fw-custom-cell-paragraph": FwCustomCellParagraph;
         "fw-custom-cell-user": FwCustomCellUser;
@@ -4267,6 +4283,7 @@ declare module "@stencil/core" {
             "fw-button-group": LocalJSX.FwButtonGroup & JSXBase.HTMLAttributes<HTMLFwButtonGroupElement>;
             "fw-checkbox": LocalJSX.FwCheckbox & JSXBase.HTMLAttributes<HTMLFwCheckboxElement>;
             "fw-custom-cell-anchor": LocalJSX.FwCustomCellAnchor & JSXBase.HTMLAttributes<HTMLFwCustomCellAnchorElement>;
+            "fw-custom-cell-collection": LocalJSX.FwCustomCellCollection & JSXBase.HTMLAttributes<HTMLFwCustomCellCollectionElement>;
             "fw-custom-cell-icon": LocalJSX.FwCustomCellIcon & JSXBase.HTMLAttributes<HTMLFwCustomCellIconElement>;
             "fw-custom-cell-paragraph": LocalJSX.FwCustomCellParagraph & JSXBase.HTMLAttributes<HTMLFwCustomCellParagraphElement>;
             "fw-custom-cell-user": LocalJSX.FwCustomCellUser & JSXBase.HTMLAttributes<HTMLFwCustomCellUserElement>;

--- a/packages/crayons-core/src/components/data-table/custom-cells/collection/custom-cell-collection.scss
+++ b/packages/crayons-core/src/components/data-table/custom-cells/collection/custom-cell-collection.scss
@@ -1,0 +1,10 @@
+.show-more {
+  color: $color-azure-800;
+  white-space: nowrap;
+  font-weight: 600;
+}
+
+.show-more:hover,
+.show-more:focus {
+  cursor: pointer;
+}

--- a/packages/crayons-core/src/components/data-table/custom-cells/collection/custom-cell-collection.tsx
+++ b/packages/crayons-core/src/components/data-table/custom-cells/collection/custom-cell-collection.tsx
@@ -1,0 +1,72 @@
+import { Component, h, Prop, State, Host, Element } from '@stencil/core';
+
+@Component({
+  tag: 'fw-custom-cell-collection',
+  styleUrl: 'custom-cell-collection.scss',
+  shadow: true,
+})
+export class CustomCellCollection {
+  @Element() el: HTMLElement;
+
+  @Prop() collection = [];
+
+  @Prop() show = 2;
+
+  @State() open = false;
+
+  showMoreButton = null;
+
+  toggleCollection() {
+    this.open = !this.open;
+  }
+
+  onFocus() {
+    if (this.showMoreButton) {
+      this.showMoreButton.focus();
+    } else {
+      this.el.parentElement.setAttribute('tabindex', '0');
+      this.el.parentElement.focus();
+    }
+  }
+
+  render() {
+    return (
+      <Host onFocus={() => this.onFocus()}>
+        <div>
+          {this.collection.length <= this.show ? (
+            <span>{this.collection.join(', ')}</span>
+          ) : (
+            <span>
+              <span>
+                {this.open
+                  ? this.collection.join(', ')
+                  : this.collection.slice(0, this.show).join(', ')}{' '}
+              </span>
+              {
+                // eslint-disable-next-line jsx-a11y/anchor-is-valid
+                <a
+                  class='show-more'
+                  role='button'
+                  tabIndex={0}
+                  onKeyUp={(event) => {
+                    if (event.code === 'Space' || event.code === 'Enter') {
+                      event.preventDefault();
+                      this.toggleCollection();
+                    }
+                  }}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    this.toggleCollection();
+                  }}
+                  ref={(el) => (this.showMoreButton = el)}
+                >
+                  {this.open ? 'show less' : 'show more'}
+                </a>
+              }
+            </span>
+          )}
+        </div>
+      </Host>
+    );
+  }
+}

--- a/packages/crayons-core/src/components/data-table/custom-cells/collection/custom-cell-collection.tsx
+++ b/packages/crayons-core/src/components/data-table/custom-cells/collection/custom-cell-collection.tsx
@@ -1,4 +1,5 @@
 import { Component, h, Prop, State, Host, Element } from '@stencil/core';
+import { TranslationController } from '../../../../global/Translation';
 
 @Component({
   tag: 'fw-custom-cell-collection',
@@ -60,7 +61,9 @@ export class CustomCellCollection {
                   }}
                   ref={(el) => (this.showMoreButton = el)}
                 >
-                  {this.open ? 'show less' : 'show more'}
+                  {this.open
+                    ? TranslationController.t('datatable.showLess')
+                    : TranslationController.t('datatable.showMore')}
                 </a>
               }
             </span>

--- a/packages/crayons-core/src/components/data-table/custom-cells/collection/readme.md
+++ b/packages/crayons-core/src/components/data-table/custom-cells/collection/readme.md
@@ -1,0 +1,31 @@
+# fw-custom-cell-collection
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property     | Attribute | Description | Type     | Default |
+| ------------ | --------- | ----------- | -------- | ------- |
+| `collection` | --        |             | `any[]`  | `[]`    |
+| `show`       | `show`    |             | `number` | `2`     |
+
+
+## Dependencies
+
+### Used by
+
+ - [fw-data-table](../..)
+
+### Graph
+```mermaid
+graph TD;
+  fw-data-table --> fw-custom-cell-collection
+  style fw-custom-cell-collection fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+Built with ❤ at Freshworks

--- a/packages/crayons-core/src/components/data-table/data-table.e2e.ts
+++ b/packages/crayons-core/src/components/data-table/data-table.e2e.ts
@@ -218,6 +218,12 @@ describe('fw-data-table', () => {
           position: 4,
           variant: 'paragraph',
         },
+        {
+          key: 'collection',
+          text: 'Collection',
+          position: 5,
+          variant: 'collection',
+        },
       ],
       rows: [
         {
@@ -230,6 +236,9 @@ describe('fw-data-table', () => {
           icon: { name: 'agent' },
           paragraph: {
             text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam eleifend mattis mattis. Curabitur accumsan in augue vel mollis. Fusce sagittis tincidunt augue, ut tempus erat condimentum finibus. Aliquam egestas lectus vel ligula egestas, sit amet lacinia nisl dapibus. Curabitur vestibulum nibh vel turpis posuere, a pellentesque magna gravida. Vestibulum imperdiet varius dui a fringilla. Nullam placerat tortor a nulla porta, eget vulputate justo facilisis. Curabitur cursus luctus mauris, ac mollis arcu posuere sit amet. Proin pulvinar blandit lorem, ac tempor purus suscipit id.',
+          },
+          collection: {
+            collection: ['Hotels', 'Bookings'],
           },
         },
       ],
@@ -248,10 +257,14 @@ describe('fw-data-table', () => {
     const paraComponent = await page.find(
       'fw-data-table >>> tbody > tr:first-child > td:nth-child(4) > fw-custom-cell-paragraph'
     );
+    const collectionComponent = await page.find(
+      'fw-data-table >>> tbody > tr:first-child > td:nth-child(5) > fw-custom-cell-collection'
+    );
     expect(anchorComponent).toBeTruthy();
     expect(userComponent).toBeTruthy();
     expect(iconComponent).toBeTruthy();
     expect(paraComponent).toBeTruthy();
+    expect(collectionComponent).toBeTruthy();
   });
 
   it('should align text in a column when textAlign is passed as a column configuration', async () => {

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -36,6 +36,10 @@ const PREDEFINED_VARIANTS_META: any = {
     componentName: 'fw-custom-cell-paragraph',
     isFocusable: true,
   },
+  collection: {
+    componentName: 'fw-custom-cell-collection',
+    isFocusable: true,
+  },
 };
 
 const TABLE_POPPER_CONFIG: any = {
@@ -1103,6 +1107,10 @@ export class DataTable {
     } else if (columnVariant === 'paragraph') {
       template = (
         <fw-custom-cell-paragraph {...cellValue}></fw-custom-cell-paragraph>
+      );
+    } else if (columnVariant === 'collection') {
+      template = (
+        <fw-custom-cell-collection {...cellValue}></fw-custom-cell-collection>
       );
     } else {
       template = null;

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -16,6 +16,7 @@ import {
   DataTableColumn,
   DataTableRow,
   DataTableAction,
+  VariantProperties,
 } from '../../utils/types';
 
 const PREDEFINED_VARIANTS_META: any = {
@@ -1096,21 +1097,47 @@ export class DataTable {
    * private
    * @returns {JSX.Element} returns jsx from a predefined set of components
    */
-  renderPredefinedVariant(columnVariant: string, cellValue: any) {
+  renderPredefinedVariant(
+    columnVariant: string,
+    cellValue: any,
+    variantProps: VariantProperties
+  ) {
     let template: JSX.Element;
+    const columnProps = variantProps ? variantProps : {};
     if (columnVariant === 'anchor') {
-      template = <fw-custom-cell-anchor {...cellValue}></fw-custom-cell-anchor>;
+      template = (
+        <fw-custom-cell-anchor
+          {...columnProps}
+          {...cellValue}
+        ></fw-custom-cell-anchor>
+      );
     } else if (columnVariant === 'user') {
-      template = <fw-custom-cell-user {...cellValue}></fw-custom-cell-user>;
+      template = (
+        <fw-custom-cell-user
+          {...columnProps}
+          {...cellValue}
+        ></fw-custom-cell-user>
+      );
     } else if (columnVariant === 'icon') {
-      template = <fw-custom-cell-icon {...cellValue}></fw-custom-cell-icon>;
+      template = (
+        <fw-custom-cell-icon
+          {...columnProps}
+          {...cellValue}
+        ></fw-custom-cell-icon>
+      );
     } else if (columnVariant === 'paragraph') {
       template = (
-        <fw-custom-cell-paragraph {...cellValue}></fw-custom-cell-paragraph>
+        <fw-custom-cell-paragraph
+          {...columnProps}
+          {...cellValue}
+        ></fw-custom-cell-paragraph>
       );
     } else if (columnVariant === 'collection') {
       template = (
-        <fw-custom-cell-collection {...cellValue}></fw-custom-cell-collection>
+        <fw-custom-cell-collection
+          {...columnProps}
+          {...cellValue}
+        ></fw-custom-cell-collection>
       );
     } else {
       template = null;
@@ -1125,7 +1152,11 @@ export class DataTable {
   renderTableCell(column: DataTableColumn, cellValue: any) {
     let template: JSX.Element;
     if (column.variant) {
-      template = this.renderPredefinedVariant(column.variant, cellValue);
+      template = this.renderPredefinedVariant(
+        column.variant,
+        cellValue,
+        column.variantProperties
+      );
     } else if (column.customTemplate) {
       template = this.renderCustomTemplate(column.customTemplate, cellValue);
     } else {

--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -1103,7 +1103,7 @@ export class DataTable {
     variantProps: VariantProperties
   ) {
     let template: JSX.Element;
-    const columnProps = variantProps ? variantProps : {};
+    const columnProps = variantProps ?? {};
     if (columnVariant === 'anchor') {
       template = (
         <fw-custom-cell-anchor

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -679,6 +679,9 @@ Row value for this column variant should be an object with the following propert
         "key": "related",
         "text": "Related Objects",
         "variant": "collection",
+        "variantProperties": {
+          "show": 2
+        },
         "widthProperties": {
           "width": "400px"
         },
@@ -692,7 +695,6 @@ Row value for this column variant should be an object with the following propert
         "objectname": "Library",
         "related": { 
           "collection": ["Books", "Authors", "Locations", "Tags"],
-          "show": 2
         },
         "count": 4
       }, {
@@ -727,6 +729,9 @@ Row value for this column variant should be an object with the following propert
       "key": "related",
       "text": "Related Objects",
       "variant": "collection",
+      "variantProperties": {
+        "show": 2
+      },
       "widthProperties": {
         "width": "400px"
       },
@@ -739,8 +744,7 @@ Row value for this column variant should be an object with the following propert
       "id": "0011",
       "objectname": "Library",
       "related": { 
-        "collection": ["Books", "Authors", "Locations", "Tags"],
-        "show": 2
+        "collection": ["Books", "Authors", "Locations", "Tags"]
       },
       "count": 4
     }, {
@@ -775,6 +779,9 @@ function App() {
       "key": "related",
       "text": "Related Objects",
       "variant": "collection",
+      "variantProperties": {
+        "show": 2
+      },
       "widthProperties": {
         "width": "400px"
       },
@@ -787,8 +794,7 @@ function App() {
       "id": "0011",
       "objectname": "Library",
       "related": { 
-        "collection": ["Books", "Authors", "Locations", "Tags"],
-        "show": 2
+        "collection": ["Books", "Authors", "Locations", "Tags"]
       },
       "count": 4
     }, {

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -658,6 +658,158 @@ function App() {
 </code-block>
 </code-group>
 
+
+#### Collection variant
+
+Row value for this column variant should be an object with the following properties:
+
+1. collection - Array of strings.
+2. show (optional) - Number of items to show from collection initially. Default value is 2.
+
+```html live
+  <fw-data-table id="datatable-33" label="Data table 33">
+  </fw-data-table>
+
+  <script type="application/javascript">
+    var data = {
+      columns: [{
+        "key": "objectname",
+        "text": "Object Name"
+      }, {
+        "key": "related",
+        "text": "Related Objects",
+        "variant": "collection",
+        "widthProperties": {
+          "width": "400px"
+        },
+      },
+      {
+        "key": "count",
+        "text": "Count"
+      }],
+      rows: [{
+        "id": "0011",
+        "objectname": "Library",
+        "related": { 
+          "collection": ["Books", "Authors", "Locations", "Tags"],
+          "show": 2
+        },
+        "count": 4
+      }, {
+        "id": "0022",
+        "objectname": "Hotel",
+        "related": {
+          "collection": ["Bookings", "Contacts"]
+        },
+        "count": 5
+      }]
+    }; 
+
+    var datatable = document.getElementById('datatable-33');
+    datatable.columns = data.columns;
+    datatable.rows = data.rows;
+  </script>
+```
+
+<code-group>
+<code-block title="HTML">
+```html 
+  <fw-data-table id="datatable-33" label="Data table 33">
+  </fw-data-table>
+```
+
+```javascript
+  var data = {
+    columns: [{
+      "key": "objectname",
+      "text": "Object Name"
+    }, {
+      "key": "related",
+      "text": "Related Objects",
+      "variant": "collection",
+      "widthProperties": {
+        "width": "400px"
+      },
+    },
+    {
+      "key": "count",
+      "text": "Count"
+    }],
+    rows: [{
+      "id": "0011",
+      "objectname": "Library",
+      "related": { 
+        "collection": ["Books", "Authors", "Locations", "Tags"],
+        "show": 2
+      },
+      "count": 4
+    }, {
+      "id": "0022",
+      "objectname": "Hotel",
+      "related": {
+        "collection": ["Bookings", "Contacts"]
+      },
+      "count": 5
+    }]
+  }; 
+
+  var datatable = document.getElementById('datatable-33');
+  datatable.columns = data.columns;
+  datatable.rows = data.rows;
+```
+</code-block>
+
+<code-block title="React">
+
+```jsx
+import React from "react";
+import ReactDOM from "react-dom";
+import { FwDataTable } from "@freshworks/crayons/react";
+function App() {
+
+  var data = {
+    columns: [{
+      "key": "objectname",
+      "text": "Object Name"
+    }, {
+      "key": "related",
+      "text": "Related Objects",
+      "variant": "collection",
+      "widthProperties": {
+        "width": "400px"
+      },
+    },
+    {
+      "key": "count",
+      "text": "Count"
+    }],
+    rows: [{
+      "id": "0011",
+      "objectname": "Library",
+      "related": { 
+        "collection": ["Books", "Authors", "Locations", "Tags"],
+        "show": 2
+      },
+      "count": 4
+    }, {
+      "id": "0022",
+      "objectname": "Hotel",
+      "related": {
+        "collection": ["Bookings", "Contacts"]
+      },
+      "count": 5
+    }]
+  }; 
+
+  return (
+    <FwDataTable columns={data.columns} rows={data.rows} label="Data Table 33">
+    </FwDataTable>
+  );
+}
+```
+</code-block>
+</code-group>
+
 ### Custom templates
 
 This codeblock shows how to use custom cell function to display HTML content in a cell.
@@ -1980,6 +2132,7 @@ Type: `Promise<DataTableColumn[]>`
 - [fw-custom-cell-user](./custom-cells/user)
 - [fw-custom-cell-icon](./custom-cells/icon)
 - [fw-custom-cell-paragraph](./custom-cells/paragraph)
+- [fw-custom-cell-collection](./custom-cells/collection)
 - [fw-checkbox](../checkbox)
 - [fw-tooltip](../tooltip)
 - [fw-button](../button)
@@ -1995,6 +2148,7 @@ graph TD;
   fw-data-table --> fw-custom-cell-user
   fw-data-table --> fw-custom-cell-icon
   fw-data-table --> fw-custom-cell-paragraph
+  fw-data-table --> fw-custom-cell-collection
   fw-data-table --> fw-checkbox
   fw-data-table --> fw-tooltip
   fw-data-table --> fw-button

--- a/packages/crayons-core/src/utils/types.ts
+++ b/packages/crayons-core/src/utils/types.ts
@@ -53,6 +53,10 @@ export type DataTableRow = {
   [prop: string]: any;
 };
 
+export type VariantProperties = {
+  [prop: string]: any;
+};
+
 export type customTemplateFunc<T> = (
   createElement: HyperFunc<T>,
   props: DataTableRow
@@ -62,6 +66,7 @@ export type DataTableColumn = {
   key: string;
   text: string;
   variant?: string;
+  variantProperties?: VariantProperties;
   position?: number;
   hide?: boolean;
   lock?: boolean;

--- a/packages/crayons-i18n/i18n/en-US.json
+++ b/packages/crayons-i18n/i18n/en-US.json
@@ -45,7 +45,9 @@
     "chooseColumns": "Choose columns",
     "actions": "Actions",
     "hide": "Hide",
-    "show": "Show"
+    "show": "Show",
+    "showMore": "show more",
+    "showLess": "show less"
   },
   "platformTable": {
     "delete": "Delete",


### PR DESCRIPTION
#### Feature of Data Table in this PR.

- Adding a new collections variant in fw-data-table component. 

```js
var dataTableColumns = [{
  "key": "related",
  "text": "Related Objects",
  "variant": "collection"
}];
```

#### Demo


https://user-images.githubusercontent.com/61269786/163340301-618770e3-b342-427d-add8-8461060b98a8.mov



#### Steps to run vuepress documentation:
- From root of project run npm run docs:dev
- Open the link that shows up in console after running above command.
- Navigate to DataTable component in sidebar



## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome browser.
