### PR TITLE
fix(modal): adding accessibility events when adding modal with isOpen…

### DIFF
--- a/packages/crayons-core/src/components/modal/modal.tsx
+++ b/packages/crayons-core/src/components/modal/modal.tsx
@@ -124,6 +124,10 @@ export class Modal {
    */
   modalContainer: HTMLElement = null;
 
+  /**
+   * private
+   * Handler to run on modal container opening
+   */
   modalContainerHandler = null;
 
   /**
@@ -132,6 +136,10 @@ export class Modal {
    */
   firstFocusableElement: HTMLElement = null;
 
+  /**
+   * private
+   * Handler to first focusable element. Focuses last element on tab for focus locking.
+   */
   firstFocusableElementHandler = null;
 
   /**
@@ -140,6 +148,10 @@ export class Modal {
    */
   lastFocusableElement: HTMLElement = null;
 
+  /**
+   * private
+   * Handler for last focusable element. Focus first element on shift+tab for focus locking.
+   */
   lastFocusableElementHandler = null;
 
   /**

--- a/packages/crayons-core/src/components/modal/modal.tsx
+++ b/packages/crayons-core/src/components/modal/modal.tsx
@@ -9,7 +9,7 @@ import {
   Watch,
   h,
 } from '@stencil/core';
-import { isFocusable } from '../../utils';
+import { getFocusableChildren } from '../../utils';
 import { i18n } from '../../global/Translation';
 
 @Component({
@@ -37,16 +37,6 @@ export class Modal {
    * Modal content element
    */
   @State() modalContent: HTMLFwModalContentElement;
-
-  /**
-   * Modal content element
-   */
-  @State() firstFocusElement: HTMLElement = null;
-
-  /**
-   * Modal content element
-   */
-  @State() lastFocusElement: HTMLElement = null;
 
   /**
    * Property to add or remove the top right close icon button
@@ -130,6 +120,36 @@ export class Modal {
 
   /**
    * private
+   * Modal container ref
+   */
+  modalContainer: HTMLElement = null;
+
+  modalContainerHandler = null;
+
+  /**
+   * private
+   * Modal first focus element
+   */
+  firstFocusableElement: HTMLElement = null;
+
+  firstFocusableElementHandler = null;
+
+  /**
+   * private
+   * Modal last focus element
+   */
+  lastFocusableElement: HTMLElement = null;
+
+  lastFocusableElementHandler = null;
+
+  /**
+   * private
+   * Modal element to focus on open
+   */
+  modalOpenFocusElement: HTMLElement = null;
+
+  /**
+   * private
    * flag to add events to elements only on initial modal load
    */
   accessibilityAdded = false;
@@ -193,6 +213,20 @@ export class Modal {
     }
   }
 
