### PR TITLE
feat(fw-platform-table): [Enhancement] - Ability to modify CSS or (change height or width) of fw-data-table of FwPlatformTable

### DIFF
--- a/packages/crayons-extended/custom-objects/src/components.d.ts
+++ b/packages/crayons-extended/custom-objects/src/components.d.ts
@@ -412,6 +412,11 @@ export namespace Components {
          */
         "clearTableSelection": () => Promise<void>;
         /**
+          * Custom css styles (background/margins/width/height etc.)
+          * @type {({[k: string]: string} | string)}
+         */
+        "customStyles": { [key: string]: string } | string;
+        /**
           * Whether the checkbox should be visible.
          */
         "isSelectable": boolean;
@@ -440,9 +445,17 @@ export namespace Components {
          */
         "sortableColumns": {};
         /**
+          * Height of the data-table ex. 100vh, 100%, auto etc.
+         */
+        "tableHeight": string;
+        /**
           * Props for the fw-pagination component
          */
         "tableProps": {};
+        /**
+          * Width of the data-table ex. 100vh, 100%, auto etc.
+         */
+        "tableWidth": string;
     }
     interface FwSearchDropdown {
         /**
@@ -1194,6 +1207,11 @@ declare namespace LocalJSX {
     }
     interface FwPlatformTable {
         /**
+          * Custom css styles (background/margins/width/height etc.)
+          * @type {({[k: string]: string} | string)}
+         */
+        "customStyles"?: { [key: string]: string } | string;
+        /**
           * Whether the checkbox should be visible.
          */
         "isSelectable"?: boolean;
@@ -1230,9 +1248,17 @@ declare namespace LocalJSX {
          */
         "sortableColumns"?: {};
         /**
+          * Height of the data-table ex. 100vh, 100%, auto etc.
+         */
+        "tableHeight"?: string;
+        /**
           * Props for the fw-pagination component
          */
         "tableProps"?: {};
+        /**
+          * Width of the data-table ex. 100vh, 100%, auto etc.
+         */
+        "tableWidth"?: string;
     }
     interface FwSearchDropdown {
         /**

--- a/packages/crayons-extended/custom-objects/src/components/platform-table/platform-table.scss
+++ b/packages/crayons-extended/custom-objects/src/components/platform-table/platform-table.scss
@@ -1,3 +1,8 @@
+/**
+ * @prop --fw-platform-table-height: Platform-table height: Default: 100% for the data table
+ * @prop --fw-platform-table-width: Platform-table width: Default: 100% for the data table
+ */
+
 .toolbar {
   display: flex;
   align-items: center;

--- a/packages/crayons-extended/custom-objects/src/components/platform-table/platform-table.scss
+++ b/packages/crayons-extended/custom-objects/src/components/platform-table/platform-table.scss
@@ -41,6 +41,8 @@
 }
 
 .table {
+  height: var(--fw-platform-table-width, 100%);
+  width: var(--fw-platform-table-height, 100%);
   border: 1px solid rgba(207, 215, 223, 0.4);
   border-end-start-radius: 0px;
   border-end-end-radius: 0px;

--- a/packages/crayons-extended/custom-objects/src/components/platform-table/platform-table.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/platform-table/platform-table.tsx
@@ -36,6 +36,24 @@ export class PlatformTable {
    * Props for the fw-pagination component
    */
   @Prop() paginationProps = {};
+
+  /**
+   * Custom css styles (background/margins/width/height etc.)
+   *
+   * @type {({[k: string]: string} | string)}
+   */
+  @Prop() customStyles: { [key: string]: string } | string = {};
+
+  /**
+   * Width of the data-table ex. 100vh, 100%, auto etc.
+   */
+  @Prop() tableWidth: string = null;
+
+  /**
+   * Height of the data-table ex. 100vh, 100%, auto etc.
+   */
+  @Prop() tableHeight: string = null;
+
   /**
    * The sort by column key.
    */
@@ -95,6 +113,29 @@ export class PlatformTable {
     e.stopImmediatePropagation();
     e.stopPropagation();
     e.preventDefault();
+  }
+
+  get style(): any {
+    const dimensionsStyles: {
+      width?: string;
+      height?: string;
+    } = {
+      width: null,
+      height: null,
+    };
+
+    if (this.tableWidth) {
+      dimensionsStyles.width = this.tableWidth;
+    }
+
+    if (this.tableHeight) {
+      dimensionsStyles.height = this.tableHeight;
+    }
+
+    const styles =
+      typeof this.customStyles === 'object' ? this.customStyles : {};
+
+    return { ...dimensionsStyles, ...styles };
   }
 
   /**
@@ -192,6 +233,7 @@ export class PlatformTable {
           <slot name='error-state'></slot>
         ) : (
           <fw-data-table
+            style={this.style}
             {...this.defaultProps}
             {...this.tableProps}
             class='table'

--- a/packages/crayons-extended/custom-objects/src/components/platform-table/readme.md
+++ b/packages/crayons-extended/custom-objects/src/components/platform-table/readme.md
@@ -1116,7 +1116,9 @@ export default Table
 | `showError`       | `show-error`    | When set true the error state slot will be shown. | `boolean` | `false`     |
 | `sortableColumns` | --              | The sortable columns object.                      | `{}`      | `{}`        |
 | `tableProps`      | --              | Props for the fw-pagination component             | `{}`      | `{}`        |
-
+| `tableHeight`     | `table-height`  | Height of the data-table ex. 100vh, 100%, auto    | `string`  | `null`      |
+| `tableWidth`      | `table-width`   | Width of the data-table ex. 100vw, 100%, auto     | `string`  | `null`      |
+| `customStyles`    | `custom-styles` | Custom css styles (background/width/height etc.)  | `string \| { [key: string]: string; }` | `{}`      |
 ## Events
 
 | Event          | Description                                | Type               |

--- a/packages/crayons-extended/custom-objects/src/components/platform-table/readme.md
+++ b/packages/crayons-extended/custom-objects/src/components/platform-table/readme.md
@@ -1119,6 +1119,14 @@ export default Table
 | `tableHeight`     | `table-height`  | Height of the data-table ex. 100vh, 100%, auto    | `string`  | `null`      |
 | `tableWidth`      | `table-width`   | Width of the data-table ex. 100vw, 100%, auto     | `string`  | `null`      |
 | `customStyles`    | `custom-styles` | Custom css styles (background/width/height etc.)  | `string \| { [key: string]: string; }` | `{}`      |
+
+## CSS Custom Properties
+
+| Name                          | Description                                                                               |
+| ----------------------------- | ----------------------------------------------------------------------------------------- |
+| `--fw-platform-table-height`        |  Platform-table height: Default: 100% for the data table    |
+| `--fw-platform-table-width`         |  Platform-table width: Default: 100% for the data table     |
+
 ## Events
 
 | Event          | Description                                | Type               |


### PR DESCRIPTION


 [Enhancement] - Ability to modify CSS or (change height or width) of fw-data-table of FwPlatformTable

Currently FwPlatformTable has a toolbar set that could be used to search and customise the columns and fw-data-table.
We have a request to display the table with horizontal scrollbar.
Since fw-data-table is the shadow element present in FwPlatformTable. We are currently unable to modify the height of the fw-data-table to meet the expectations.
We have tried different css ways to modify the FwPlatformTable to ensure we get the horizontal scrollbar.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?


Have added the properties and have manually tested the scenarios.
<img width="1792" alt="Screenshot 2023-08-09 at 6 19 27 PM" src="https://github.com/freshworks/crayons/assets/96039290/e5b82e35-52d8-45e5-a5a9-406905a2d2b9">


<img width="1792" alt="Screenshot 2023-08-09 at 6 20 17 PM" src="https://github.com/freshworks/crayons/assets/96039290/c3e1928e-2cd1-4dd7-ac15-1acc39aa07bb">

