### PR TITLE
fix(data-table): adding key to table row to avoid rendering issues

### DIFF
--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -1226,6 +1226,7 @@ export class DataTable {
       ? this.rows.map((row, rowIndex) => {
           return (
             <tr
+              key={row.id}
               role='row'
               class={{
                 active: this.selected.includes(row.id),


### PR DESCRIPTION
Issue:
- In cases where rows are re-rendered (when a row is deleted, filter is applied), contents move from one cell move to another. eg: 'show more' button on para variant moves to next cell.

https://user-images.githubusercontent.com/61269786/165032781-b3ee6560-ff46-4496-8f3f-3336197a0cc7.mov


Fix: 
- Adding key prop to table rows, solve this issue.


https://user-images.githubusercontent.com/61269786/165032831-96934ecb-7516-484b-9702-a5631a298aff.mov



## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome.
