### PR TITLE
fix(filter-condition): avoid passing value to date picker when mode i…

### DIFF
--- a/packages/crayons-extended/custom-objects/src/components/filter/filter-condition/filter-condition.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/filter/filter-condition/filter-condition.tsx
@@ -191,7 +191,7 @@ export class FilterCondition {
           const { from: fromDate, to: toDate } = this.value;
           if (fromDate && toDate) {
             const value = { fromDate, toDate };
-            props = { ...props, ...value, value };
+            props = { ...props, ...value };
           }
         }
         return (


### PR DESCRIPTION
…s range

To address:
https://github.com/freshworks/crayons/issues/865

Steps to reproduce:

1. Add a range to table filter.
2. Click on apply in the slider and save filter.
3. Re-open the filter slider.
4. Note '[object object]' in place of selected date range.
5. An error is printed in the console.

Before fix:

https://github.com/freshworks/crayons/assets/61269786/97230f13-e60d-4e5c-919e-9c64079149fc


After fix:

https://github.com/freshworks/crayons/assets/61269786/54e3e836-2f80-420d-b26a-c0f8fa2a6a11


## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)

