### PR TITLE
fix(fw-timepicker): fixed the documentation examples and improper loop

### DIFF
--- a/packages/crayons-core/package.json
+++ b/packages/crayons-core/package.json
@@ -58,7 +58,7 @@
     "start": "stencil build --dev --watch --serve --port=3333",
     "storybook:start": "wait-on -d 30000 loader/index.js && start-storybook -p 9001 -c .storybook",
     "storybook": "run-p local storybook:start",
-    "test:watch": "stencil test --spec --e2e --watchAll",
+    "test:watch": "stencil test --spec --e2e --watchAll --verbose",
     "test": "stencil test --spec --e2e",
     "test:ci": "stencil test --spec --ci --e2e --max-workers=2"
   },

--- a/packages/crayons-core/src/components/timepicker/readme.md
+++ b/packages/crayons-core/src/components/timepicker/readme.md
@@ -1,14 +1,14 @@
 # Timepicker (fw-timepicker)
-fw-timepicker displays a list or drop-down box with prepopulated time values and enables picking a time. The time values displayed in the list box are based on the fw-timepicker attribute values.
 
+fw-timepicker displays a list or drop-down box with prepopulated time values and enables picking a time. The time values displayed in the list box are based on the fw-timepicker attribute values.
 
 ## Demo
 
 ```html live
-<fw-label value="An interval based picker" color="yellow"></fw-label><br/> 
-<fw-timepicker interval=45 hour-format="hh:mm p"></fw-timepicker>
-<fw-label value="A range based picker" color="yellow"></fw-label><br/>
-<fw-timepicker min-time="04:30" max-time="08:30 PM"></fw-timepicker>
+<fw-label value="An interval based picker" color="yellow"></fw-label><br />
+<fw-timepicker interval="45" format="hh:mm p"></fw-timepicker>
+<fw-label value="A range based picker" color="yellow"></fw-label><br />
+<fw-timepicker min-time="04:30 PM" max-time="08:30 PM"></fw-timepicker>
 ```
 
 ## Usage
@@ -17,9 +17,9 @@ fw-timepicker displays a list or drop-down box with prepopulated time values and
 <code-block title="HTML">
 ```html 
 <fw-label value="An interval based picker" color="yellow"></fw-label><br/> 
-<fw-timepicker interval=45 hour-format="hh:mm p"></fw-timepicker>
+<fw-timepicker interval=45 format="hh:mm p"></fw-timepicker>
 <fw-label value="A range based picker" color="yellow"></fw-label><br/>
-<fw-timepicker min-time="04:30" max-time="08:30 PM"></fw-timepicker>
+<fw-timepicker min-time="04:30 PM" max-time="08:30 PM"></fw-timepicker>
 ```
 </code-block>
 
@@ -31,18 +31,16 @@ import { FwTimepicker } from "@freshworks/crayons/react";
 function App() {
   return (<div>
           <label>An interval based picker</label><br/> 
-          <FwTimepicker interval={45} hourFormat="hh:mm p"></FwTimepicker>
+          <FwTimepicker interval={45} format="hh:mm p"></FwTimepicker>
           <label>A range based picker</label><br/>
-          <FwTimepicker minTime="04:30" maxTime="08:30 PM"></FwTimepicker>
+          <FwTimepicker minTime="04:30 PM" maxTime="08:30 PM"></FwTimepicker>
     </div>);
 }
 ```
 </code-block>
 </code-group>
 
-
 <!-- Auto Generated Below -->
-
 
 ## Properties
 
@@ -63,7 +61,6 @@ function App() {
 | `value`       | `value`        | Time output value                                                                                                                                                                              | `string`                           | `undefined`                                    |
 | `warningText` | `warning-text` | Warning text displayed below the text box.                                                                                                                                                     | `string`                           | `''`                                           |
 
-
 ## Events
 
 | Event      | Description                                                                 | Type               |
@@ -71,7 +68,6 @@ function App() {
 | `fwBlur`   | Triggered when the list box loses focus.                                    | `CustomEvent<any>` |
 | `fwChange` | Triggered when a value is selected or deselected from the list box options. | `CustomEvent<any>` |
 | `fwFocus`  | Triggered when the list box comes into focus.                               | `CustomEvent<any>` |
-
 
 ## Methods
 
@@ -83,9 +79,6 @@ Sets focus on a specific `fw-timepicker`.
 
 Type: `Promise<void>`
 
-
-
-
 ## CSS Custom Properties
 
 | Name                 | Description                |
@@ -94,12 +87,11 @@ Type: `Promise<void>`
 | `--fw-hint-color`    | Color of the hint text.    |
 | `--fw-warning-color` | Color of the warning text. |
 
-
 ## Dependencies
 
 ### Used by
 
- - [fw-form-control](../form-control)
+- [fw-form-control](../form-control)
 
 ### Depends on
 
@@ -107,6 +99,7 @@ Type: `Promise<void>`
 - [fw-select-option](../select-option)
 
 ### Graph
+
 ```mermaid
 graph TD;
   fw-timepicker --> fw-select
