### PR TITLE
fix(data-table): capitalizing show more text in paragraph variant

### DIFF
--- a/packages/crayons-i18n/i18n/en-US.json
+++ b/packages/crayons-i18n/i18n/en-US.json
@@ -46,8 +46,8 @@
     "actions": "Actions",
     "hide": "Hide",
     "show": "Show",
-    "showMore": "show more",
-    "showLess": "show less"
+    "showMore": "Show more",
+    "showLess": "Show less"
   },
   "platformTable": {
     "delete": "Delete",


### PR DESCRIPTION
Changed 'show more' to 'Show more'. Requested by designer. 

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
