### PR TITLE
fix(data-table): adding showmore/showless to paragraph variant

### DIFF
--- a/packages/crayons-core/src/components/data-table/custom-cells/paragraph/custom-cell-paragraph.scss
+++ b/packages/crayons-core/src/components/data-table/custom-cells/paragraph/custom-cell-paragraph.scss
@@ -7,32 +7,23 @@
     margin: 0px;
   }
 
-  .paragraph-text.open {
-    margin-bottom: 15px;
+  .paragraph-text.expanded {
+    display: inline;
   }
 
   .paragraph-toggle {
-    position: absolute;
-    display: block;
-    bottom: -19px;
-    right: 5px;
-    height: 15px;
+    display: inline;
     text-decoration: none;
-    background-color: $color-smoke-25;
-    // padding: 0px 4px;
-    padding: 2px 8px;
+    -webkit-box-sizing: border-box;
     box-sizing: border-box;
     text-align: center;
-    border-radius: 4px;
-    border: 1px solid $color-smoke-100;
+    color: $color-azure-800;
+    white-space: nowrap;
+    font-weight: 600;
 
     &:hover,
     &:focus {
       cursor: pointer;
-    }
-
-    fw-icon {
-      display: inline;
     }
   }
 }

--- a/packages/crayons-core/src/components/data-table/custom-cells/paragraph/custom-cell-paragraph.scss
+++ b/packages/crayons-core/src/components/data-table/custom-cells/paragraph/custom-cell-paragraph.scss
@@ -19,7 +19,7 @@
     text-align: center;
     color: $color-azure-800;
     white-space: nowrap;
-    font-weight: 600;
+    font-weight: $font-weight-600;
 
     &:hover,
     &:focus {

--- a/packages/crayons-core/src/components/data-table/custom-cells/paragraph/custom-cell-paragraph.tsx
+++ b/packages/crayons-core/src/components/data-table/custom-cells/paragraph/custom-cell-paragraph.tsx
@@ -90,12 +90,13 @@ export class CustomCellParagraph {
         class={{
           'paragraph-text': true,
           'open': this.showToggle,
+          'expanded': !this.hide,
         }}
         style={{
           maxHeight: this.maxHeight,
         }}
       >
-        {this.text}
+        {this.text}{' '}
       </p>
     );
     return (
@@ -114,42 +115,23 @@ export class CustomCellParagraph {
             para
           )}
           {this.showToggle && (
-            <fw-tooltip
-              content={
-                this.hide
-                  ? TranslationController.t('datatable.show')
-                  : TranslationController.t('datatable.hide')
+            <div
+              class='paragraph-toggle'
+              role='button'
+              tabIndex={0}
+              onKeyUp={(event) =>
+                (event.code === 'Space' || event.code === 'Enter') &&
+                this.toggleParagraph()
               }
-              hoist={true}
-              placement='bottom-start'
-              fallbackPlacements={['top-start']}
+              onClick={() => this.toggleParagraph()}
+              ref={(el) => (this.toggleParaButton = el)}
             >
-              <div
-                class='paragraph-toggle'
-                role='button'
-                tabIndex={0}
-                onKeyUp={(event) =>
-                  (event.code === 'Space' || event.code === 'Enter') &&
-                  this.toggleParagraph()
-                }
-                onClick={() => this.toggleParagraph()}
-                ref={(el) => (this.toggleParaButton = el)}
-              >
-                {this.hide ? (
-                  <fw-icon
-                    name='more-horizontal'
-                    library='system'
-                    size={10}
-                  ></fw-icon>
-                ) : (
-                  <fw-icon
-                    name='chevron-up'
-                    library='system'
-                    size={8}
-                  ></fw-icon>
-                )}
-              </div>
-            </fw-tooltip>
+              {this.hide ? (
+                <span>{TranslationController.t('datatable.showMore')}</span>
+              ) : (
+                <span>{TranslationController.t('datatable.showLess')}</span>
+              )}
+            </div>
           )}
         </div>
       </Host>

--- a/packages/crayons-core/src/components/data-table/custom-cells/paragraph/readme.md
+++ b/packages/crayons-core/src/components/data-table/custom-cells/paragraph/readme.md
@@ -21,17 +21,12 @@
 ### Depends on
 
 - [fw-tooltip](../../../tooltip)
-- [fw-icon](../../../icon)
 
 ### Graph
 ```mermaid
 graph TD;
   fw-custom-cell-paragraph --> fw-tooltip
-  fw-custom-cell-paragraph --> fw-icon
   fw-tooltip --> fw-popover
-  fw-icon --> fw-toast-message
-  fw-toast-message --> fw-spinner
-  fw-toast-message --> fw-icon
   fw-data-table --> fw-custom-cell-paragraph
   style fw-custom-cell-paragraph fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/crayons-core/src/components/data-table/readme.md
+++ b/packages/crayons-core/src/components/data-table/readme.md
@@ -2008,7 +2008,6 @@ graph TD;
   fw-toast-message --> fw-spinner
   fw-toast-message --> fw-icon
   fw-custom-cell-paragraph --> fw-tooltip
-  fw-custom-cell-paragraph --> fw-icon
   fw-tooltip --> fw-popover
   fw-checkbox --> fw-icon
   fw-button --> fw-spinner

--- a/packages/crayons-core/src/components/icon/readme.md
+++ b/packages/crayons-core/src/components/icon/readme.md
@@ -243,7 +243,6 @@ It comes packed with a ultra tuned svgo-config. We support YML Config convention
  - [fw-button](../button)
  - [fw-checkbox](../checkbox)
  - [fw-custom-cell-icon](../data-table/custom-cells/icon)
- - [fw-custom-cell-paragraph](../data-table/custom-cells/paragraph)
  - [fw-data-table](../data-table)
  - [fw-datepicker](../datepicker)
  - [fw-drag-item](../drag-item)
@@ -275,7 +274,6 @@ graph TD;
   fw-button --> fw-icon
   fw-checkbox --> fw-icon
   fw-custom-cell-icon --> fw-icon
-  fw-custom-cell-paragraph --> fw-icon
   fw-data-table --> fw-icon
   fw-datepicker --> fw-icon
   fw-drag-item --> fw-icon

--- a/packages/crayons-i18n/i18n/en-US.json
+++ b/packages/crayons-i18n/i18n/en-US.json
@@ -45,7 +45,9 @@
     "chooseColumns": "Choose columns",
     "actions": "Actions",
     "hide": "Hide",
-    "show": "Show"
+    "show": "Show",
+    "showMore": "show more",
+    "showLess": "show less"
   },
   "platformTable": {
     "delete": "Delete",


### PR DESCRIPTION
Adding show more and show less to paragraph variant instead of icons.

<img width="820" alt="Screenshot 2022-04-20 at 9 13 29 AM" src="https://user-images.githubusercontent.com/61269786/164146525-a910fab0-8088-4b8e-8e96-2ca8a1ecd59d.png">

<img width="818" alt="Screenshot 2022-04-20 at 9 13 43 AM" src="https://user-images.githubusercontent.com/61269786/164146580-e5e767ad-e249-43f3-ad02-454835cad273.png">


## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome browser.
