### PR TITLE
fix: pass of position of the form values on searching specific field in fw-form-builder

### DIFF
--- a/packages/crayons-extended/custom-objects/src/components/form-builder/components/field-editor.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/components/field-editor.tsx
@@ -948,7 +948,10 @@ export class FieldEditor {
 
   private confirmDeleteFieldHandler = () => {
     this.isDeleting = true;
-    this.fwDelete.emit({ index: this.index });
+    this.fwDelete.emit({
+      index: this.index,
+      position: this.oldFormValues?.position,
+    });
     this.modalConfirmDelete?.close();
   };
 


### PR DESCRIPTION
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
Issue: 
Fw-form-builder shares the index of the field on click of delete in the field of the fw-form-builder
The issue arises when a field is searched, the field when selected passes the index as of local value.
So if the oldFormValues has 20 fields and the position of the field searched is 10, and on searching the field which might be unique by name and on clicking on the deleteFieldHandler leads to index being passed as 1 instead leading to the below error.

