### PR TITLE
Add a flag to prevent section fields reset while using setFieldsValue

### DIFF
--- a/packages/crayons-core/src/components.d.ts
+++ b/packages/crayons-core/src/components.d.ts
@@ -858,7 +858,7 @@ export namespace Components {
         /**
           * Method to set values on the form fields.  param: valuesObj - Object with key as form field name and value as the updated value for the field example: `{ first_name: "new name", last_name: "new last name" }` param: shouldValidate - should this form be validated with the updated values. Default to true.
          */
-        "setFieldsValue": (valuesObj: FormValues, shouldValidate?: boolean) => Promise<void>;
+        "setFieldsValue": (valuesObj: FormValues, shouldValidate?: boolean, isManualUpdate?: boolean) => Promise<void>;
         /**
           * Method to set hidden fields on the form dynamically.  Note: You must always pass all the fields that you want to hide. Also, note that the validation for hidden fields will be skipped.  param: hiddenFields - key value pair of [fieldName]: true | false example: `setHiddenFields({ first_name: true, last_name: false })`
          */

--- a/packages/crayons-core/src/components/form/form.tsx
+++ b/packages/crayons-core/src/components/form/form.tsx
@@ -46,6 +46,8 @@ export class Form {
 
   private controls: any;
   private fields: any;
+  private isInternalUpdate = false;
+  private internalUpdateResetTimer: any;
 
   /**
    * Initial field values of the form. It is an object with keys pointing to field name
@@ -274,6 +276,9 @@ export class Form {
     this.el?.removeEventListener?.('fwBlur', this.handleBlurListener);
     this.el?.removeEventListener?.('fwInput', this.handleInputListener);
     this.el?.removeEventListener?.('fwChange', this.handleChangeListener);
+    if (this.internalUpdateResetTimer) {
+      clearTimeout(this.internalUpdateResetTimer);
+    }
   }
 
   handleSubmit = async (event: Event): Promise<FormSubmit> => {
@@ -384,22 +389,36 @@ export class Form {
 
     // reset for section fields when values changed
 
-    const previousfield = this.formSchema?.fields?.find(
-      (field) => field.name === name
-    );
-
-    if (previousfield && previousfield?.field_options?.has_sections) {
-      const selectedObj = previousfield?.choices?.find(
-        ({ id }) => id === this.values[name]
+    if (!this.isInternalUpdate) {
+      const previousfield = this.formSchema?.fields?.find(
+        (field) => field.name === name
       );
 
-      selectedObj?.dependent_ids?.field?.forEach((fieldId) => {
-        const fieldOptionName = previousfield?.fields.find(
-          ({ id }) => id === fieldId
-        )?.name;
+      if (previousfield && previousfield?.field_options?.has_sections) {
+        const selectedObj = previousfield?.choices?.find(
+          ({ id }) => id === this.values[name]
+        );
 
-        delete this.values[fieldOptionName];
-      });
+        selectedObj?.dependent_ids?.field?.forEach((fieldId) => {
+          const fieldOption = previousfield?.fields.find(
+            ({ id }) => id === fieldId
+          );
+
+          const isDependentField = fieldOption?.field_options?.dependent;
+
+          if (isDependentField) {
+            // If the field is dependent, we need to delete all the values of the dependent fields
+            let next = fieldOption;
+
+            while (next) {
+              delete this.values[next.name];
+              next = next.fields?.[0];
+            }
+          } else {
+            delete this.values[fieldOption?.name];
+          }
+        });
+      }
     }
 
     this.values = {
@@ -599,10 +618,14 @@ export class Form {
   @Method()
   async setFieldsValue(
     valuesObj: FormValues,
-    shouldValidate = true
+    shouldValidate = true,
+    isManualUpdate = false
   ): Promise<void> {
     if (!valuesObj) return;
 
+    if (isManualUpdate) {
+      this.isInternalUpdate = true;
+    }
     let newValues = { ...this.values };
     let newTouchedFields = { ...this.touched };
 
@@ -622,6 +645,13 @@ export class Form {
 
     if (shouldValidate) {
       await this.handleValidation();
+    }
+
+    if (isManualUpdate) {
+      // Adding a delay to ensure that handleInput is called before resetting the isInternalUpdate flag.
+      this.internalUpdateResetTimer = setTimeout(() => {
+        this.isInternalUpdate = false;
+      }, 1000);
     }
   }
 

--- a/packages/crayons-core/src/components/form/readme.md
+++ b/packages/crayons-core/src/components/form/readme.md
@@ -3447,7 +3447,7 @@ Type: `Promise<void>`
 
 
 
-### `setFieldsValue(valuesObj: FormValues, shouldValidate?: boolean) => Promise<void>`
+### `setFieldsValue(valuesObj: FormValues, shouldValidate?: boolean, isManualUpdate?: boolean) => Promise<void>`
 
 Method to set values on the form fields.
 


### PR DESCRIPTION
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## Overview

At present, if we set a section field and it's child fields using setFieldsValue, each update is treated as done by a user and handleInput logic is executed. As per the logic present there, if a section field value is changed, all the child fields are reset. This is a problem because it resets all the child fields that should be updated along with the section field.

## Implementation

1. As a fix, I have introduced a flag that can be passed as an argument to the setFieldsValue method. This would prevent the reset logic from being executed for updates done using this method when the argument (isManualUpdate) is passed.

Since the `setFieldsValue` method and the `handleInput` method are linked by a chain of emitted events, the flag passed would be kept active for a second under the assumption (and based on testing) that the events would be processed within this time period.

2. There is also an enhancement done to the reset logic. Currently, the reset does not clear all the levels of a dependent field within a section. With this change, all the levels of a dependent field within a section is reset properly.

## Impact

1. Impacts `setFieldsValue` and `handleInput` method when called with the new argument. By default, the flag's value defaults to false and hence it won't impact any existing implementations.
2. Reset logic now clears all levels of a dependent field.
