### PR TITLE
fix(file-uploader): correcting MB to KB conversion formula

### DIFF
--- a/packages/crayons-core/src/components/file-uploader-2/file-2/file-2.tsx
+++ b/packages/crayons-core/src/components/file-uploader-2/file-2/file-2.tsx
@@ -15,6 +15,7 @@ import {
   iconAddLibrary,
 } from '../../../utils/assets';
 import { TranslationController } from '../../../global/Translation';
+import { KB_TO_BYTE } from '../../../constants';
 
 @Component({
   tag: 'fw-file-2',
@@ -151,7 +152,7 @@ export class File2 {
       return ' (0 B)';
     }
 
-    const k = 1024;
+    const k = KB_TO_BYTE;
     const dm = 2;
     const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
     const i = Math.floor(Math.log(bytes) / Math.log(k));

--- a/packages/crayons-core/src/components/file-uploader-2/file-uploader-2.tsx
+++ b/packages/crayons-core/src/components/file-uploader-2/file-uploader-2.tsx
@@ -17,6 +17,7 @@ import {
   UploaderFile,
 } from './file-uploader2-util';
 import { fileDragSVG, fileErrorSVG } from '../../utils/assets';
+import { MB_TO_KB, KB_TO_BYTE } from '../../constants';
 
 let fileCount = 0;
 
@@ -375,7 +376,7 @@ export class FileUploader {
       passed = false;
     } else if (
       this.totalFileSizeAllowed !== 0 &&
-      totalSize > this.totalFileSizeAllowed * 1024 * 1024
+      totalSize > this.totalFileSizeAllowed * MB_TO_KB * KB_TO_BYTE
     ) {
       this.errorText = this.totalFileSizeAllowedError;
       passed = false;
@@ -413,7 +414,7 @@ export class FileUploader {
       }
     }
     if (this.maxFileSize !== 0) {
-      if (fileSize > this.maxFileSize * 1024 * 1024) {
+      if (fileSize > this.maxFileSize * MB_TO_KB * KB_TO_BYTE) {
         isPassed = false;
         errors.push(this.maxFileSizeError);
       }

--- a/packages/crayons-core/src/components/file-uploader/file-uploader.tsx
+++ b/packages/crayons-core/src/components/file-uploader/file-uploader.tsx
@@ -10,8 +10,8 @@ import {
   Method,
 } from '@stencil/core';
 import { TranslationController } from '../../global/Translation';
-
 import { renderHiddenField } from '../../utils';
+import { MB_TO_KB, KB_TO_BYTE } from '../../constants';
 
 let fileCount = 1;
 
@@ -349,7 +349,7 @@ export class FileUploader {
       }
     }
     if (this.maxFileSize !== 0) {
-      if (fileSize > this.maxFileSize * 1024 * 1024) {
+      if (fileSize > this.maxFileSize * MB_TO_KB * KB_TO_BYTE) {
         isPassed = false;
         errors.push(
           this.maxFileSizeError ||

--- a/packages/crayons-core/src/constants/index.ts
+++ b/packages/crayons-core/src/constants/index.ts
@@ -1,0 +1,2 @@
+export const MB_TO_KB = 1000;
+export const KB_TO_BYTE = 1000;


### PR DESCRIPTION
During file validation, we compare the uploaded file size to the permitted file size. We convert the permitted file size from KB to MB. 

Conversion previously used was 1MB is 1024KB. Which led to cases where file sizes that shouldn't have passed validation, passed.
Now correctly this conversion formula to 1MB is 1000KB. 

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
- By adding a file exactly 5.1MB. This was previously passing the validation in place. After fix, this is properly restricted and error message is shown.
