### PR TITLE
feat(fw-timepicker): added placement option for the dropdown

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -1623,6 +1623,10 @@ export namespace Components {
     }
     interface FwTimepicker {
         /**
+          * Whether the arrow/caret should be shown in the timepicker.
+         */
+        "caret": boolean;
+        /**
           * Set true to disable the element
          */
         "disabled": boolean;
@@ -1658,6 +1662,10 @@ export namespace Components {
           * Name of the component, saved as part of form data.
          */
         "name": string;
+        /**
+          * Placement of the options list with respect to timepicker.
+         */
+        "optionsPlacement": PopoverPlacementType;
         /**
           * Text displayed in the select before an option is selected.
          */
@@ -3933,6 +3941,10 @@ declare namespace LocalJSX {
     }
     interface FwTimepicker {
         /**
+          * Whether the arrow/caret should be shown in the timepicker.
+         */
+        "caret"?: boolean;
+        /**
           * Set true to disable the element
          */
         "disabled"?: boolean;
@@ -3980,6 +3992,10 @@ declare namespace LocalJSX {
           * Triggered when the list box comes into focus.
          */
         "onFwFocus"?: (event: CustomEvent<any>) => void;
+        /**
+          * Placement of the options list with respect to timepicker.
+         */
+        "optionsPlacement"?: PopoverPlacementType;
         /**
           * Text displayed in the select before an option is selected.
          */

--- a/packages/crayons-core/src/components/timepicker/readme.md
+++ b/packages/crayons-core/src/components/timepicker/readme.md
@@ -42,24 +42,28 @@ function App() {
 
 <!-- Auto Generated Below -->
 
+
 ## Properties
 
-| Property      | Attribute      | Description                                                                                                                                                                                    | Type                               | Default                                        |
-| ------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ---------------------------------------------- |
-| `disabled`    | `disabled`     | Set true to disable the element                                                                                                                                                                | `boolean`                          | `false`                                        |
-| `errorText`   | `error-text`   | Error text displayed below the text box.                                                                                                                                                       | `string`                           | `''`                                           |
-| `format`      | `format`       | Format in which time values are populated in the list box. If the value is hh:mm p, the time values are in the 12-hour format. If the value is hh:mm, the time values are in the 24-hr format. | `"HH:mm" \| "hh:mm a"`             | `'hh:mm a'`                                    |
-| `hintText`    | `hint-text`    | Hint text displayed below the text box.                                                                                                                                                        | `string`                           | `''`                                           |
-| `interval`    | `interval`     | Time interval between the values displayed in the list, specified in minutes.                                                                                                                  | `number`                           | `30`                                           |
-| `label`       | `label`        | Label displayed on the interface, for the component.                                                                                                                                           | `string`                           | `''`                                           |
-| `maxTime`     | `max-time`     | Upper time-limit for the values displayed in the list. If this attribute's value is in the hh:mm format, it is assumed to be hh:mm AM.                                                         | `string`                           | `this.isMeridianFormat ? '11:30 PM' : '23:30'` |
-| `minTime`     | `min-time`     | Lower time-limit for the values displayed in the list. If this attribute's value is in the hh:mm format, it is assumed to be hh:mm AM.                                                         | `string`                           | `this.isMeridianFormat ? '12:00 AM' : '00:00'` |
-| `name`        | `name`         | Name of the component, saved as part of form data.                                                                                                                                             | `string`                           | `''`                                           |
-| `placeholder` | `placeholder`  | Text displayed in the select before an option is selected.                                                                                                                                     | `string`                           | `undefined`                                    |
-| `required`    | `required`     | Specifies the input box as a mandatory field and displays an asterisk next to the label. If the attribute's value is undefined, the value is set to false.                                     | `boolean`                          | `false`                                        |
-| `state`       | `state`        | Theme based on which the input of the timepicker is styled.                                                                                                                                    | `"error" \| "normal" \| "warning"` | `'normal'`                                     |
-| `value`       | `value`        | Time output value                                                                                                                                                                              | `string`                           | `undefined`                                    |
-| `warningText` | `warning-text` | Warning text displayed below the text box.                                                                                                                                                     | `string`                           | `''`                                           |
+| Property           | Attribute           | Description                                                                                                                                                                                    | Type                                                                                                                                                                 | Default                                        |
+| ------------------ | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `caret`            | `caret`             | Whether the arrow/caret should be shown in the timepicker.                                                                                                                                     | `boolean`                                                                                                                                                            | `true`                                         |
+| `disabled`         | `disabled`          | Set true to disable the element                                                                                                                                                                | `boolean`                                                                                                                                                            | `false`                                        |
+| `errorText`        | `error-text`        | Error text displayed below the text box.                                                                                                                                                       | `string`                                                                                                                                                             | `''`                                           |
+| `format`           | `format`            | Format in which time values are populated in the list box. If the value is hh:mm p, the time values are in the 12-hour format. If the value is hh:mm, the time values are in the 24-hr format. | `"HH:mm" \| "hh:mm a"`                                                                                                                                               | `'hh:mm a'`                                    |
+| `hintText`         | `hint-text`         | Hint text displayed below the text box.                                                                                                                                                        | `string`                                                                                                                                                             | `''`                                           |
+| `interval`         | `interval`          | Time interval between the values displayed in the list, specified in minutes.                                                                                                                  | `number`                                                                                                                                                             | `30`                                           |
+| `label`            | `label`             | Label displayed on the interface, for the component.                                                                                                                                           | `string`                                                                                                                                                             | `''`                                           |
+| `maxTime`          | `max-time`          | Upper time-limit for the values displayed in the list. If this attribute's value is in the hh:mm format, it is assumed to be hh:mm AM.                                                         | `string`                                                                                                                                                             | `this.isMeridianFormat ? '11:30 PM' : '23:30'` |
+| `minTime`          | `min-time`          | Lower time-limit for the values displayed in the list. If this attribute's value is in the hh:mm format, it is assumed to be hh:mm AM.                                                         | `string`                                                                                                                                                             | `this.isMeridianFormat ? '12:00 AM' : '00:00'` |
+| `name`             | `name`              | Name of the component, saved as part of form data.                                                                                                                                             | `string`                                                                                                                                                             | `''`                                           |
+| `optionsPlacement` | `options-placement` | Placement of the options list with respect to timepicker.                                                                                                                                      | `"bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"` | `'bottom'`                                     |
+| `placeholder`      | `placeholder`       | Text displayed in the select before an option is selected.                                                                                                                                     | `string`                                                                                                                                                             | `undefined`                                    |
+| `required`         | `required`          | Specifies the input box as a mandatory field and displays an asterisk next to the label. If the attribute's value is undefined, the value is set to false.                                     | `boolean`                                                                                                                                                            | `false`                                        |
+| `state`            | `state`             | Theme based on which the input of the timepicker is styled.                                                                                                                                    | `"error" \| "normal" \| "warning"`                                                                                                                                   | `'normal'`                                     |
+| `value`            | `value`             | Time output value                                                                                                                                                                              | `string`                                                                                                                                                             | `undefined`                                    |
+| `warningText`      | `warning-text`      | Warning text displayed below the text box.                                                                                                                                                     | `string`                                                                                                                                                             | `''`                                           |
+
 
 ## Events
 
@@ -68,6 +72,7 @@ function App() {
 | `fwBlur`   | Triggered when the list box loses focus.                                    | `CustomEvent<any>` |
 | `fwChange` | Triggered when a value is selected or deselected from the list box options. | `CustomEvent<any>` |
 | `fwFocus`  | Triggered when the list box comes into focus.                               | `CustomEvent<any>` |
+
 
 ## Methods
 
@@ -79,19 +84,14 @@ Sets focus on a specific `fw-timepicker`.
 
 Type: `Promise<void>`
 
-## CSS Custom Properties
 
-| Name                 | Description                |
-| -------------------- | -------------------------- |
-| `--fw-error-color`   | Color of the error text.   |
-| `--fw-hint-color`    | Color of the hint text.    |
-| `--fw-warning-color` | Color of the warning text. |
+
 
 ## Dependencies
 
 ### Used by
 
-- [fw-form-control](../form-control)
+ - [fw-form-control](../form-control)
 
 ### Depends on
 
@@ -99,7 +99,6 @@ Type: `Promise<void>`
 - [fw-select-option](../select-option)
 
 ### Graph
-
 ```mermaid
 graph TD;
   fw-timepicker --> fw-select
@@ -128,6 +127,6 @@ graph TD;
   style fw-timepicker fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
----
+----------------------------------------------
 
 Built with ❤ at Freshworks

--- a/packages/crayons-core/src/components/timepicker/timepicker.e2e.ts
+++ b/packages/crayons-core/src/components/timepicker/timepicker.e2e.ts
@@ -1,7 +1,7 @@
 import { newE2EPage } from '@stencil/core/testing';
 
 async function getSelectOptions(page) {
-  const list = await page.find('fw-timepicker >>> .field-control');
+  const list = await page.find('fw-timepicker >>> .timepicker');
   const popover = await list.find('fw-select >>> fw-popover');
   const selectOptions = await popover.findAll(
     'fw-list-options >>> fw-select-option'

--- a/packages/crayons-core/src/components/timepicker/timepicker.scss
+++ b/packages/crayons-core/src/components/timepicker/timepicker.scss
@@ -1,7 +1,3 @@
-/**
-  @prop --fw-hint-color: Color of the hint text.
-  @prop --fw-warning-color: Color of the warning text.
-  @prop --fw-error-color: Color of the error text.
-*/
-
-@import '../../function-components/field-control.scss';
+:host {
+  display: block;
+}

--- a/packages/crayons-core/src/components/timepicker/timepicker.scss
+++ b/packages/crayons-core/src/components/timepicker/timepicker.scss
@@ -1,3 +1,3 @@
-:host {
+.timepicker {
   display: block;
 }

--- a/packages/crayons-core/src/components/timepicker/timepicker.tsx
+++ b/packages/crayons-core/src/components/timepicker/timepicker.tsx
@@ -244,30 +244,32 @@ export class Timepicker {
     renderHiddenField(host, name, value);
 
     return (
-      <fw-select
-        name={this.name}
-        label={this.label}
-        hintText={this.hintText}
-        errorText={this.errorText}
-        warningText={this.warningText}
-        disabled={this.disabled}
-        value={this.value}
-        required={this.required}
-        onFwChange={(e) => this.setTimeValue(e)}
-        onFwBlur={this.onBlur}
-        ref={(el) => (this.nativeInput = el)}
-        state={this.state}
-        placeholder={this.placeholder}
-        search={false}
-        optionsPlacement={this.optionsPlacement}
-        caret={this.caret}
-      >
-        {this.timeValues.map((time) => (
-          <fw-select-option value={this.currentTimeValue(time)}>
-            {this.currentTimeLabel(time)}
-          </fw-select-option>
-        ))}
-      </fw-select>
+      <div class='timepicker'>
+        <fw-select
+          name={this.name}
+          label={this.label}
+          hintText={this.hintText}
+          errorText={this.errorText}
+          warningText={this.warningText}
+          disabled={this.disabled}
+          value={this.value}
+          required={this.required}
+          onFwChange={(e) => this.setTimeValue(e)}
+          onFwBlur={this.onBlur}
+          ref={(el) => (this.nativeInput = el)}
+          state={this.state}
+          placeholder={this.placeholder}
+          search={false}
+          optionsPlacement={this.optionsPlacement}
+          caret={this.caret}
+        >
+          {this.timeValues.map((time) => (
+            <fw-select-option value={this.currentTimeValue(time)}>
+              {this.currentTimeLabel(time)}
+            </fw-select-option>
+          ))}
+        </fw-select>
+      </div>
     );
   }
 }

--- a/packages/crayons-core/src/components/timepicker/timepicker.tsx
+++ b/packages/crayons-core/src/components/timepicker/timepicker.tsx
@@ -12,7 +12,7 @@ import { parse, format, addMinutes } from 'date-fns';
 import { enUS } from 'date-fns/locale';
 
 import { renderHiddenField, hasSlot } from '../../utils';
-import FieldControl from '../../function-components/field-control';
+import { PopoverPlacementType } from '../../utils/types';
 
 @Component({
   tag: 'fw-timepicker',
@@ -99,6 +99,14 @@ export class Timepicker {
    * Text displayed in the select before an option is selected.
    */
   @Prop() placeholder?: string | null;
+  /**
+   * Placement of the options list with respect to timepicker.
+   */
+  @Prop({ reflect: true }) optionsPlacement: PopoverPlacementType = 'bottom';
+  /**
+   * Whether the arrow/caret should be shown in the timepicker.
+   */
+  @Prop() caret = true;
 
   /**
    * Triggered when a value is selected or deselected from the list box options.
@@ -236,41 +244,30 @@ export class Timepicker {
     renderHiddenField(host, name, value);
 
     return (
-      <FieldControl
-        inputId={this.name}
+      <fw-select
+        name={this.name}
         label={this.label}
-        labelId={`${this.label}-${this.name}`}
-        state={this.state}
-        hintTextId={`hint-${this.name}`}
         hintText={this.hintText}
-        hasHintTextSlot={this.hasHintTextSlot}
-        errorTextId={`error-${this.name}`}
         errorText={this.errorText}
-        hasErrorTextSlot={this.hasErrorTextSlot}
-        warningTextId={`warning-${this.name}`}
         warningText={this.warningText}
-        hasWarningTextSlot={this.hasWarningTextSlot}
+        disabled={this.disabled}
+        value={this.value}
         required={this.required}
+        onFwChange={(e) => this.setTimeValue(e)}
+        onFwBlur={this.onBlur}
+        ref={(el) => (this.nativeInput = el)}
+        state={this.state}
+        placeholder={this.placeholder}
+        search={false}
+        optionsPlacement={this.optionsPlacement}
+        caret={this.caret}
       >
-        <fw-select
-          name={this.name}
-          disabled={this.disabled}
-          value={this.value}
-          required={this.required}
-          onFwChange={(e) => this.setTimeValue(e)}
-          onFwBlur={this.onBlur}
-          ref={(el) => (this.nativeInput = el)}
-          state={this.state}
-          placeholder={this.placeholder}
-          search={false}
-        >
-          {this.timeValues.map((time) => (
-            <fw-select-option value={this.currentTimeValue(time)}>
-              {this.currentTimeLabel(time)}
-            </fw-select-option>
-          ))}
-        </fw-select>
-      </FieldControl>
+        {this.timeValues.map((time) => (
+          <fw-select-option value={this.currentTimeValue(time)}>
+            {this.currentTimeLabel(time)}
+          </fw-select-option>
+        ))}
+      </fw-select>
     );
   }
 }

--- a/packages/crayons-core/src/components/timepicker/timepicker.tsx
+++ b/packages/crayons-core/src/components/timepicker/timepicker.tsx
@@ -26,9 +26,6 @@ export class Timepicker {
    * State for all the time values
    */
   @State() timeValues: any[] = [];
-  @State() hasHintTextSlot = false;
-  @State() hasWarningTextSlot = false;
-  @State() hasErrorTextSlot = false;
 
   /**
    * Format in which time values are populated in the list box. If the value is hh:mm p, the time values are in the 12-hour format. If the value is hh:mm, the time values are in the 24-hr format.
@@ -228,14 +225,6 @@ export class Timepicker {
       this.setEndTime();
     }
     this.setTimeValues();
-
-    this.checkSlotContent();
-  }
-
-  checkSlotContent() {
-    this.hasHintTextSlot = hasSlot(this.host, 'hint-text');
-    this.hasWarningTextSlot = hasSlot(this.host, 'warning-text');
-    this.hasErrorTextSlot = hasSlot(this.host, 'error-text');
   }
 
   render() {

--- a/packages/crayons-core/src/components/timepicker/timepicker.tsx
+++ b/packages/crayons-core/src/components/timepicker/timepicker.tsx
@@ -11,7 +11,7 @@ import {
 import { parse, format, addMinutes } from 'date-fns';
 import { enUS } from 'date-fns/locale';
 
-import { renderHiddenField, hasSlot } from '../../utils';
+import { renderHiddenField } from '../../utils';
 import { PopoverPlacementType } from '../../utils/types';
 
 @Component({


### PR DESCRIPTION
## Description:
- Exposed caret and optionsPlacement prop to control the position of the dropdown
- Removed the FieldControl as it is used in the fw-select.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
