### PR TITLE
fix(datepicker): fix timezone offset issue for datepicker in form

### DIFF
--- a/packages/crayons-core/src/components/datepicker/datepicker.tsx
+++ b/packages/crayons-core/src/components/datepicker/datepicker.tsx
@@ -342,7 +342,7 @@ export class Datepicker {
             locale: this.langModule,
           })
         )
-      : formatISO(new Date(this.handleUserTimeZoneOffset(value)));
+      : formatISO(new Date(value));
   }
 
   /**
@@ -1037,20 +1037,25 @@ export class Datepicker {
       this.timeValue = '';
     } else {
       if (this.mode !== 'range') {
+        // if the value is of the ISO UTC time format, timezone offset need not be calculated
+        // when datepicker is used in form component, the value will be passed to form in UTC ISO format, hence skipping.
+        const utcTimeRegex =
+          /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})[+-](\d{2}):(\d{2})/;
         // If ISO format, format it to display format and validate
         try {
           if (isValid(parseISO(value)))
-            value = this.showTimePicker
-              ? format(new Date(value), this.displayFormat, {
-                  locale: this.langModule,
-                })
-              : format(
-                  new Date(this.handleUserTimeZoneOffset(value)),
-                  this.displayFormat,
-                  {
+            value =
+              this.showTimePicker || utcTimeRegex.test(value)
+                ? format(new Date(value), this.displayFormat, {
                     locale: this.langModule,
-                  }
-                );
+                  })
+                : format(
+                    new Date(this.handleUserTimeZoneOffset(value)),
+                    this.displayFormat,
+                    {
+                      locale: this.langModule,
+                    }
+                  );
           this.processValueChange(value, true);
           this.checkYearRestriction();
         } catch (e) {
@@ -1389,10 +1394,7 @@ export class Datepicker {
             }
           );
           this.value = this.startDateFormatted + ' to ' + this.endDateFormatted;
-          this.emitEvent(e, {
-            fromDate: this.formatDate(this.startDateFormatted),
-            toDate: this.formatDate(this.endDateFormatted),
-          });
+          this.emitEvent(e, this.value);
           this.showDatePicker = false;
           this.host.shadowRoot.querySelector('fw-popover').hide();
         }
@@ -1456,10 +1458,7 @@ export class Datepicker {
       this.toDate = this.endDateFormatted;
 
       this.value = this.startDateFormatted + ' to ' + this.endDateFormatted;
-      this.emitEvent(e, {
-        fromDate: this.formatDate(this.startDateFormatted),
-        toDate: this.formatDate(this.endDateFormatted),
-      });
+      this.emitEvent(e, this.value);
     }
   }
 

--- a/packages/crayons-core/src/components/datepicker/datepicker.tsx
+++ b/packages/crayons-core/src/components/datepicker/datepicker.tsx
@@ -1394,7 +1394,10 @@ export class Datepicker {
             }
           );
           this.value = this.startDateFormatted + ' to ' + this.endDateFormatted;
-          this.emitEvent(e, this.value);
+          this.emitEvent(e, {
+            fromDate: this.formatDate(this.startDateFormatted),
+            toDate: this.formatDate(this.endDateFormatted),
+          });
           this.showDatePicker = false;
           this.host.shadowRoot.querySelector('fw-popover').hide();
         }
@@ -1458,7 +1461,10 @@ export class Datepicker {
       this.toDate = this.endDateFormatted;
 
       this.value = this.startDateFormatted + ' to ' + this.endDateFormatted;
-      this.emitEvent(e, this.value);
+      this.emitEvent(e, {
+        fromDate: this.formatDate(this.startDateFormatted),
+        toDate: this.formatDate(this.endDateFormatted),
+      });
     }
   }
 

--- a/packages/crayons-core/src/components/form/form.e2e.ts
+++ b/packages/crayons-core/src/components/form/form.e2e.ts
@@ -1116,4 +1116,24 @@ describe('fw-form', () => {
     expect(result.values['pincode']).toEqual(56000);
     expect(result.values['amount_paid']).toEqual(5000);
   });
+
+  it('should render the right date in datepicker which user has passed/selected', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<fw-form></fw-form>');
+    await page.$eval(
+      'fw-form',
+      (ele: any, { formSchema }) => {
+        ele.formSchema = formSchema;
+      },
+      fieldOptionsData
+    );
+
+    await page.waitForChanges();
+    const element = await page.find('fw-form');
+    await element.callMethod('setFieldsValue', {
+      date_of_birth: '2023-05-10',
+    });
+    const result = await element.callMethod('doSubmit');
+    expect(result.values['date_of_birth']).toEqual('2023-05-10');
+  });
 });


### PR DESCRIPTION
To test the fix, Please use the below link. 
https://snazzy-blini-707dc6.netlify.app/components/core/form/#demo-dynamic-form

Test scenarios: Change the timezone to 

1. Canada (few hours behind) 
2. Russia (few hours ahead) 
3. current timezone.

Below fixes are made in the PR.
1. handled timezone offset calculation for datepicker when used in fw-form component

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
