### PR TITLE
refactor(component): showRelationshipTypeSelect based on config provided by the products

### DIFF
--- a/packages/crayons-extended/custom-objects/src/components.d.ts
+++ b/packages/crayons-extended/custom-objects/src/components.d.ts
@@ -106,6 +106,10 @@ export namespace Components {
           * flag to show dependentField resolve checkbox
          */
         "showDependentFieldResolveProp": boolean;
+        /**
+          * flag to show relationshipTypeSelect dropdown or not
+         */
+        "showRelationshipTypeSelect": boolean;
     }
     interface FbSectionCreate {
         /**
@@ -280,6 +284,10 @@ export namespace Components {
          */
         "showErrors": boolean;
         /**
+          * flag to show relationshipTypeSelect dropdown or not
+         */
+        "showRelationshipTypeSelect": boolean;
+        /**
           * source object value
          */
         "sourceObjectName": string;
@@ -392,6 +400,10 @@ export namespace Components {
           * flag to show dependentField resolve checkbox
          */
         "showDependentFieldResolveProp": boolean;
+        /**
+          * flag to show relationshipTypeSelect dropdown or not
+         */
+        "showRelationshipTypeSelect": boolean;
         "showSections": boolean;
     }
     interface FwFieldTypeMenuItem {
@@ -565,6 +577,10 @@ export namespace Components {
           * flag to show lookupField for CONVERSATION_PROPERTIES or not
          */
         "showLookupField": boolean;
+        /**
+          * flag to show relationshipTypeSelect dropdown or not
+         */
+        "showRelationshipTypeSelect": boolean;
         /**
           * Show explore plans and disable features for user having free-plan
          */
@@ -1049,6 +1065,10 @@ declare namespace LocalJSX {
           * flag to show dependentField resolve checkbox
          */
         "showDependentFieldResolveProp"?: boolean;
+        /**
+          * flag to show relationshipTypeSelect dropdown or not
+         */
+        "showRelationshipTypeSelect"?: boolean;
     }
     interface FbSectionCreate {
         /**
@@ -1261,6 +1281,10 @@ declare namespace LocalJSX {
          */
         "showErrors"?: boolean;
         /**
+          * flag to show relationshipTypeSelect dropdown or not
+         */
+        "showRelationshipTypeSelect"?: boolean;
+        /**
           * source object value
          */
         "sourceObjectName"?: string;
@@ -1389,6 +1413,10 @@ declare namespace LocalJSX {
           * flag to show dependentField resolve checkbox
          */
         "showDependentFieldResolveProp"?: boolean;
+        /**
+          * flag to show relationshipTypeSelect dropdown or not
+         */
+        "showRelationshipTypeSelect"?: boolean;
         "showSections"?: boolean;
     }
     interface FwFieldTypeMenuItem {
@@ -1598,6 +1626,10 @@ declare namespace LocalJSX {
           * flag to show lookupField for CONVERSATION_PROPERTIES or not
          */
         "showLookupField"?: boolean;
+        /**
+          * flag to show relationshipTypeSelect dropdown or not
+         */
+        "showRelationshipTypeSelect"?: boolean;
         /**
           * Show explore plans and disable features for user having free-plan
          */

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/assets/form-mapper.json
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/assets/form-mapper.json
@@ -241,7 +241,6 @@
       "freePlanFieldAddDisabledButton": "",
       "noCreatePermissionFieldAddDisabledHeader": "",
       "noCreatePermissionFieldAddDisabledMessage": "",
-      "boolShowRelationshipTypeSelect": true,
       "boolShowCustomToggle": false,
       "showCustomToggleField": ""
     },
@@ -463,7 +462,6 @@
       "freePlanFieldAddDisabledButton": "freePlanFieldAddDisabledButton",
       "noCreatePermissionFieldAddDisabledHeader": "noCreatePermissionFieldAddDisabledHeader",
       "noCreatePermissionFieldAddDisabledMessage": "noCreatePermissionFieldAddDisabledMessage",
-      "boolShowRelationshipTypeSelect": false,
       "boolShowCustomToggle": true,
       "showCustomToggleField": "status"
     },

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/components/fb-field-drag-drop-item.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/components/fb-field-drag-drop-item.tsx
@@ -42,6 +42,10 @@ export class FormBuilderFieldDragDropItem {
    */
   @Prop({ mutable: true }) formValues = null;
   /**
+   * flag to show relationshipTypeSelect dropdown or not
+   */
+  @Prop({ mutable: true }) showRelationshipTypeSelect = true;
+  /**
    * object to store the lookup target entities
    */
   @Prop({ mutable: true }) lookupTargetObjects = false;
@@ -187,6 +191,7 @@ export class FormBuilderFieldDragDropItem {
           index={this.index}
           key={this.keyProp}
           productName={this.productName}
+          showRelationshipTypeSelect={this.showRelationshipTypeSelect}
           dataProvider={this.dataProvider}
           entityName={this.entityName}
           expanded={this.expanded}

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/components/fb-field-lookup.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/components/fb-field-lookup.tsx
@@ -16,7 +16,6 @@ import {
   isUniqueField,
 } from '../utils/form-builder-utils';
 import presetSchema from '../assets/form-builder-preset.json';
-import formMapper from '../assets/form-mapper.json';
 
 @Component({
   tag: 'fw-fb-field-lookup',
@@ -41,6 +40,10 @@ export class FbFieldDropdown {
    * source object value
    */
   @Prop({ mutable: true }) sourceObjectName = '';
+  /**
+   * flag to show relationshipTypeSelect dropdown or not
+   */
+  @Prop({ mutable: true }) showRelationshipTypeSelect = true;
   /**
    * array for target objects
    */
@@ -206,11 +209,6 @@ export class FbFieldDropdown {
     const boolShowDescription =
       strDescription && strDescription !== '' ? true : false;
 
-    const objProductPreset = formMapper[this.productName];
-    const objProductPresetConfig = objProductPreset?.config;
-    const boolShowRelationshipTypeSelect =
-      objProductPresetConfig?.boolShowRelationshipTypeSelect;
-
     return (
       <Host tabIndex='-1'>
         <div class={`${strBaseClassName}-root`}>
@@ -224,7 +222,7 @@ export class FbFieldDropdown {
               value={this.sourceObjectName}
               disabled
             ></fw-input>
-            {boolShowRelationshipTypeSelect ? (
+            {this.showRelationshipTypeSelect ? (
               <div class={`${strBaseClassName}-relationship-select-container`}>
                 <fw-select
                   readonly={true}

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/components/field-editor.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/components/field-editor.tsx
@@ -96,6 +96,10 @@ export class FieldEditor {
    */
   @Prop({ mutable: true }) formValues = null;
   /**
+   * flag to show relationshipTypeSelect dropdown or not
+   */
+  @Prop({ mutable: true }) showRelationshipTypeSelect = true;
+  /**
    * object to store the lookup target entities
    */
   @Prop({ mutable: true }) lookupTargetObjects = false;
@@ -1468,6 +1472,7 @@ export class FieldEditor {
         onFwChange={this.lookupChangeHandler}
         formValues={objFormValue}
         productName={this.productName}
+        showRelationshipTypeSelect={this.showRelationshipTypeSelect}
       ></fw-fb-field-lookup>
     );
   }

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
@@ -86,6 +86,10 @@ export class FormBuilder {
    */
   @Prop({ mutable: true }) showLookupField = true;
   /**
+   * flag to show relationshipTypeSelect dropdown or not
+   */
+  @Prop({ mutable: true }) showRelationshipTypeSelect = true;
+  /**
    * flag to show dependentField for CONVERSATION_PROPERTIES or not
    */
   @Prop({ mutable: true }) showDependentField = true;
@@ -1353,6 +1357,7 @@ export class FormBuilder {
         index={intIndex}
         keyProp={strKey}
         productName={this.productName}
+        showRelationshipTypeSelect={this.showRelationshipTypeSelect}
         dataProvider={dataItem}
         entityName={strEntityName}
         expanded={boolItemExpanded}


### PR DESCRIPTION
showRelationshipTypeSelect based on config provide by the products default value being true.

As we need that support in conversation properties when custom objects is enabled as part of one UCR effort.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
