### PR TITLE
feat(token builder): selector based tokens

### DIFF
--- a/packages/crayons-styles/scripts/convertTokens.js
+++ b/packages/crayons-styles/scripts/convertTokens.js
@@ -49,7 +49,6 @@ function createTokens() {
       const parsedSelector = selector.trim().toLowerCase();
       const cssSelector =
         parsedSelector === 'base' ? ':root' : `fw-${parsedSelector}`;
-      console.log(cssString);
       return (cssString += `${cssSelector}{${convertTokenToString(
         value[selector]
       )}}`);

--- a/packages/crayons-styles/scripts/convertTokens.js
+++ b/packages/crayons-styles/scripts/convertTokens.js
@@ -45,9 +45,18 @@ function writeFile(outPath, content) {
 function createTokens() {
   const tokens = readFiles(tokensDir);
   for (const [key, value] of Object.entries(tokens)) {
-    const tokenPath = path.join(tokenOutDir, `${key}.js`);
+    const cssString = Object.keys(value).reduce((cssString, selector) => {
+      const parsedSelector = selector.trim().toLowerCase();
+      const cssSelector =
+        parsedSelector === 'base' ? ':root' : `fw-${parsedSelector}`;
+      console.log(cssString);
+      return (cssString += `${cssSelector}{${convertTokenToString(
+        value[selector]
+      )}}`);
+    }, '');
+
     const cssPath = path.join(cssOutDir, `${key}-theme.min.css`);
-    const cssString = `:root {${convertTokenToString(value)}}`;
+    const tokenPath = path.join(tokenOutDir, `${key}.js`);
     writeFile(cssPath, cssString);
     writeFile(tokenPath, `const ${key}= '${cssString}'; export default ${key}`);
   }


### PR DESCRIPTION
## Description:
Selector based css variables supports 

Instead of dumping all the css variables inside the root selector, the css variables are placed based on the component as shown below. This will help to overwrite global css variables at component level.
```
:root {
	--fw-color-primary-600: #447093;
	--fw-color-primary-700: #345c7c;
}

fw-button {
	--fw-button-font-weight: 500;
	--fw-button-font-size: 12px;
}

fw-tabs {
	--fw-tabs-padding-left: 0px;
	--fw-tabs-padding-right: 0px;
	--fw-tabs-padding-lr: 0px;
}
```