### PR TITLE
fix(country-phone): Resetting is breaking on country code select dropdown

### DIFF
--- a/packages/crayons-core/src/components/country-phone/countries.json
+++ b/packages/crayons-core/src/components/country-phone/countries.json
@@ -1256,21 +1256,6 @@
       "code2l":"GN"
    },
    {
-      "country_name":"Guinea-Bissau",
-      "native":"Guiné-Bissau",
-      "phone":"245",
-      "continent_name":"AF",
-      "capital":"Bissau",
-      "currency":"XOF",
-      "languages":[
-         "pt"
-      ],
-      "emoji":"🇬🇼",
-      "emojiU":"U+1F1EC U+1F1FC",
-      "code3l":"GNB",
-      "code2l":"GW"
-   },
-   {
       "country_name":"Guyana",
       "native":"Guyana",
       "phone":"592",
@@ -3698,7 +3683,9 @@
          "nl"
       ],
       "emoji":"🇧🇶",
-      "emojiU":"U+1F1E7 U+1F1F6"
+      "emojiU":"U+1F1E7 U+1F1F6",
+      "code3l": "BES",
+      "code2l": "BQ"
    },
    {
       "country_name":"Falkland Islands",
@@ -3756,7 +3743,9 @@
          "fa"
       ],
       "emoji":"🇮🇷",
-      "emojiU":"U+1F1EE U+1F1F7"
+      "emojiU":"U+1F1EE U+1F1F7",
+      "code3l": "IR",
+      "code2l": "IR"
    },
    {
       "country_name":"Moldova",

--- a/packages/crayons-core/src/components/country-phone/country-phone.e2e.ts
+++ b/packages/crayons-core/src/components/country-phone/country-phone.e2e.ts
@@ -160,4 +160,20 @@ describe('fw-country-phone hydrated', () => {
       },
     });
   });
+  it('reset to empty when selected values are deleted from select dropdown', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<fw-country-phone value="919999999999"></fw-country-phone>'
+    );
+    const element = await page.find('fw-country-phone >>> fw-select');
+
+    element.setProperty('value', '');
+    element.waitForEvent('fwChange');
+
+    await page.waitForChanges();
+    const selectElement = await page.find('fw-country-phone >>> fw-select');
+    const selectValue = await selectElement.getProperty('value');
+    expect(selectValue).toBe('');
+  });
 });

--- a/packages/crayons-core/src/components/country-phone/country-phone.tsx
+++ b/packages/crayons-core/src/components/country-phone/country-phone.tsx
@@ -323,9 +323,16 @@ export class CountryPhone {
     this.countryCode = value as CountryCode;
 
     const currentCountry = this.getCountryDetails(value);
-    this.phoneCode = currentCountry[0].phone;
-    this.countryName = currentCountry[0].country_name;
-    this.phoneNumber = '';
+    if (currentCountry && currentCountry.length > 0) {
+      this.phoneCode = currentCountry[0]?.phone || '';
+      this.countryName = currentCountry[0]?.country_name || '';
+      this.phoneNumber = '';
+    } else {
+      this.phoneCode = '';
+      this.countryName = '';
+      this.phoneNumber = '';
+    }
+
     this.isValueUpdatedFromInside = true;
     this.updateValue();
   }


### PR DESCRIPTION
1. Resetting is breaking on country code select dropdown
2. Updated country code which was missing.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
-> Tested Locally 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No impact