@@ -135,6 +128,6 @@ graph TD;
   style fw-timepicker fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
 Built with ❤ at Freshworks

--- a/packages/crayons-core/src/components/timepicker/timepicker.e2e.ts
+++ b/packages/crayons-core/src/components/timepicker/timepicker.e2e.ts
@@ -1,5 +1,14 @@
 import { newE2EPage } from '@stencil/core/testing';
 
+async function getSelectOptions(page) {
+  const list = await page.find('fw-timepicker >>> .field-control');
+  const popover = await list.find('fw-select >>> fw-popover');
+  const selectOptions = await popover.findAll(
+    'fw-list-options >>> fw-select-option'
+  );
+  return selectOptions;
+}
+
 describe('fw-timepicker', () => {
   it('renders', async () => {
     const page = await newE2EPage();
@@ -40,34 +49,15 @@ describe('fw-timepicker', () => {
     expect(fwFocus).toHaveReceivedEvent();
   });
 
-  it('it emits fwFocus when the focus is on the component', async () => {
+  it('it sets start value, end value and interval as per the properties provided', async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<fw-timepicker></fw-timepicker>`);
-    const fwFocus = await page.spyOnEvent('fwFocus');
-    const element = await page.find('fw-timepicker');
-
-    await element.click();
-    await page.keyboard.press('Tab');
-
-    await page.waitForChanges();
-
-    expect(fwFocus).toHaveReceivedEvent();
+    await page.setContent(
+      `<fw-timepicker min-time="09:00 AM" interval=15></fw-timepicker>`
+    );
+    const selectOptions = await getSelectOptions(page);
+    expect(await selectOptions[0].getProperty('value')).toBe('09:00');
   });
-
-  // TODO: Better test case to check for the first value.
-
-  // it('it sets start value, end value and interval as per the properties provided', async () => {
-  //   const page = await newE2EPage();
-
-  //   await page.setContent(
-  //     `<fw-timepicker min-time="09:00 AM" interval=15></fw-timepicker>`
-  //   );
-  //   const el = await page.find('fw-timepicker >>> fw-select');
-  //   expect(el.shadowRoot).toEqualHtml(
-  //     `<div class="select-container">   <fw-popover class="hydrated" same-width>    <div class="input-container normal" slot="popover-trigger">         <div class="input-container-inner">           <input autocomplete="off" placeholder="" type="text">           <span class="dropdown-status-icon"></span>         </div>       </div>        <fw-list-options class="hydrated" slot="popover-content" value=""></fw-list-options> </fw-popover>     </div>     </fw-popover></div>`
-  //   );
-  // });
 
   it('sets the value when the option is selected', async () => {
     const page = await newE2EPage();
@@ -75,12 +65,16 @@ describe('fw-timepicker', () => {
     await page.setContent(
       `<fw-timepicker min-time="09:00 AM" interval=15></fw-timepicker>`
     );
+    const fwChange = await page.spyOnEvent('fwChange');
     const el = await page.find('fw-timepicker');
-    const selectEl = await page.find('fw-timepicker >>> fw-select');
-    selectEl.setProperty('value', '09:00');
+    await el.click();
     await page.waitForChanges();
 
-    expect(await el.getProperty('value')).toBe('09:00');
+    // click on the first option
+    const selectOptions = await getSelectOptions(page);
+    await selectOptions[0].click();
+    await page.waitForChanges();
+    expect(fwChange).toHaveReceivedEvent();
   });
 
   it('sets the value from the attribute', async () => {

--- a/packages/crayons-core/src/components/timepicker/timepicker.tsx
+++ b/packages/crayons-core/src/components/timepicker/timepicker.tsx
@@ -180,12 +180,11 @@ export class Timepicker {
 
   private setTimeValue(e: any) {
     const { value } = e.detail;
-    this.value = value;
-    if (this.value)
+    if (value)
       this.fwChange.emit({
         event: e,
         name: this.name,
-        value: this.value,
+        value: value,
       });
   }
 
@@ -263,6 +262,7 @@ export class Timepicker {
           ref={(el) => (this.nativeInput = el)}
           state={this.state}
           placeholder={this.placeholder}
+          search={false}
         >
           {this.timeValues.map((time) => (
             <fw-select-option value={this.currentTimeValue(time)}>


### PR DESCRIPTION
## Description:
- Fixed the example in the docs
- Improved the existing test cases and removed duplicate test case.
- removed the logic to set the `value` state in `fwChange` event to prevent the component re-render.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
