### PR TITLE
fix: DatePicker issue observed when selecting date for icelandic language.

### DIFF
--- a/packages/crayons-core/src/components/datepicker/datepicker.e2e.ts
+++ b/packages/crayons-core/src/components/datepicker/datepicker.e2e.ts
@@ -814,4 +814,40 @@ describe('fw-datepicker', () => {
     const dateVal = await dateInput.getAttribute('value');
     expect(dateVal).toBe('07/22/2022');
   });
+
+  it('should update the value of the date input when value is set, when the locale is is', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<fw-datepicker locale="is" value="2022-04-20"></fw-datepicker>'
+    );
+    await page.waitForChanges();
+    const dp = await page.find('fw-datepicker');
+    await dp.setProperty('value', '2022-04-20');
+    await page.waitForChanges();
+    const val = await dp.getProperty('value');
+    expect(val).toBe('20.04.2022');
+    const shadow = await page.find(
+      'fw-datepicker >>> fw-input >>> :first-child'
+    );
+    const alertElement = await shadow.find('.invalid-alert');
+    expect(alertElement).toBeFalsy();
+  });
+
+  it('should update the value of the date input when value is set, when the locale is is', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<fw-datepicker locale="is" value="2022-04-20"></fw-datepicker>'
+    );
+    await page.waitForChanges();
+    const dp = await page.find('fw-datepicker');
+    await dp.setProperty('value', '2022-11-20');
+    await page.waitForChanges();
+    const val = await dp.getProperty('value');
+    expect(val).toBe('20.04.2022');
+    const shadow = await page.find(
+      'fw-datepicker >>> fw-input >>> :first-child'
+    );
+    const alertElement = await shadow.find('.invalid-alert');
+    expect(alertElement).toBeFalsy();
+  });
 });

