### PR TITLE
fix(datepicker): replace event.path with event.composedPath as it is deprecated from chrome 109 version

### DIFF
--- a/packages/crayons-core/src/components/datepicker/datepicker.tsx
+++ b/packages/crayons-core/src/components/datepicker/datepicker.tsx
@@ -418,7 +418,7 @@ export class Datepicker {
         this.updateValueAndEmitEvent(e);
       }
     }
-    if (e.path[0].innerText === cancelText && !this.value) {
+    if (e.composedPath()[0].innerText === cancelText && !this.value) {
       if (this.mode === 'range') {
         this.startDate = this.endDate = undefined;
       } else {
@@ -426,15 +426,15 @@ export class Datepicker {
       }
     }
 
-    if (e.path[0].innerText === cancelText) {
+    if (e.composedPath()[0].innerText === cancelText) {
       this.handlePopoverClose(e);
     }
 
     // Close datepicker only for fwClick event of Update and cancel buttons. Since this will
     // be triggered for month and year select dropdown as well the below check is added.
     if (
-      e.path[0].innerText === updateText ||
-      e.path[0].innerText === cancelText
+      e.composedPath()[0].innerText === updateText ||
+      e.composedPath()[0].innerText === cancelText
     ) {
       this.showDatePicker = false;
       this.host.shadowRoot.querySelector('fw-popover').hide();
@@ -449,7 +449,7 @@ export class Datepicker {
     e.stopImmediatePropagation();
     if (e.composedPath()[0].classList.value.includes('range-date-input')) {
       // Range input
-      const val = e.path[0].value;
+      const val = e.composedPath()[0].value;
 
       if (!val) {
         this.value = undefined;
@@ -516,7 +516,7 @@ export class Datepicker {
         this.toMonth === 0 ? this.yearCalculation(this.year, 1) : this.year;
     } else {
       // Single Date input
-      const val = e.path[0].value;
+      const val = e.composedPath()[0].value;
 
       if (!val) {
         this.value = undefined;
@@ -577,7 +577,7 @@ export class Datepicker {
    */
   @Listen('fwChange')
   handleMonthYearDropDownSelection(e) {
-    if (e.path[0].tagName !== 'FW-DATEPICKER') {
+    if (e.composedPath()[0].tagName !== 'FW-DATEPICKER') {
       e.stopImmediatePropagation();
     }
 


### PR DESCRIPTION

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
