### PR TITLE
fix: height of avatar variant of multi select

### DIFF
--- a/packages/crayons-core/src/components/select/select.scss
+++ b/packages/crayons-core/src/components/select/select.scss
@@ -91,6 +91,10 @@ $disabled-color: $input-disabled-color;
       display: flex;
       flex-wrap: wrap;
       min-width: inherit;
+
+      &.avatar {
+        min-height: 40px;
+      }
       /* stylelint-disable-next-line a11y/no-outline-none */
       &:active,
       &:focus,

--- a/packages/crayons-core/src/components/select/select.tsx
+++ b/packages/crayons-core/src/components/select/select.tsx
@@ -939,7 +939,7 @@ export class Select {
                     <div class='input-container-inner'>
                       {this.multiple && (
                         <div
-                          class='tag-container'
+                          class={`tag-container ${this.tagVariant}`}
                           onFocus={this.focusOnTagContainer}
                           ref={(tagContainer) =>
                             (this.tagContainer = tagContainer)


### PR DESCRIPTION
Issue mentioned in the document - [https://docs.google.com/spreadsheets/d/1bFQbT-lrnAvVNsneIBpHpibeAcpLvjscb3uPRUzFv4U/edit#gid=0](url)

Height of select is not constant. When a tag of avatar variant is added, the height of the select container is increased. This issue has been resolved in this PR.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