+  componentDidLoad() {
+    if (this.isOpen && !this.accessibilityAdded) {
+      document.body.style.overflow = 'hidden';
+      this.addAccesibilityEvents();
+    }
+  }
+
+  disconnectedCallback() {
+    if (this.isOpen) {
+      document.body.style.overflow = 'auto';
+      this.removeAccesibilityEvents();
+    }
+  }
+
   @Watch('isOpen')
   visibilityChange(open: boolean) {
     if (!open) {
@@ -249,53 +283,74 @@ export class Modal {
    * Major actions would be to focus-lock inside modal and to focus on close button when opening the component.
    */
   addAccesibilityEvents() {
-    if (!this.accessibilityAdded) {
-      /**
-       * Focus trapping inside Modal. Below function gets all focusable elements from the modal.
-       * These include elements inside shadow dom too.
-       */
-      const getFocuableChildren = (node: HTMLElement) => {
-        let focusableElements = [];
-        const getAllNodes = (element: any, root = true) => {
-          root && (focusableElements = []);
-          element = element.shadowRoot ? element.shadowRoot : element;
-          element.querySelectorAll('*').forEach((el: any) => {
-            if (isFocusable(el)) {
-              focusableElements.push(el);
-            } else if (el.nodeName === 'SLOT') {
-              el.assignedElements({ flatten: true }).forEach(
-                (assignedEl: HTMLElement) => getAllNodes(assignedEl, false)
-              );
-            } else if (el.shadowRoot) {
-              getAllNodes(el, false);
+    if (
+      !this.accessibilityAdded ||
+      !this.firstFocusableElement?.parentNode ||
+      !this.modalOpenFocusElement?.parentNode ||
+      !this.lastFocusableElement?.parentNode
+    ) {
+      this.modalContainerHandler &&
+        this.modalContainer.removeEventListener(
+          'animationend',
+          this.modalContainerHandler
+        );
+      this.modalContainerHandler = (() => {
+        this.firstFocusableElementHandler &&
+          this.firstFocusableElement.removeEventListener(
+            'keydown',
+            this.firstFocusableElementHandler
+          );
+        this.lastFocusableElementHandler &&
+          this.lastFocusableElement.removeEventListener(
+            'keydown',
+            this.lastFocusableElementHandler
+          );
+        /**
+         * Focus trapping inside Modal. Below function gets all focusable elements from the modal.
+         * These include elements inside shadow dom too.
+         */
+        const focusableElements = getFocusableChildren(this.el);
+        if (focusableElements.length) {
+          this.firstFocusableElement = focusableElements[0];
+          this.lastFocusableElement =
+            focusableElements[focusableElements.length - 1];
+          this.modalOpenFocusElement =
+            focusableElements.length > 1 &&
+            this.firstFocusableElement.classList.contains('close-btn')
+              ? focusableElements[1]
+              : this.firstFocusableElement;
+
+          this.lastFocusableElementHandler = ((e: any) => {
+            if (!e.shiftKey && e.keyCode === 9) {
+              e.preventDefault();
+              this.focusElement(this.firstFocusableElement);
             }
-          });
-        };
-        getAllNodes(node);
-        return focusableElements;
-      };
-      const focusableElements = getFocuableChildren(this.el);
-      if (focusableElements.length) {
-        this.firstFocusElement = focusableElements[0];
-        this.lastFocusElement = focusableElements[focusableElements.length - 1];
-        this.lastFocusElement.addEventListener('keydown', (e: any) => {
-          !e.shiftKey &&
-            e.keyCode === 9 &&
-            this.focusElement(this.firstFocusElement);
-        });
-        this.firstFocusElement.addEventListener('keydown', (e: any) => {
-          e.shiftKey &&
-            e.keyCode === 9 &&
-            this.focusElement(this.lastFocusElement);
-        });
-      }
-      if (this.firstFocusElement) {
-        const modalContainer = this.el.shadowRoot.querySelector('.modal');
-        modalContainer &&
-          modalContainer.addEventListener('animationend', () => {
-            this.isOpen && this.focusElement(this.firstFocusElement);
-          });
-      }
+          }).bind(this);
+          this.firstFocusableElementHandler = ((e: any) => {
+            if (e.shiftKey && e.keyCode === 9) {
+              e.preventDefault();
+              this.focusElement(this.lastFocusableElement);
+            }
+          }).bind(this);
+          this.lastFocusableElement.addEventListener(
+            'keydown',
+            this.lastFocusableElementHandler
+          );
+          this.firstFocusableElement.addEventListener(
+            'keydown',
+            this.firstFocusableElementHandler
+          );
+        }
+
+        if (this.isOpen && this.modalOpenFocusElement) {
+          this.focusElement(this.modalOpenFocusElement);
+        }
+      }).bind(this);
+      this.modalContainer &&
+        this.modalContainer.addEventListener(
+          'animationend',
+          this.modalContainerHandler
+        );
       this.accessibilityAdded = true;
     }
     this.escapeHandler = ((e: any) => {
@@ -317,13 +372,18 @@ export class Modal {
   }
 
   /**
-   * To apply focus to HTML elements after timeout to avoid focus changing issue.
-   * When adding focus to an element inside shadow dom, the focus seems to change. The timeout
-   * helps fix this issue.
    * @param element element to focus on
    */
-  focusElement(element: HTMLElement) {
-    setTimeout(() => element.focus(), 1);
+  focusElement(element) {
+    try {
+      if (element.setFocus) {
+        element.setFocus();
+      } else {
+        element.focus();
+      }
+    } catch (error) {
+      console.log(error);
+    }
   }
 
   /**
@@ -393,7 +453,11 @@ export class Modal {
           'slider': this.slider,
         }}
       >
-        <div class={{ modal: true, [this.size]: true }} aria-modal='true'>
+        <div
+          class={{ modal: true, [this.size]: true }}
+          aria-modal='true'
+          ref={(el) => (this.modalContainer = el)}
+        >
           {this.hasCloseIconButton && (
             <button class='close-btn' onClick={() => this.close()}>
               <fw-icon

--- a/packages/crayons-core/src/utils/index.ts
+++ b/packages/crayons-core/src/utils/index.ts
@@ -99,15 +99,17 @@ export const getFocusableChildren = (node: HTMLElement) => {
   const getAllNodes = (element: any, root = true) => {
     root && (focusableElements = []);
     element = element.shadowRoot ? element.shadowRoot : element;
-    element.querySelectorAll('*').forEach((el: any) => {
+    Array.from(element.children).forEach((el: any) => {
       if (isFocusable(el)) {
         focusableElements.push(el);
       } else if (el.nodeName === 'SLOT') {
         el.assignedElements({ flatten: true }).forEach(
           (assignedEl: HTMLElement) => getAllNodes(assignedEl, false)
         );
-      } else if (el.shadowRoot) {
-        getAllNodes(el, false);
+      } else if (el.children.length > 0 || el.shadowRoot) {
+        if (!(parseInt(el.getAttribute('tabindex')) < 0)) {
+          getAllNodes(el, false);
+        }
       }
     });
   };
@@ -116,12 +118,40 @@ export const getFocusableChildren = (node: HTMLElement) => {
 };
 
 export const isFocusable = (element) => {
-  if (element.tabIndex < 0) {
+  if (parseInt(element.getAttribute('tabindex')) < 0) {
     return false;
   }
   if (element.disabled) {
     return false;
   }
+  const boundingRect = element.getBoundingClientRect();
+  if (
+    boundingRect.bottom === 0 &&
+    boundingRect.top === 0 &&
+    boundingRect.left === 0 &&
+    boundingRect.right === 0 &&
+    boundingRect.height === 0 &&
+    boundingRect.width === 0 &&
+    boundingRect.x === 0 &&
+    boundingRect.y === 0
+  ) {
+    return false;
+  }
+  if (
+    element.style.display === 'none' ||
+    element.style.visibility === 'hidden' ||
+    element.style.opacity === 0
+  ) {
+    return false;
+  }
+  if (element.getAttribute('role') === 'button') {
+    return true;
+  }
+  // All crayons input components have this function.
+  if (element.setFocus) {
+    return true;
+  }
+  // To identify other native focus elements.
   switch (element.nodeName) {
     case 'A':
       return !!element.href && element.rel !== 'ignore';


### PR DESCRIPTION
… attribute set to true

On this PR, overall accessibility for modal component is improved.

Issues:
1. Accessibility events not added when fw-modal is added with is-open set to true. 
2. No inputs focused when modal opens.
3. Elements identified as focusable when parent element has tabindex of  '-1'.

Fixes:
1. Accessibility added on componentDidLoad when isOpen is true.
2. Identifying focusable elements/ adding necessary events on modal opening.
3. When parent element is of tabIndex -1 child elements are skipped as focusable elements.


## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome.
