### PR TITLE
fix(rtl): fixing popovers placement when direction is rtl

### DIFF
--- a/packages/crayons-core/src/components/data-table/data-table.tsx
+++ b/packages/crayons-core/src/components/data-table/data-table.tsx
@@ -17,6 +17,7 @@ import {
   DataTableRow,
   DataTableAction,
 } from '../../utils/types';
+import { popperModifierRTL } from '../../utils';
 
 const PREDEFINED_VARIANTS_META: any = {
   anchor: {
@@ -48,6 +49,7 @@ const TABLE_POPPER_CONFIG: any = {
         offset: [0, 2],
       },
     },
+    popperModifierRTL,
   ],
 };
 

--- a/packages/crayons-core/src/components/datepicker/datepicker.tsx
+++ b/packages/crayons-core/src/components/datepicker/datepicker.tsx
@@ -98,6 +98,7 @@ export class Datepicker {
   @State() toMonth: number;
   @State() firstFocusElement: HTMLElement = null;
   @State() lastFocusElement: HTMLElement = null;
+  @State() popoverContentElement: HTMLElement;
   @State() langModule: any;
   @State() shortMonthNames: any;
   @State() longMonthNames: any;
@@ -1382,7 +1383,12 @@ export class Datepicker {
             </fw-input>
           </div>
           {this.showSingleDatePicker() ? (
-            <div id='datepicker' class='datepicker' slot='popover-content'>
+            <div
+              id='datepicker'
+              class='datepicker'
+              slot='popover-content'
+              ref={(el) => (this.popoverContentElement = el)}
+            >
               <div class='mdp-container'>
                 {/* Head section */}
                 <div class='mdpc-head'>
@@ -1393,8 +1399,8 @@ export class Datepicker {
                         readonly={true}
                         value={this.shortMonthNames[this.month]}
                         same-width='false'
-                        variant='button'
                         options-placement='bottom-start'
+                        variant='button'
                         options={this.longMonthNames.map((month, i) => ({
                           value: this.shortMonthNames[i],
                           key: i,
@@ -1402,6 +1408,7 @@ export class Datepicker {
                           text: month,
                         }))}
                         allowDeselect={false}
+                        boundary={this.popoverContentElement}
                       ></fw-select>
                     </span>
 
@@ -1411,9 +1418,10 @@ export class Datepicker {
                         readonly={true}
                         value={this.year}
                         same-width='false'
-                        options-placement='bottom'
+                        options-placement='bottom-start'
                         variant='button'
                         allow-deselect='false'
+                        boundary={this.popoverContentElement}
                       >
                         {this.renderSupportedYears()}
                       </fw-select>
@@ -1433,7 +1441,12 @@ export class Datepicker {
             ''
           )}
           {this.showDateRangePicker() ? (
-            <div id='datepicker' class='daterangepicker' slot='popover-content'>
+            <div
+              id='datepicker'
+              class='daterangepicker'
+              slot='popover-content'
+              ref={(el) => (this.popoverContentElement = el)}
+            >
               <div class='mdp-range-container'>
                 {/* Head section */}
                 <div class='mdpc-head'>
@@ -1453,6 +1466,7 @@ export class Datepicker {
                           text: month,
                         }))}
                         allowDeselect={false}
+                        boundary={this.popoverContentElement}
                       ></fw-select>
                     </span>
                     <span class='mdpchc-year'>
@@ -1461,9 +1475,10 @@ export class Datepicker {
                         readonly={true}
                         value={this.year}
                         same-width='false'
-                        options-placement='bottom'
+                        options-placement='bottom-start'
                         variant='button'
                         allow-deselect='false'
+                        boundary={this.popoverContentElement}
                       >
                         {this.renderSupportedYears()}
                       </fw-select>
@@ -1485,6 +1500,7 @@ export class Datepicker {
                           text: month,
                         }))}
                         allowDeselect={false}
+                        boundary={this.popoverContentElement}
                       ></fw-select>
                     </span>
                     <span class='mdpchc-year'>
@@ -1493,9 +1509,10 @@ export class Datepicker {
                         readonly={true}
                         value={this.toYear}
                         same-width='false'
-                        options-placement='bottom'
+                        options-placement='bottom-start'
                         variant='button'
                         allow-deselect='false'
+                        boundary={this.popoverContentElement}
                       >
                         {this.renderSupportedYears()}
                       </fw-select>

--- a/packages/crayons-core/src/components/popover/popover.tsx
+++ b/packages/crayons-core/src/components/popover/popover.tsx
@@ -11,6 +11,7 @@ import {
 } from '@stencil/core';
 import { createPopper, Instance } from '@popperjs/core';
 import { PopoverPlacementType, PopoverTriggerType } from '../../utils/types';
+import { popperModifierRTL } from '../../utils';
 
 @Component({
   tag: 'fw-popover',
@@ -232,6 +233,7 @@ export class Popover {
             offset: [Number(this.skidding), Number(this.distance)],
           },
         },
+        popperModifierRTL,
       ],
     };
   }

--- a/packages/crayons-core/src/utils/index.ts
+++ b/packages/crayons-core/src/utils/index.ts
@@ -343,6 +343,36 @@ export const popperModifierRTL = {
         if (state.options?.placement) {
           state.options.placement = rtlPlacement;
         }
+        if (state.options?.modifiers) {
+          const fallbackPlacementModIndex = state.options.modifiers.findIndex(
+            (mod) => {
+              return mod.name === 'flip';
+            }
+          );
+          const fallbackPlacementOrderModIndex =
+            state.orderedModifiers.findIndex((mod) => {
+              return mod.name === 'flip';
+            });
+          if (state.options.modifiers[fallbackPlacementModIndex]) {
+            const fallbackPlacements = [];
+            state.options.modifiers[
+              fallbackPlacementModIndex
+            ].options.fallbackPlacements?.forEach((fp: any) => {
+              fallbackPlacements.push(
+                fp.replace(
+                  /right|left|start|end/,
+                  (matched) => replaceMap[matched]
+                )
+              );
+            });
+            state.options.modifiers[
+              fallbackPlacementModIndex
+            ].options.fallbackPlacements = fallbackPlacements;
+            state.orderedModifiers[
+              fallbackPlacementOrderModIndex
+            ].options.fallbackPlacements = fallbackPlacements;
+          }
+        }
         if (!state.modifiersData['popperModifierRTL#persistent']) {
           state.modifiersData['popperModifierRTL#persistent'] = {};
         }

--- a/packages/crayons-core/src/utils/index.ts
+++ b/packages/crayons-core/src/utils/index.ts
@@ -314,3 +314,42 @@ export const addRTL = (host) => {
     host.setAttribute('dir', 'ltr');
   }
 };
+
+export const popperModifierRTL = {
+  name: 'popperModifierRTL',
+  enabled: true,
+  phase: 'beforeRead',
+  fn({ state }) {
+    if (
+      document.documentElement.dir === 'rtl' ||
+      state.modifiersData['popperModifierRTL#persistent']?._previousDirection
+    ) {
+      if (
+        !state.modifiersData['popperModifierRTL#persistent']?._skip ||
+        state.modifiersData['popperModifierRTL#persistent']
+          ?._previousDirection !== document.documentElement.dir
+      ) {
+        const replaceMap = {
+          end: 'start',
+          start: 'end',
+          left: 'right',
+          right: 'left',
+        };
+        const rtlPlacement = state.placement.replace(
+          /right|left|start|end/,
+          (matched) => replaceMap[matched]
+        );
+        state.placement = rtlPlacement;
+        if (state.options?.placement) {
+          state.options.placement = rtlPlacement;
+        }
+        if (!state.modifiersData['popperModifierRTL#persistent']) {
+          state.modifiersData['popperModifierRTL#persistent'] = {};
+        }
+        state.modifiersData['popperModifierRTL#persistent']._skip = true;
+        state.modifiersData['popperModifierRTL#persistent']._previousDirection =
+          document.documentElement.dir;
+      }
+    }
+  },
+};


### PR DESCRIPTION
Position of the popover modified with popper js custom modifier.

Before Fix:
<img width="1420" alt="Screenshot 2022-06-17 at 11 14 34 AM" src="https://user-images.githubusercontent.com/61269786/174233159-b76fdf77-6d1e-492f-aa9e-f17e6536825e.png">
<img width="614" alt="Screenshot 2022-06-17 at 11 14 50 AM" src="https://user-images.githubusercontent.com/61269786/174233287-df744f96-9439-4663-93d3-2c8f09e5fb9e.png">
<img width="426" alt="Screenshot 2022-06-17 at 11 14 22 AM" src="https://user-images.githubusercontent.com/61269786/174233359-95b34f9a-d82f-4aeb-bd6f-30cbd3846ea5.png">

After Fix:
<img width="950" alt="Screenshot 2022-06-17 at 11 08 10 AM" src="https://user-images.githubusercontent.com/61269786/174233389-9cb95201-7da1-4055-b191-f8e64a7b6b3b.png">
<img width="673" alt="Screenshot 2022-06-17 at 11 08 59 AM" src="https://user-images.githubusercontent.com/61269786/174233533-5cfd96c2-b9ae-4e99-a9e3-e0baf54f7161.png">
<img width="453" alt="Screenshot 2022-06-17 at 11 10 42 AM" src="https://user-images.githubusercontent.com/61269786/174233573-9fbf2449-44df-4f22-89b4-59309d824898.png">


## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Tested in Chrome, Firefox and Safari browsers.
