### PR TITLE
fix(tooltip): text wrapping inherited from parent component

### DIFF
--- a/packages/crayons-core/src/components/tooltip/tooltip.scss
+++ b/packages/crayons-core/src/components/tooltip/tooltip.scss
@@ -15,4 +15,5 @@
   overflow: visible;
   overflow-wrap: anywhere;
   word-break: break-word;
+  white-space: initial;
 }


### PR DESCRIPTION
Tooltip inherits properties for white space wrapping from its parent. In accordions case, there is a no-wrap for white space, which causes text inside tooltip to overflow. This PR fixes the issue.

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
