### PR TITLE
Fix section related bugs

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -505,6 +505,10 @@ export namespace Components {
           * Whether the list should be sortable.
          */
         "sortable": boolean;
+        /**
+          * flag to support dependentFields & Multi select dropdown within sections
+         */
+        "supportDependentAndMSDDInSections": boolean;
     }
     interface FwDragItem {
         /**
@@ -3627,6 +3631,10 @@ declare namespace LocalJSX {
           * Whether the list should be sortable.
          */
         "sortable"?: boolean;
+        /**
+          * flag to support dependentFields & Multi select dropdown within sections
+         */
+        "supportDependentAndMSDDInSections"?: boolean;
     }
     interface FwDragItem {
         /**

--- a/packages/crayons-core/src/components/drag-container/drag-container.tsx
+++ b/packages/crayons-core/src/components/drag-container/drag-container.tsx
@@ -39,6 +39,11 @@ export class DragContainer {
   @Prop() sortable = true;
 
   /**
+   * flag to support dependentFields & Multi select dropdown within sections
+   */
+  @Prop() supportDependentAndMSDDInSections = false;
+
+  /**
    * Triggered when a draggable item is dropped inside the container.
    */
   @Event() fwDrop: EventEmitter<void>;
@@ -60,6 +65,7 @@ export class DragContainer {
       copy: this.copy,
       placeholderClass: this.placeholderClass,
       sortable: this.sortable,
+      supportDependentAndMSDDInSections: this.supportDependentAndMSDDInSections,
     });
 
     this.host.addEventListener('fwDropBase', this.emitFwDrop.bind(this));

