### PR TITLE
feat(fw-textarea): added maxRows to fw-textarea for dynamic Resizing

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -2019,6 +2019,14 @@ export namespace Components {
          */
         "label": string;
         /**
+          * Max number of rows the textarea can create when user writes content greater than regular rows.
+         */
+        "maxRows"?: number;
+        /**
+          * Debounce timer for setting rows dynamically based on user input and maxRows, default is 200ms.
+         */
+        "maxRowsDebounceTimer"?: number;
+        /**
           * Maximum number of characters a user can enter in the input box.
          */
         "maxlength"?: number;
@@ -4938,6 +4946,14 @@ declare namespace LocalJSX {
           * Label displayed on the interface, for the component.
          */
         "label"?: string;
+        /**
+          * Max number of rows the textarea can create when user writes content greater than regular rows.
+         */
+        "maxRows"?: number;
+        /**
+          * Debounce timer for setting rows dynamically based on user input and maxRows, default is 200ms.
+         */
+        "maxRowsDebounceTimer"?: number;
         /**
           * Maximum number of characters a user can enter in the input box.
          */

--- a/packages/crayons-core/src/components/textarea/readme.md
+++ b/packages/crayons-core/src/components/textarea/readme.md
@@ -45,6 +45,21 @@ fw-textarea displays an input box on the user interface and enables assigning mu
   state="normal"
 >
 </fw-textarea>
+<fw-textarea
+  cols="75"
+  rows="4"
+  max-rows="10"
+  label="Description"
+>
+</fw-textarea>
+<fw-textarea
+  cols="75"
+  rows="4"
+  max-rows="10"
+  max-rows-debounce-timer="300"
+  label="Description"
+>
+</fw-textarea>
 ```
 
 ## Usage
@@ -133,6 +148,8 @@ function App() {
 | `hintText`    | `hint-text`    | Hint text displayed below the text box.                                                                                                                                                                                                                           | `string`                                         | `''`        |
 | `label`       | `label`        | Label displayed on the interface, for the component.                                                                                                                                                                                                              | `string`                                         | `''`        |
 | `maxlength`   | `maxlength`    | Maximum number of characters a user can enter in the input box.                                                                                                                                                                                                   | `number`                                         | `undefined` |
+| `maxRows`        | `max-rows`         | Max Number of rows the textarea can create when user writes content greater than regular rows. | `Number`                               | `undefined`    |
+| `maxRowsDebounceTimer`        | `max-rows-debounce-timer`         |  Debounce Timer For Setting Rows Dynamically based on user input and maxRows. Default is 200 | `Number`                               | `200`    |
 | `minlength`   | `minlength`    | Minimum number of characters a user must enter in the input box for the value to be valid.                                                                                                                                                                        | `number`                                         | `undefined` |
 | `name`        | `name`         | Name of the component, saved as part of form data.                                                                                                                                                                                                                | `string`                                         | `''`        |
 | `placeholder` | `placeholder`  | Text displayed in the input box before a user enters a value.                                                                                                                                                                                                     | `string`                                         | `undefined` |

--- a/packages/crayons-core/src/components/textarea/textarea.e2e.ts
+++ b/packages/crayons-core/src/components/textarea/textarea.e2e.ts
@@ -81,4 +81,17 @@ describe('fw-textarea', () => {
 
     expect(fwChange).not.toHaveReceivedEvent();
   });
+
+  it('it does not call addListeners function if maxRows props not added', async () => {
+    const addListeners = jest.fn();
+    const page = await newE2EPage();
+    await page.exposeFunction('addListeners', () => {
+      addListeners();
+    });
+    await page.setContent('<fw-textarea rows="4"> </fw-textarea>');
+    const element = await page.find('fw-textarea');
+    element.setProperty('value', '1\n2\n3\n4\n5\n6');
+    await page.waitForChanges();
+    expect(addListeners).not.toHaveBeenCalled();
+  });
 });

--- a/packages/crayons-core/src/components/textarea/textarea.e2e.ts
+++ b/packages/crayons-core/src/components/textarea/textarea.e2e.ts
@@ -82,6 +82,21 @@ describe('fw-textarea', () => {
     expect(fwChange).not.toHaveReceivedEvent();
   });
 
+  it('it does not increase row size more than max-rows when content lines are greater than max-rows', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<fw-textarea rows="4" max-rows="5"> </fw-textarea>');
+    const element = await page.find('fw-textarea');
+    await element.click();
+    page.keyboard.type('1\n2\n3\n4\n5\n6\n7');
+    await page.waitFor(2000);
+    await page.waitForChanges();
+    const value = await element.getProperty('value');
+    const nativeElement = await page.find('fw-textarea >>> textarea');
+    const nativeRows = await nativeElement.getAttribute('rows');
+    expect(value).toBe('1\n2\n3\n4\n5\n6\n7');
+    expect(nativeRows).toBe('5');
+  });
+
   it('it does not call addListeners function if maxRows props not added', async () => {
     const addListeners = jest.fn();
     const page = await newE2EPage();

--- a/packages/crayons-core/src/components/textarea/textarea.tsx
+++ b/packages/crayons-core/src/components/textarea/textarea.tsx
@@ -45,11 +45,11 @@ export class Textarea {
    */
   @Prop() rows?: number;
   /**
-   * Max Number of rows the textarea can create when user writes content greater than regular rows.
+   * Max number of rows the textarea can create when user writes content greater than regular rows.
    */
   @Prop() maxRows?: number;
   /**
-   * Debounce Timer For Setting Rows Dynamically based on user input and maxRows. Default is 200ms
+   * Debounce timer for setting rows dynamically based on user input and maxRows, default is 200ms.
    */
   @Prop() maxRowsDebounceTimer?: number;
   /**

--- a/packages/crayons-core/src/components/textarea/textarea.tsx
+++ b/packages/crayons-core/src/components/textarea/textarea.tsx
@@ -4,12 +4,13 @@ import {
   Event,
   EventEmitter,
   Method,
+  Watch,
   Prop,
   State,
   h,
 } from '@stencil/core';
 
-import { renderHiddenField, hasSlot } from '../../utils';
+import { renderHiddenField, hasSlot, debounce } from '../../utils';
 
 import FieldControl from '../../function-components/field-control';
 
@@ -43,6 +44,14 @@ export class Textarea {
    * Height of the input box, specified as number of rows.
    */
   @Prop() rows?: number;
+  /**
+   * Max Number of rows the textarea can create when user writes content greater than regular rows.
+   */
+  @Prop() maxRows?: number;
+  /**
+   * Debounce Timer For Setting Rows Dynamically based on user input and maxRows. Default is 200ms
+   */
+  @Prop() maxRowsDebounceTimer?: number;
   /**
    * Maximum number of characters a user can enter in the input box.
    */
@@ -152,6 +161,20 @@ export class Textarea {
     }
   }
 
+  @Watch('rows')
+  rowsChangeHandler() {
+    if (this.maxRows) {
+      this.removeListeners();
+      this.addListeners();
+    }
+  }
+
+  @Watch('maxRows')
+  maxRowsChangeHandler() {
+    this.removeListeners();
+    this.addListeners();
+  }
+
   componentWillLoad() {
     this.checkSlotContent();
   }
@@ -168,6 +191,48 @@ export class Textarea {
     else if (this.state === 'warning') return `warning-${this.name}`;
     return null;
   }
+
+  componentDidLoad(): void {
+    if (this.maxRows) {
+      this.addListeners();
+    }
+  }
+
+  private addListeners() {
+    this.nativeInput.addEventListener('change', this.debouncedResizeTextArea);
+    this.nativeInput.addEventListener('keydown', this.debouncedResizeTextArea);
+  }
+
+  private removeListeners() {
+    this.nativeInput.removeEventListener(
+      'change',
+      this.debouncedResizeTextArea
+    );
+    this.nativeInput.removeEventListener(
+      'keydown',
+      this.debouncedResizeTextArea
+    );
+  }
+
+  debouncedResizeTextArea = debounce(
+    (_e: Event) => {
+      const lineBreaksCount = this.nativeInput.value.split('\n').length + 1;
+      const rows = this.rows ? this.rows : 2;
+      const isLineBreakBetweenRange =
+        lineBreaksCount >= rows && lineBreaksCount <= this.maxRows;
+      if (isLineBreakBetweenRange) {
+        this.nativeInput.rows = lineBreaksCount;
+      }
+      if (lineBreaksCount <= rows) {
+        this.nativeInput.rows = rows;
+      }
+      if (lineBreaksCount > this.maxRows) {
+        this.nativeInput.rows = this.maxRows;
+      }
+    },
+    this,
+    this.maxRowsDebounceTimer ? this.maxRowsDebounceTimer : 200
+  );
 
   render() {
     const { host, name, value } = this;
@@ -224,6 +289,7 @@ export class Textarea {
                 onBlur={this.onBlur}
                 onFocus={this.onFocus}
                 rows={this.rows}
+                data-max-rows={this.maxRows}
                 cols={this.cols}
                 wrap={this.wrap}
                 id={this.name}


### PR DESCRIPTION
## Checklist:
feat(fw-textarea): added maxRows to fw-textarea for dynamic Resizing.

![fw-textarea-maxRows](https://user-images.githubusercontent.com/112637427/228437107-401ff399-347e-4df9-9032-ce1762c6440d.gif)


<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?

- Tested on local host with both variations with `rows` and `max-rows` and with just `max-rows` prop
  - Eg: When rows=4 and max-rows=10, the default row size will be 4 and as the user interacts with textarea the row size will increase/decrease as the per the number of lines in the content.
  - if no rows is set the default row size is considered as `2` which corresponds to the actual row size of the textarea when no rows prop is passed
  - We also have an optional prop called `max-rows-debounce-timer` which can debounce the events callback to improve performance. Its default value is `200ms`

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