--- a/packages/crayons-core/src/components/datepicker/datepicker.e2e.ts
+++ b/packages/crayons-core/src/components/datepicker/datepicker.e2e.ts
@@ -836,7 +836,7 @@ describe('fw-datepicker', () => {
   it('should update the value of the date input when value is set, when the locale is is', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<fw-datepicker locale="is" value="2022--20"></fw-datepicker>'
+      '<fw-datepicker locale="is" value="2022-11-20"></fw-datepicker>'
     );
     await page.waitForChanges();
     const dp = await page.find('fw-datepicker');

--- a/packages/crayons-core/src/components/datepicker/datepicker.e2e.ts
+++ b/packages/crayons-core/src/components/datepicker/datepicker.e2e.ts
@@ -836,14 +836,14 @@ describe('fw-datepicker', () => {
   it('should update the value of the date input when value is set, when the locale is is', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<fw-datepicker locale="is" value="2022-04-20"></fw-datepicker>'
+      '<fw-datepicker locale="is" value="2022--20"></fw-datepicker>'
     );
     await page.waitForChanges();
     const dp = await page.find('fw-datepicker');
     await dp.setProperty('value', '2022-11-20');
     await page.waitForChanges();
     const val = await dp.getProperty('value');
-    expect(val).toBe('20.04.2022');
+    expect(val).toBe('20.11.2022');
     const shadow = await page.find(
       'fw-datepicker >>> fw-input >>> :first-child'
     );

--- a/packages/crayons-core/src/components/datepicker/datepicker.tsx
+++ b/packages/crayons-core/src/components/datepicker/datepicker.tsx
@@ -357,13 +357,11 @@ export class Datepicker {
         /jan\.|feb\.|mars|apríl|maí|júní|júlí|ágúst|sept\.|okt\.|nóv\.|des\./g,
         (match) => icelandicMonthMapper[match]
       );
-      return this.displayFormat
-        ? formatISO(
-            parse(correctedDate, isLanguageDisplayFormat, new Date(), {
-              locale: this.langModule,
-            })
-          )
-        : formatISO(new Date(value));
+      return formatISO(
+        parse(correctedDate, isLanguageDisplayFormat, new Date(), {
+          locale: this.langModule,
+        })
+      );
     }
     return this.displayFormat
       ? formatISO(

--- a/packages/crayons-core/src/components/datepicker/datepicker.tsx
+++ b/packages/crayons-core/src/components/datepicker/datepicker.tsx
@@ -337,8 +337,8 @@ export class Datepicker {
   private formatDate(value) {
     if (!value) return value;
     // For Icelandic language, the date format is different. There is a discrepency which is handled in this PR https://github.com/date-fns/date-fns/pull/3934
-    if (this.langModule?.code === 'is' && this.dateFormat === 'dd MMMM yyyy') {
-      const isLanguageDisplayFormat = 'dd MMMM yyyy';
+    if (this.langModule?.code === 'is' && this.dateFormat === 'dd MMM yyyy') {
+      const icelandicLanguageDisplayFormat = 'dd MMMM yyyy';
       const icelandicMonthMapper = {
         'jan.': 'jan.',
         'feb.': 'feb.',
@@ -358,7 +358,7 @@ export class Datepicker {
         (match) => icelandicMonthMapper[match]
       );
       return formatISO(
-        parse(correctedDate, isLanguageDisplayFormat, new Date(), {
+        parse(correctedDate, icelandicLanguageDisplayFormat, new Date(), {
           locale: this.langModule,
         })
       );

--- a/packages/crayons-core/src/components/datepicker/datepicker.tsx
+++ b/packages/crayons-core/src/components/datepicker/datepicker.tsx
@@ -363,6 +363,7 @@ export class Datepicker {
         })
       );
     }
+
     return this.displayFormat
       ? formatISO(
           parse(value, this.displayFormat, new Date(), {

--- a/packages/crayons-core/src/components/datepicker/datepicker.tsx
+++ b/packages/crayons-core/src/components/datepicker/datepicker.tsx
@@ -336,6 +336,35 @@ export class Datepicker {
 
   private formatDate(value) {
     if (!value) return value;
+    // For Icelandic language, the date format is different. There is a discrepency which is handled in this PR https://github.com/date-fns/date-fns/pull/3934
+    if (this.langModule?.code === 'is') {
+      const isLanguageDisplayFormat = 'dd MMMM yyyy';
+      const icelandicMonthMapper = {
+        'jan.': 'jan.',
+        'feb.': 'feb.',
+        'mars': 'm',
+        'apríl': 'apríl',
+        'maí': 'maí',
+        'júní': 'júní',
+        'júlí': 'júlí',
+        'ágúst': 'á',
+        'sept.': 's',
+        'okt.': 'o',
+        'nóv.': 'n',
+        'des.': 'd',
+      };
+      const correctedDate = value.replace(
+        /jan\.|feb\.|mars|apríl|maí|júní|júlí|ágúst|sept\.|okt\.|nóv\.|des\./g,
+        (match) => icelandicMonthMapper[match]
+      );
+      return this.displayFormat
+        ? formatISO(
+            parse(correctedDate, isLanguageDisplayFormat, new Date(), {
+              locale: this.langModule,
+            })
+          )
+        : formatISO(new Date(value));
+    }
     return this.displayFormat
       ? formatISO(
           parse(value, this.displayFormat, new Date(), {

--- a/packages/crayons-core/src/components/datepicker/datepicker.tsx
+++ b/packages/crayons-core/src/components/datepicker/datepicker.tsx
@@ -349,7 +349,7 @@ export class Datepicker {
         'júlí': 'júlí',
         'ágúst': 'á',
         'sept.': 's',
-        'okt.': 'o',
+        'okt.': 'ó',
         'nóv.': 'n',
         'des.': 'd',
       };

--- a/packages/crayons-core/src/components/datepicker/datepicker.tsx
+++ b/packages/crayons-core/src/components/datepicker/datepicker.tsx
@@ -337,7 +337,7 @@ export class Datepicker {
   private formatDate(value) {
     if (!value) return value;
     // For Icelandic language, the date format is different. There is a discrepency which is handled in this PR https://github.com/date-fns/date-fns/pull/3934
-    if (this.langModule?.code === 'is') {
+    if (this.langModule?.code === 'is' && this.dateFormat === 'dd MMMM yyyy') {
       const isLanguageDisplayFormat = 'dd MMMM yyyy';
       const icelandicMonthMapper = {
         'jan.': 'jan.',


### PR DESCRIPTION
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
version: 2.28.0
date-fns/locale = is

import { formatISO, parse } from 'date-fns';
import { is } from 'date-fns/locale';

const values = [
  '12 jan. 2024',
  '06 feb. 2024',
  '06 mars 2024',
  '17 apríl 2024',
  '07 maí 2024',
  '13 júní 2024',
  '18 júlí 2024',
  '04 sept. 2024',
  '23 okt. 2024',
  '15 nóv. 2024',
  '04 des. 2024'
];

const formattedDates = values.map((value) => {
  try {
    const parsedDate = formatISO(
      parse(value, 'dd MMMM yyyy', new Date(), { locale: is })
    );
    return parsedDate;
  } catch (error) {
    console.info(value, error);
  }
});

console.log(formattedDates);


For the above code, we are observing the parsing is not occuring for the month sept. , okt. , nov., des.
We are observing the below error.

![image](https://github.com/user-attachments/assets/1984d133-5bf7-4fe1-8e16-2818b078573b)


Stackblitz link for reference: https://stackblitz.com/edit/date-fns-bug-theqmk?file=package.json,index.ts

We are observing the same issue, even in the current version as well. 4.1.0
We have raised the PR with date-fns team to resolve this issue.
https://github.com/date-fns/date-fns/pull/3934

This is a fix to resolve the date picker flow till our changes are merged.

<img width="1357" alt="Screenshot 2024-11-05 at 1 58 47 PM" src="https://github.com/user-attachments/assets/7a626f12-cbba-4eb2-a15a-b7e6e5222537">