--- a/packages/crayons-core/src/components/drag-container/readme.md
+++ b/packages/crayons-core/src/components/drag-container/readme.md
@@ -153,13 +153,14 @@ drop.addEventListener('fwDrop', (e) => {
 
 ## Properties
 
-| Property           | Attribute           | Description                                                                                                                   | Type      | Default |
-| ------------------ | ------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------- | ------- |
-| `acceptFrom`       | `accept-from`       | Id of the fw-sortable element from which draggable content can be accepted. Add comma separated id's for multiple containers. | `string`  | `''`    |
-| `addOnDrop`        | `add-on-drop`       | Whether the drag element should be added to the container on drop. If set to false, the placeholder will be retained.         | `boolean` | `true`  |
-| `copy`             | `copy`              | Whether the drag element should be moved or copied.                                                                           | `boolean` | `true`  |
-| `placeholderClass` | `placeholder-class` | The class name for the drag/drop placeholder. Add space separated class names for multiple classes                            | `string`  | `''`    |
-| `sortable`         | `sortable`          | Whether the list should be sortable.                                                                                          | `boolean` | `true`  |
+| Property                            | Attribute                                   | Description                                                                                                                   | Type      | Default |
+| ----------------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------- | ------- |
+| `acceptFrom`                        | `accept-from`                               | Id of the fw-sortable element from which draggable content can be accepted. Add comma separated id's for multiple containers. | `string`  | `''`    |
+| `addOnDrop`                         | `add-on-drop`                               | Whether the drag element should be added to the container on drop. If set to false, the placeholder will be retained.         | `boolean` | `true`  |
+| `copy`                              | `copy`                                      | Whether the drag element should be moved or copied.                                                                           | `boolean` | `true`  |
+| `placeholderClass`                  | `placeholder-class`                         | The class name for the drag/drop placeholder. Add space separated class names for multiple classes                            | `string`  | `''`    |
+| `sortable`                          | `sortable`                                  | Whether the list should be sortable.                                                                                          | `boolean` | `true`  |
+| `supportDependentAndMSDDInSections` | `support-dependent-and-m-s-d-d-in-sections` | flag to support dependentFields & Multi select dropdown within sections                                                       | `boolean` | `false` |
 
 
 ## Events

--- a/packages/crayons-core/src/utils/draggable.spec.ts
+++ b/packages/crayons-core/src/utils/draggable.spec.ts
@@ -1,0 +1,140 @@
+import { Draggable } from './draggable';
+
+describe('Draggable - isDropNotAllowed', () => {
+  let container;
+  let draggableInstance;
+  let mockDragElement;
+  let dragStartEvent;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.id = 'test-container';
+    document.body.appendChild(container);
+
+    draggableInstance = new Draggable(container, {
+      sortable: false,
+      supportDependentAndMSDDInSections: false,
+    });
+
+    mockDragElement = document.createElement('div');
+    mockDragElement.id = 'drag-item';
+    mockDragElement['dataProvider'] = { type: 'DEPENDENT_FIELD' };
+    container.appendChild(mockDragElement);
+
+    dragStartEvent = new Event('dragstart', {
+      bubbles: true,
+      cancelable: true,
+    }) as DragEvent;
+
+    Object.defineProperty(dragStartEvent, 'dataTransfer', {
+      value: {
+        setData: jest.fn(),
+        getData: jest.fn(),
+      },
+    });
+
+    mockDragElement.dispatchEvent(dragStartEvent);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    draggableInstance.destroy();
+  });
+
+  it('should return true when dropping a dependent field in a section with supportDependentAndMSDDInSections as false', () => {
+    container.id = 'sectionIdentifier-test';
+    expect(draggableInstance.isDropNotAllowed()).toBe(true);
+  });
+
+  it('should return false when dropping a valid new DROPDOWN field', () => {
+    container.id = 'sectionIdentifier-test';
+    mockDragElement['dataProvider'] = {
+      type: 'DROPDOWN',
+      choices: [{ value: '' }],
+      custom: true,
+      field_options: {
+        has_sections: false,
+      },
+    };
+
+    expect(draggableInstance['isDropNotAllowed']()).toBe(false);
+  });
+
+  it('should return false when there are 12 fields and a dependent field is added and supportDependentAndMSDDInSections is true', () => {
+    draggableInstance.supportDependentAndMSDDInSections = true;
+    container.id = 'sectionIdentifier-test';
+    for (let i = 0; i < 12; i++) {
+      const child = document.createElement('div');
+      child['dataProvider'] = { type: 'TEXT_FIELD' };
+      container.appendChild(child);
+    }
+
+    const parentElement = document.createElement('div');
+    container.removeChild(mockDragElement);
+    parentElement.appendChild(mockDragElement);
+
+    expect(draggableInstance['isDropNotAllowed']()).toBe(false);
+  });
+
+  it('should return false when reordering a dependent field within a section with 15 fields count', () => {
+    draggableInstance.supportDependentAndMSDDInSections = true;
+    container.id = 'sectionIdentifier-test';
+    for (let i = 0; i < 12; i++) {
+      const child = document.createElement('div');
+      child['dataProvider'] = { type: 'TEXT_FIELD' };
+      container.appendChild(child);
+    }
+
+    expect(draggableInstance['isDropNotAllowed']()).toBe(false);
+  });
+
+  it('should return true when there are 13 fields and adding a dependent field', () => {
+    draggableInstance.supportDependentAndMSDDInSections = true;
+    container.id = 'sectionIdentifier-test';
+    for (let i = 0; i < 13; i++) {
+      const child = document.createElement('div');
+      child['dataProvider'] = { type: 'TEXT_FIELD' };
+      container.appendChild(child);
+    }
+
+    const parentElement = document.createElement('div');
+    container.removeChild(mockDragElement);
+    parentElement.appendChild(mockDragElement);
+
+    expect(draggableInstance['isDropNotAllowed']()).toBe(true);
+  });
+
+  it('should return false when there are 14 fields and adding a TEXT_FIELD', () => {
+    container.id = 'sectionIdentifier-test';
+    for (let i = 0; i < 14; i++) {
+      const child = document.createElement('div');
+      child['dataProvider'] = { type: 'TEXT_FIELD' };
+      container.appendChild(child);
+    }
+    const parentElement = document.createElement('div');
+    container.removeChild(mockDragElement);
+    parentElement.appendChild(mockDragElement);
+    mockDragElement['dataProvider'] = {
+      type: 'TEXT_FIELD',
+    };
+
+    expect(draggableInstance['isDropNotAllowed']()).toBe(false);
+  });
+
+  it('should return true when dropping a required field', () => {
+    container.id = 'sectionIdentifier-test';
+    mockDragElement['dataProvider'] = { required: true };
+
+    const parentElement = document.createElement('div');
+    container.removeChild(mockDragElement);
+    parentElement.appendChild(mockDragElement);
+
+    expect(draggableInstance['isDropNotAllowed']()).toBe(true);
+  });
+
+  it('should return false when dropping a valid field in a non-section container', () => {
+    container.id = 'nonSectionContainer';
+
+    expect(draggableInstance['isDropNotAllowed']()).toBe(false);
+  });
+});

