### PR TITLE
Converting CSS directional properties to logical properties to support RTL.

### DIFF
--- a/packages/crayons-core/src/components/checkbox/checkbox.scss
+++ b/packages/crayons-core/src/components/checkbox/checkbox.scss
@@ -84,7 +84,7 @@
   position: relative;
   font-weight: 400;
   word-wrap: break-word;
-  padding-left: 22px;
+  padding-inline-start: 22px;
 }
 
 input[type='checkbox'] {
@@ -92,7 +92,7 @@ input[type='checkbox'] {
 
   & + label {
     user-select: none;
-    margin-bottom: 0;
+    margin-block-end: 0;
     vertical-align: middle;
     font-size: 14px;
     color: #12344d;
@@ -105,7 +105,7 @@ input[type='checkbox'] {
     }
 
     #label {
-      padding-left: 22px;
+      padding-inline-start: 22px;
       box-decoration-break: clone;
       -webkit-box-decoration-break: clone;
 
@@ -113,10 +113,10 @@ input[type='checkbox'] {
         content: '*';
         position: relative;
         display: inline-block;
-        top: 2px;
+        inset-block-start: 2px;
         font-size: 14px;
         color: $app-error;
-        padding-left: 2px;
+        padding-inline-start: 2px;
         font-weight: $font-weight-bold;
       }
     }
@@ -129,8 +129,8 @@ input[type='checkbox'] {
 
     &::before {
       position: absolute;
-      left: 0;
-      top: 3px;
+      inset-inline-start: 0;
+      inset-block-start: 3px;
       display: block;
       content: '';
       border: $checkbox-border-width solid $color-smoke-700;
@@ -150,8 +150,8 @@ input[type='checkbox'] {
       }
       &::before {
         position: absolute;
-        left: 0;
-        top: 3px;
+        inset-inline-start: 0;
+        inset-block-start: 3px;
         display: block;
         content: '';
         border: $checkbox-border-width solid $app-error;
@@ -174,8 +174,8 @@ input[type='checkbox'] {
       position: absolute;
       display: block;
       content: '';
-      left: 3px;
-      top: -1px;
+      inset-inline-start: 3px;
+      inset-block-start: -1px;
       width: 8px;
       height: 8px;
       opacity: 0;

--- a/packages/crayons-core/src/components/data-table/data-table.scss
+++ b/packages/crayons-core/src/components/data-table/data-table.scss
@@ -53,7 +53,7 @@ div.fw-data-table-container {
             font-weight: 600;
             letter-spacing: 0.2px;
             text-overflow: ellipsis;
-            text-align: left;
+            text-align: start;
             z-index: 1;
             box-sizing: border-box;
             min-width: 40px;
@@ -64,12 +64,12 @@ div.fw-data-table-container {
             white-space: normal;
 
             &:first-of-type {
-              padding-left: 16px;
+              padding-inline-start: 16px;
               border-radius: 4px 0px 0px 0px;
             }
 
             &:last-of-type {
-              padding-right: 16px;
+              padding-inline-end: 16px;
               border-radius: 0px 4px 0px 0px;
             }
 
@@ -144,11 +144,11 @@ div.fw-data-table-container {
             }
 
             &:first-child {
-              padding-left: 16px;
+              padding-inline-start: 16px;
             }
 
             &:last-child {
-              padding-right: 16px;
+              padding-inline-end: 16px;
             }
           }
 
@@ -158,11 +158,11 @@ div.fw-data-table-container {
             white-space: nowrap;
 
             & fw-button {
-              margin-right: 5px;
+              margin-inline-end: 5px;
             }
 
             & fw-tooltip:last-child fw-button {
-              margin-right: 0px;
+              margin-inline-end: 0px;
             }
           }
 
@@ -192,7 +192,8 @@ div.fw-data-table-container {
         fw-skeleton {
           display: block;
           height: 10px;
-          padding: 4px 0px;
+          padding-block: 4px;
+          padding-inline: 0px;
           box-sizing: content-box;
         }
       }
@@ -222,16 +223,16 @@ div.fw-data-table-container {
 
   .fw-data-table--loading {
     position: absolute;
-    top: 0px;
-    left: 0px;
+    inset-block-start: 0px;
+    inset-inline-start: 0px;
     width: 100%;
     height: 100%;
   }
 
   .table-settings {
     position: absolute;
-    right: 0px;
-    top: 0px;
+    inset-inline-end: 0px;
+    inset-block-start: 0px;
 
     .table-settings-container {
       position: relative;
@@ -270,7 +271,8 @@ div.fw-data-table-container {
         border: 1px solid $color-smoke-50;
         border-radius: 4px;
         box-shadow: -15px 20px 40px rgba(0, 0, 0, 0.04);
-        padding: 22px 0px 0px 0px;
+        padding-block: 22px 0px;
+        padding-inline: 0px;
         display: none;
         animation: appear 0.3s;
 
@@ -284,8 +286,9 @@ div.fw-data-table-container {
           box-sizing: border-box;
           font-weight: 600;
           align-items: flex-end;
-          padding: 0px 22px;
-          margin-bottom: 16px;
+          padding-block: 0px;
+          padding-inline: 22px;
+          margin-block-end: 16px;
 
           span.title {
             flex-grow: 1;
@@ -300,7 +303,7 @@ div.fw-data-table-container {
             font-weight: 600;
             text-decoration: none;
             line-height: 17px;
-            padding-right: 4px;
+            padding-inline-end: 4px;
             margin: 0px;
             background: $color-milk;
             border: 0px;
@@ -317,7 +320,8 @@ div.fw-data-table-container {
           width: 100%;
           height: 342px;
           box-sizing: border-box;
-          padding: 0px 22px;
+          padding-block: 0px;
+          padding-inline: 22px;
           gap: 14px;
 
           .table-settings-content-left {
@@ -328,20 +332,20 @@ div.fw-data-table-container {
 
             .table-settings-content-title {
               box-sizing: border-box;
-              padding-bottom: 5px;
-              padding-left: 5px;
+              padding-block-end: 5px;
+              padding-inline-start: 5px;
             }
 
             .table-settings-content-search {
               position: relative;
-              top: -3px;
+              inset-block-start: -3px;
             }
 
             .table-settings-content-choose {
               display: flex;
               flex-direction: column;
               flex-grow: 1;
-              margin-top: 14px;
+              margin-block-start: 14px;
               overflow-y: hidden;
               transform: translateX(-3px);
               width: calc(100% + 5px);
@@ -350,11 +354,11 @@ div.fw-data-table-container {
                 display: flex;
                 flex-direction: column;
                 overflow-y: auto;
-                padding-left: 5px;
-                padding-right: 5px;
+                padding-inline: 5px;
 
                 div {
-                  margin: 5px 0px;
+                  margin-block: 5px;
+                  margin-inline: 0px;
 
                   fw-checkbox {
                     width: 100%;
@@ -371,17 +375,23 @@ div.fw-data-table-container {
             width: 220px;
             box-sizing: border-box;
             background: $color-smoke-50;
-            border-radius: 4px 4px 0px 0px;
+            border-start-start-radius: 4px;
+            border-start-end-radius: 4px;
+            border-end-start-radius: 0px;
+            border-end-end-radius: 0px;
 
             .table-settings-content-title {
               box-sizing: border-box;
-              padding: 8px 12px 3px;
+              padding-inline: 12px;
+              padding-block-start: 8px;
+              padding-block-end: 3px;
             }
 
             .table-settings-content-draggable {
               width: 100%;
               flex-grow: 1;
-              padding: 0px 12px;
+              padding-block: 0px;
+              padding-inline: 12px;
               box-sizing: border-box;
               overflow-y: auto;
 
@@ -391,8 +401,11 @@ div.fw-data-table-container {
                 border-radius: 4px;
                 box-shadow: 0px 2px 4px rgba(18, 52, 77, 0.06);
                 border: 1px solid $color-smoke-50;
-                padding: 7px 8px 7px 14px;
-                margin: 8px 0px;
+                padding-block: 7px;
+                padding-inline-end: 8px;
+                padding-inline-start: 14px;
+                margin-block: 8px;
+                margin-inline: 0px;
                 font-size: 14px;
 
                 .table-settings-drag-item-icon,
@@ -426,7 +439,8 @@ div.fw-data-table-container {
                 .table-settings-drag-item-text {
                   flex-grow: 1;
                   color: $color-elephant-900;
-                  padding: 0px 11px;
+                  padding-block: 0px;
+                  padding-inline: 11px;
                   box-sizing: border-box;
                   text-overflow: ellipsis;
                   overflow: hidden;
@@ -454,7 +468,8 @@ div.fw-data-table-container {
           width: 100%;
           box-sizing: border-box;
           background: $color-smoke-25;
-          padding: 12px 16px;
+          padding-block: 12px;
+          padding-inline: 16px;
           gap: 12px;
           justify-content: flex-end;
         }
@@ -471,8 +486,8 @@ div.fw-data-table-container {
       position: fixed;
       width: 100vw;
       height: 100vh;
-      top: 0px;
-      left: 0px;
+      inset-block-start: 0px;
+      inset-inline-start: 0px;
       z-index: 95;
     }
   }


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1xfdMLnUkbsmEnfD6xWUWMXJUNSta-_9UGxjZXdRPUYA/edit?usp=sharing

Components converted in this PR:
- Datatable
- Checkbox

Things that logical properties could not achieve. This would still require JS/Autogeneration for RTL support.
- box-shadow
- transition
- Popper direction

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome, Firefox, Safari.
