### PR TITLE
fix: enable date filter to contain maxYear for filters in custom object

### DIFF
--- a/packages/crayons-extended/custom-objects/src/components/filter/filter-condition/filter-condition.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/filter/filter-condition/filter-condition.tsx
@@ -122,6 +122,12 @@ export class FilterCondition {
 
   renderContent(condition) {
     let props = {};
+    const dateProps = {
+      displayFormat: 'dd MMM yyyy',
+      readonly: true,
+      maxYear: 2080,
+      minYear: 1970,
+    };
     switch (condition.type) {
       case 'TEXT':
       case 'NUMBER':
@@ -172,8 +178,7 @@ export class FilterCondition {
         );
       case 'DATE':
         props = {
-          displayFormat: 'dd MMM yyyy',
-          readonly: true,
+          ...dateProps,
           value: this.value,
         };
         return (
@@ -187,11 +192,8 @@ export class FilterCondition {
         );
       case 'DATE_RANGE':
         props = {
-          displayFormat: 'dd MMM yyyy',
-          readonly: true,
+          ...dateProps,
           mode: 'range',
-          maxYear: 2080,
-          minYear: 1970,
         };
         if (this.value) {
           const { from: fromDate, to: toDate } = this.value;

--- a/packages/crayons-extended/custom-objects/src/components/filter/filter-condition/filter-condition.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/filter/filter-condition/filter-condition.tsx
@@ -186,7 +186,13 @@ export class FilterCondition {
           ></fw-date-condition>
         );
       case 'DATE_RANGE':
-        props = { displayFormat: 'dd MMM yyyy', readonly: true, mode: 'range' };
+        props = {
+          displayFormat: 'dd MMM yyyy',
+          readonly: true,
+          mode: 'range',
+          maxYear: 2080,
+          minYear: 1970,
+        };
         if (this.value) {
           const { from: fromDate, to: toDate } = this.value;
           if (fromDate && toDate) {


### PR DESCRIPTION
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
We have added maxYear and minYear for filter conditions as for filters in custom objects, we have possibality of attribute containing dates of similar range that needs to be filtered