--- a/packages/crayons-core/src/utils/draggable.ts
+++ b/packages/crayons-core/src/utils/draggable.ts
@@ -14,6 +14,7 @@ const DEFAULT_OPTIONS = {
 export class Draggable {
   dragContainer: HTMLElement;
   options;
+  supportDependentAndMSDDInSections = false;
   childElements = [];
   acceptFrom = [];
   placeholder: HTMLElement;
@@ -51,6 +52,8 @@ export class Draggable {
       ? this.options.acceptFrom.split(',')
       : [];
     this.options.sortable && this.acceptFrom.push(this.dragContainer.id);
+    this.supportDependentAndMSDDInSections =
+      this.options.supportDependentAndMSDDInSections;
     this.addListeners();
   }
 
@@ -99,7 +102,9 @@ export class Draggable {
   };
 
   private isDropNotAllowed() {
-    const inValidTypesForSection = ['RELATIONSHIP'];
+    const inValidTypesForSection = this.supportDependentAndMSDDInSections
+      ? ['RELATIONSHIP']
+      : ['DEPENDENT_FIELD', 'MULTI_SELECT', 'RELATIONSHIP'];
     const dragId = this.dragContainer.id;
     const isSection = dragId.includes('sectionIdentifier-');
     const isFieldTypeNotAllowed = inValidTypesForSection.includes(
@@ -125,15 +130,29 @@ export class Draggable {
       dragElement.dataProvider?.field_options &&
       parseBoolean(dragElement.dataProvider?.field_options?.has_sections);
     // Check if the section already has the maximum number of fields
-    const isSectionFieldLimitExceeded =
-      Array.from(this.dragContainer?.children || []).reduce((count, child) => {
-        const childDataProvider = (
-          child as HTMLElement & {
-            dataProvider?: { type?: string };
-          }
-        )?.dataProvider;
-        return count + (childDataProvider?.type === 'DEPENDENT_FIELD' ? 3 : 1);
-      }, 0) > 15;
+    const existingFieldsCount = Array.from(
+      this.dragContainer?.children || []
+    ).reduce((count, child) => {
+      const childDataProvider = (
+        child as HTMLElement & {
+          dataProvider?: { type?: string; name?: string };
+        }
+      )?.dataProvider;
+      if (childDataProvider?.type) {
+        count = count + (childDataProvider?.type === 'DEPENDENT_FIELD' ? 3 : 1);
+      }
+      return count;
+    }, 0);
+
+    const isFieldInTheSameContainer =
+      this.dragContainer.id === dragElement.parentElement.id;
+
+    const newFieldsCount = isFieldInTheSameContainer
+      ? existingFieldsCount
+      : existingFieldsCount +
+        (dragElement.dataProvider?.type === 'DEPENDENT_FIELD' ? 3 : 1);
+
+    const isSectionFieldLimitExceeded = newFieldsCount > 15;
 
     // Check if the dragElement is present and the field is required
     const isFieldRequired = dragElement?.dataProvider?.required;

--- a/packages/crayons-core/src/utils/draggable.ts
+++ b/packages/crayons-core/src/utils/draggable.ts
@@ -145,7 +145,7 @@ export class Draggable {
     }, 0);
 
     const isFieldInTheSameContainer =
-      this.dragContainer.id === dragElement.parentElement.id;
+      this.dragContainer.id === dragElement.parentElement?.id;
 
     const newFieldsCount = isFieldInTheSameContainer
       ? existingFieldsCount

--- a/packages/crayons-extended/custom-objects/src/components.d.ts
+++ b/packages/crayons-extended/custom-objects/src/components.d.ts
@@ -582,6 +582,10 @@ export namespace Components {
          */
         "showRelationshipTypeSelect": boolean;
         /**
+          * flag to support dependentFields & Multi select dropdown within sections
+         */
+        "supportDependentAndMSDDInSections": boolean;
+        /**
           * Show explore plans and disable features for user having free-plan
          */
         "userPlan": 'trial' | 'admin';
@@ -1630,6 +1634,10 @@ declare namespace LocalJSX {
           * flag to show relationshipTypeSelect dropdown or not
          */
         "showRelationshipTypeSelect"?: boolean;
+        /**
+          * flag to support dependentFields & Multi select dropdown within sections
+         */
+        "supportDependentAndMSDDInSections"?: boolean;
         /**
           * Show explore plans and disable features for user having free-plan
          */

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
@@ -329,8 +329,8 @@ export class FormBuilder {
                     label: arrFields[i1]?.fields[j1].label,
                     name: arrFields[i1]?.fields[j1].name,
                     fields: [arrFields[i1]?.fields[j1]],
-                    field_options: arrFields[i1]?.field_options,
-                    custom: arrFields[i1]?.custom,
+                    field_options: arrFields[i1]?.fields[j1]?.field_options,
+                    custom: arrFields[i1]?.fields[j1]?.custom,
                   },
                   internalNamePrefix
                 );

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
@@ -323,6 +323,7 @@ export class FormBuilder {
                     label: arrFields[i1]?.fields[j1].label,
                     name: arrFields[i1]?.fields[j1].name,
                     fields: [arrFields[i1]?.fields[j1]],
+                    field_options: arrFields[i1]?.fields[j1].field_options,
                   },
                   internalNamePrefix
                 );

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
@@ -99,6 +99,10 @@ export class FormBuilder {
    */
   @Prop({ mutable: true }) showDependentFieldResolveProp = true;
   /**
+   * flag to support dependentFields & Multi select dropdown within sections
+   */
+  @Prop({ mutable: true }) supportDependentAndMSDDInSections = false;
+  /**
    * link to show dependent field document
    */
   @Prop() dependentFieldLink = '';
@@ -305,6 +309,8 @@ export class FormBuilder {
                 label: arrFields[i1].label,
                 name: arrFields[i1].name,
                 fields: [arrFields[i1]],
+                field_options: arrFields[i1]?.field_options,
+                custom: arrFields[i1]?.custom,
               },
               internalNamePrefix
             );
@@ -323,7 +329,8 @@ export class FormBuilder {
                     label: arrFields[i1]?.fields[j1].label,
                     name: arrFields[i1]?.fields[j1].name,
                     fields: [arrFields[i1]?.fields[j1]],
-                    field_options: arrFields[i1]?.fields[j1].field_options,
+                    field_options: arrFields[i1]?.field_options,
+                    custom: arrFields[i1]?.custom,
                   },
                   internalNamePrefix
                 );
@@ -557,20 +564,27 @@ export class FormBuilder {
     const objDetail = event.detail,
       elField = objDetail.droppedElement;
     let elFieldType = elField.dataProvider.type;
-    const maxLimit =
-      Array.from(objDetail.dragContainer?.children || []).reduce<number>(
-        (count, child) => {
-          const childDataProvider = (
-            child as HTMLElement & {
-              dataProvider?: { type?: string };
-            }
-          )?.dataProvider;
-          return (
-            count + (childDataProvider?.type === 'DEPENDENT_FIELD' ? 3 : 1)
-          );
-        },
-        0
-      ) > 15;
+
+    const existingCount = Array.from(
+      objDetail.dragContainer?.children || []
+    ).reduce<number>((count, child) => {
+      const childDataProvider = (
+        child as HTMLElement & {
+          dataProvider?: { type?: string };
+        }
+      )?.dataProvider;
+      if (childDataProvider?.type) {
+        count = count + (childDataProvider?.type === 'DEPENDENT_FIELD' ? 3 : 1);
+      }
+      return count;
+    }, 0);
+
+    // Adding the dragged field to the count
+    const count =
+      existingCount + (elField.dataProvider.type === 'DEPENDENT_FIELD' ? 3 : 1);
+
+    const maxLimit = count > 15;
+
     if (maxLimit) {
       elFieldType = 'MAX_LIMIT';
     }
@@ -1316,6 +1330,9 @@ export class FormBuilder {
                     acceptFrom={`fieldTypesList,fieldsContainer,${acceptFromSections}`}
                     addOnDrop={false}
                     sortable={true}
+                    supportDependentAndMSDDInSections={
+                      this.supportDependentAndMSDDInSections
+                    }
                     onFwDrop={(e) =>
                       this.fieldTypeDropHandler(
                         e,

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/form-builder.tsx
@@ -579,9 +579,14 @@ export class FormBuilder {
       return count;
     }, 0);
 
+    const isFieldInTheSameContainer =
+      objDetail.dragContainer?.id === elField.parentElement?.id;
+
     // Adding the dragged field to the count
-    const count =
-      existingCount + (elField.dataProvider.type === 'DEPENDENT_FIELD' ? 3 : 1);
+    const count = isFieldInTheSameContainer
+      ? existingCount
+      : existingCount +
+        (elField.dataProvider?.type === 'DEPENDENT_FIELD' ? 3 : 1);
 
     const maxLimit = count > 15;
 


### PR DESCRIPTION
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
 ## Change log

1. `supportDependentAndMSDDInSections` - A new property has been introduced to let users decide whether sectional fields should accept dependent and multiselect dropdown fields. This is to make the section more flexible and at the same time reduce the blast radius in case something goes wrong.

This flag only controls whether the fields are allowed to dropped in a section or not. It does not govern the below mentioned logic.
 
2. The logic for computing the maximum number of fields a section can hold has been modified. Earlier, the logic took into account the `error element` as well into calculation thus returning one more than the actual count. This logic held good  earlier since all the fields had a count of 1. Now that dependent fields are counted as 3, we needed to check what the draggedElement was and its count.

## How Has This Been Tested?

Dev testing has been done by checking the max limit breach for different field types. Checked reordering as well to ensure that the element belonging to the same container does not contribute to the count. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
