### PR TITLE
fix(data-table): separating isLoading and showShimmer functionality

### DIFF
--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -214,7 +214,6 @@ export class DataTable {
    * componentWillLoad lifecycle event
    */
   componentWillLoad() {
-    this.isLoading = true;
     this.columnOrdering(this.columns);
     if (localStorage && this.autoSaveSettings) {
       const tableId = this.el.id ? `-${this.el.id}` : '';
@@ -454,7 +453,6 @@ export class DataTable {
   hideShimmer() {
     if (this.showShimmer) {
       this.showShimmer = false;
-      this.isLoading = false;
     }
   }
 
@@ -1606,13 +1604,15 @@ export class DataTable {
       for (let index = 1; index <= shimmerCount; index++) {
         shimmerTemplate.push(
           <tr>
-            {[...Array(columnsLength).keys()].map(() => {
-              return (
-                <td>
-                  <fw-skeleton height='12px'></fw-skeleton>
-                </td>
-              );
-            })}
+            {Array(columnsLength)
+              .fill(1)
+              .map(() => {
+                return (
+                  <td>
+                    <fw-skeleton height='12px'></fw-skeleton>
+                  </td>
+                );
+              })}
           </tr>
         );
       }
@@ -1629,7 +1629,7 @@ export class DataTable {
         <div
           class={{
             'fw-data-table-scrollable': true,
-            'loading': this.isLoading,
+            'loading': this.isLoading || this.showShimmer,
             'shimmer': this.showShimmer,
           }}
           ref={(el) => (this.tableContainer = el)}
@@ -1645,14 +1645,16 @@ export class DataTable {
           >
             <thead>{this.renderTableHeader()}</thead>
             <tbody>
-              {this.showShimmer && this.isLoading
+              {this.showShimmer
                 ? this.renderTableShimmer()
                 : this.renderTableBody()}
             </tbody>
           </table>
         </div>
         {this.showSettings && this.renderTableSettings()}
-        {this.isLoading && <div class='fw-data-table--loading'></div>}
+        {(this.isLoading || this.showShimmer) && (
+          <div class='fw-data-table--loading'></div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
In this PR, we are removing the dependency between isLoading and showShimmer props.

Issue:
Table moves to a loading state intermittently. This disabled other actions on the table.

Fix: 
The issue seems to be with setting isLoading on componentWillLoad and removing it only when showShimmer is false. componentWillLoad seems to be called as part of component reattached state too like during HMR. So we removed isLoading from componentWillLoad.

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome. 
Tested locally in CO UI project.
