### PR TITLE
fix(tooltip): ability to hover over tooltip content

### DIFF
--- a/packages/crayons-core/src/components/popover/popover.tsx
+++ b/packages/crayons-core/src/components/popover/popover.tsx
@@ -191,15 +191,21 @@ export class Popover {
       trigger.addEventListener('focus', this.show.bind(this));
       trigger.addEventListener('blur', this.hide.bind(this));
       trigger.addEventListener('mouseenter', this.show.bind(this));
-      trigger.addEventListener('mouseleave', (event: any) => {
-        /**
-         * popovercontent might trigger mouseLeave callback of triggerRef during transition.
-         * This condition avoids flicker that might happen because of the mentioned case.
-         */
-        if (
-          event.relatedTarget === null ||
-          !event.relatedTarget.matches('*[slot="popover-content"]')
-        ) {
+      this.host.addEventListener('mouseleave', (event: any) => {
+        const eventPath = event.path ? event.path : event.composedPath();
+        const tooltip = eventPath.filter(
+          (node) => node.nodeName === 'FW-TOOLTIP'
+        )[0];
+        if (tooltip) {
+          const mouseLeaveHandler = (() => {
+            const hoverElements = document.querySelectorAll(':hover');
+            const index = [].indexOf.call(hoverElements, tooltip);
+            if (index < 0) {
+              this.hide();
+            }
+          }).bind(this);
+          setTimeout(mouseLeaveHandler, 200);
+        } else {
           this.hide();
         }
       });

--- a/packages/crayons-core/src/components/tooltip/tooltip.scss
+++ b/packages/crayons-core/src/components/tooltip/tooltip.scss
@@ -12,4 +12,6 @@
   padding: 6px 8px;
   max-width: 236px;
   overflow: visible;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }


### PR DESCRIPTION
Issue:
Not able to hover over tooltip content.

https://user-images.githubusercontent.com/61269786/164599586-f14f487a-eb0d-4d9f-b133-ded4b76cb122.mov

Fix: 
Issue was because we had hide on trigger leave. Now, changing mouseleave event to tooltip host and adding time to hide tooltip content so that people can move to tooltip content before the timeout/hide event.

https://user-images.githubusercontent.com/61269786/164599609-057f9a12-6612-4dfb-be7e-85bff238fc2a.mov

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in chrome browser.