### PR TITLE
fix(css-variables): renamed css variables to keep it consistent with LTR and RTL support

### DIFF
--- a/packages/crayons-core/src/components/file-uploader/file-uploader.scss
+++ b/packages/crayons-core/src/components/file-uploader/file-uploader.scss
@@ -1,3 +1,7 @@
+/**
+  @prop --fw-file-uploader-border: border color for file uploader
+**/
+
 :host {
   display: block;
 }

--- a/packages/crayons-core/src/components/file-uploader/readme.md
+++ b/packages/crayons-core/src/components/file-uploader/readme.md
@@ -131,6 +131,13 @@ Type: `Promise<void>`
 
 
 
+## CSS Custom Properties
+
+| Name                        | Description                    |
+| --------------------------- | ------------------------------ |
+| `--fw-file-uploader-border` | border color for file uploader |
+
+
 ## Dependencies
 
 ### Depends on

--- a/packages/crayons-core/src/components/label/label.scss
+++ b/packages/crayons-core/src/components/label/label.scss
@@ -1,6 +1,7 @@
 /**
   @prop --fw-label-padding-vertical: Top - bottom padding for label
-  @prop --fw-label-padding-horizontal: Left - right padding for label
+  @prop --fw-label-padding-horizontal: Left - Right padding if direction is left-to-right, and Right - Left padding if direction is right-to-left for label
+  
 */
 
 :host {

--- a/packages/crayons-core/src/components/label/readme.md
+++ b/packages/crayons-core/src/components/label/readme.md
@@ -61,10 +61,10 @@ function App() {
 
 ## CSS Custom Properties
 
-| Name                            | Description                    |
-| ------------------------------- | ------------------------------ |
-| `--fw-label-padding-horizontal` | Left - right padding for label |
-| `--fw-label-padding-vertical`   | Top - bottom padding for label |
+| Name                            | Description                                                                                                          |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `--fw-label-padding-horizontal` | Left - Right padding if direction is left-to-right, and Right - Left padding if direction is right-to-left for label |
+| `--fw-label-padding-vertical`   | Top - bottom padding for label                                                                                       |
 
 
 ----------------------------------------------

--- a/packages/crayons-core/src/components/tabs/readme.md
+++ b/packages/crayons-core/src/components/tabs/readme.md
@@ -151,14 +151,14 @@ Type: `Promise<void>`
 
 ## CSS Custom Properties
 
-| Name                      | Description                     |
-| ------------------------- | ------------------------------- |
-| `--fw-tabs-height`        | height of the tab container.    |
-| `--fw-tabs-margin-l`      | left margin for the tab items   |
-| `--fw-tabs-margin-r`      | right margin for the tab items  |
-| `--fw-tabs-padding-left`  | left padding for the tab items  |
-| `--fw-tabs-padding-right` | right padding for the tab items |
-| `--fw-tabs-width`         | width of the tab container.     |
+| Name                             | Description                                                                                                   |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `--fw-tabs-height`               | height of the tab container.                                                                                  |
+| `--fw-tabs-margin-inline-end`    | Right margin if direction is left-to-right, and Left margin if direction is right-to-left for the tab items   |
+| `--fw-tabs-margin-inline-start`  | Left margin if direction is left-to-right, and Right margin if direction is right-to-left for the tab items   |
+| `--fw-tabs-padding-inline-end`   | Right padding if direction is left-to-right, and Left padding if direction is right-to-left for the tab items |
+| `--fw-tabs-padding-inline-start` | Left padding if direction is left-to-right, and Right padding if direction is right-to-left for the tab items |
+| `--fw-tabs-width`                | width of the tab container.                                                                                   |
 
 
 ## Dependencies

--- a/packages/crayons-core/src/components/tabs/tabs.scss
+++ b/packages/crayons-core/src/components/tabs/tabs.scss
@@ -1,10 +1,10 @@
 /**
   @prop --fw-tabs-width: width of the tab container.
   @prop --fw-tabs-height: height of the tab container.
-  @prop --fw-tabs-margin-l: left margin for the tab items
-  @prop --fw-tabs-margin-r: right margin for the tab items
-  @prop --fw-tabs-padding-left: left padding for the tab items
-  @prop --fw-tabs-padding-right: right padding for the tab items
+  @prop --fw-tabs-margin-inline-start: Left margin if direction is left-to-right, and Right margin if direction is right-to-left for the tab items
+  @prop --fw-tabs-margin-inline-end: Right margin if direction is left-to-right, and Left margin if direction is right-to-left for the tab items
+  @prop --fw-tabs-padding-inline-start: Left padding if direction is left-to-right, and Right padding if direction is right-to-left for the tab items
+  @prop --fw-tabs-padding-inline-end: Right padding if direction is left-to-right, and Left padding if direction is right-to-left for the tab items
 */
 
 .tabs {
@@ -15,10 +15,10 @@
 
   &__items__nav {
     padding: 0;
-    padding-inline-start: var(--fw-tabs-padding-left, 12px);
-    padding-inline-end: var(--fw-tabs-padding-right, 12px);
-    margin-inline-start: var(--fw-tabs-margin-l, 0);
-    margin-inline-end: var(--fw-tabs-margin-r, 0);
+    padding-inline-start: var(--fw-tabs-padding-start, 12px);
+    padding-inline-end: var(--fw-tabs-padding-end, 12px);
+    margin-inline-start: var(--fw-tabs-margin-start, 0);
+    margin-inline-end: var(--fw-tabs-margin-end, 0);
     display: flex;
     border-block-end: 1px solid $color-smoke-50;
     overflow-x: auto;


### PR DESCRIPTION
BREAKING CHANGES:
1. renamed `--fw-tabs-margin-l` to `--fw-tabs-margin-inline-start` 
2. renamed `--fw-tabs-margin-r` to `--fw-tabs-margin-inline-end`
3. renamed `--fw-tabs-padding-left` to `--fw-tabs-padding-inline-start`
4. renamed `--fw-tabs-padding-right` to `--fw-tabs-padding-inline-end` 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
