### PR TITLE
fix(input): transition only on border

### DIFF
--- a/packages/crayons-core/src/components/input/input.scss
+++ b/packages/crayons-core/src/components/input/input.scss
@@ -73,7 +73,7 @@ $warning-color: $color-casablanca-300;
   border: 1px solid $input-border;
   background-color: $app-light-bg;
   border-radius: var(--fw-input-border-radius, 4px);
-  transition: all 0.3s ease;
+  transition: border 0.3s ease;
 
   &.error {
     @include stateStyle($error-color);


### PR DESCRIPTION
The change (adding transition to input) was added in #704 to animate border to blue on focus or hover.

When transition is applied for all properties, it inherits visibility property from parent and transition applies for visibility too. When trying to focus during visibility change, focus is not being applied to the component as it is considered to be invisible during visibility change. 

This is affecting crayons-internal editor popup components that use fw-input. When popup's visibility changes, 'setFocus' not working for 300ms as transition from visibility change stays in progress. 

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 