### PR TITLE
Allow different levels to have same children values in dependent fields.

### DIFF
--- a/packages/crayons-extended/custom-objects/src/components/form-builder/utils/form-builder-utils.spec.ts
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/utils/form-builder-utils.spec.ts
@@ -463,24 +463,25 @@ describe('updateChoicesInFields', () => {
 });
 
 describe('buildChoicesFromText', () => {
-  const mockDataProvider = {
-    fields: [
-      {
-        choices: [],
-        fields: [
-          {
-            choices: [],
-            fields: [{ choices: [] }],
-          },
-        ],
-      },
-    ],
-  };
+  let mockDataProvider = null;
   const mockCreateUUID = jest.fn();
   let uuidCounter = 0;
   mockCreateUUID.mockImplementation(() => `uuid-${++uuidCounter}`);
 
   beforeEach(() => {
+    mockDataProvider = {
+      fields: [
+        {
+          choices: [],
+          fields: [
+            {
+              choices: [],
+              fields: [{ choices: [] }],
+            },
+          ],
+        },
+      ],
+    };
     uuidCounter = 0; // Reset UUID counter before each test
   });
 
@@ -515,6 +516,32 @@ describe('buildChoicesFromText', () => {
     expect(
       result.fields[0].fields[0].fields[0].choices.map((choice) => choice.value)
     ).toEqual(['item 1', 'item 2', 'item 3', 'item 4', 'item 5']);
+  });
+
+  it('check if no options are processed when the text is malformed', () => {
+    const result = buildChoicesFromText('\t\t\t\tCategory', mockDataProvider);
+    expect(result.fields[0].choices).toHaveLength(0);
+    expect(result.fields[0].fields[0].choices).toHaveLength(0);
+    expect(result.fields[0].fields[0].fields[0].choices).toHaveLength(0);
+  });
+
+  it('check if same subcategories are allowed in different categories', () => {
+    const exampleText =
+      'category 1\n\tsubcategory 1\n\t\titem 1\n\t\titem 2\ncategory 2\n\tsubcategory 1\n\t\titem 1\n\t\titem 2\n\t\titem 3\n';
+    const result = buildChoicesFromText(exampleText, mockDataProvider);
+    expect(result.fields[0].choices).toHaveLength(2);
+    expect(result.fields[0].choices.map((choice) => choice.value)).toEqual([
+      'category 1',
+      'category 2',
+    ]);
+    expect(result.fields[0].fields[0].choices).toHaveLength(2);
+    expect(
+      result.fields[0].fields[0].choices.map((choice) => choice.value)
+    ).toEqual(['subcategory 1', 'subcategory 1']);
+    expect(result.fields[0].fields[0].fields[0].choices).toHaveLength(5);
+    expect(
+      result.fields[0].fields[0].fields[0].choices.map((choice) => choice.value)
+    ).toEqual(['item 1', 'item 2', 'item 1', 'item 2', 'item 3']);
   });
 });
 

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/utils/form-builder-utils.ts
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/utils/form-builder-utils.ts
@@ -305,10 +305,6 @@ export function getFieldBasedOnLevel(data, level) {
   return traverseFields(data.fields, 1);
 }
 
-const validateChoices = (choices, value) => {
-  return choices.find((choice) => choice.value === value);
-};
-
 /** Returns filtered choices by ids */
 const getChoicesById = (choices = [], ids = []) => {
   return choices.filter((choice) => ids.includes(choice.id));
@@ -373,75 +369,128 @@ export function updateFieldAttributes(
   return { ...data, fields: data.fields };
 }
 
-// NOTE: Need to optimize this better
-export function buildChoicesFromText(text, dataProvider) {
+/**
+ * Generates a hierarchical field mapping from a structured text input.
+ * The input text is expected to have a specific format with hierarchical levels
+ * represented by indentation using tabs.
+ *
+ * @param text - The structured text input where each line represents a category,
+ *               sub-category, or item based on its indentation level.
+ * @returns A Map representing the hierarchical structure:
+ *          - Top-level keys are categories (Map).
+ *          - Second-level keys are sub-categories (Map).
+ *          - Third-level values are items (Set).
+ */
+
+function generateFieldMapping(text) {
   const lines = text.split('\n');
-  const hierarchyChoices = dataProvider.fields[0];
-  let currentCategory = null;
-  let currentSubcategory = null;
+  const mapping = new Map();
+  let subCategories = null;
+  let items = null;
 
-  lines.forEach((line) => {
-    const value = line.trim().replace(/\t/g, '');
+  try {
+    lines.forEach((line) => {
+      const value = line.trim().replace(/\t/g, '');
 
-    if (value && value.length) {
-      if (!line.startsWith('\t')) {
-        if (!validateChoices(hierarchyChoices.choices, value)) {
-          const field = hierarchyChoices;
-          if (!field.id) {
-            field.id = createUUID();
+      if (value && value.length) {
+        if (!line.startsWith('\t')) {
+          if (!mapping.get(value)) {
+            mapping.set(value, new Map());
           }
-          currentCategory = {
-            id: createUUID(),
-            value: value,
-            dependent_ids: { field: [], choice: [] },
-          };
-          hierarchyChoices.choices.push(currentCategory);
-        }
-      } else if (line.startsWith('\t') && !line.startsWith('\t\t')) {
-        if (
-          currentCategory &&
-          !validateChoices(hierarchyChoices.fields[0].choices, value)
-        ) {
-          const field = hierarchyChoices.fields[0];
-          if (!field.id) {
-            field.id = createUUID();
+          subCategories = mapping.get(value);
+        } else if (line.startsWith('\t') && !line.startsWith('\t\t')) {
+          if (subCategories instanceof Map && !subCategories.get(value)) {
+            subCategories.set(value, new Set());
           }
-          currentSubcategory = {
-            id: createUUID(),
-            value: value,
-            dependent_ids: { field: [], choice: [] },
-          };
-          currentCategory.dependent_ids.choice.push(currentSubcategory.id);
-          if (!currentCategory.dependent_ids.field.length) {
-            currentCategory.dependent_ids.field.push(field.id);
+          items = subCategories.get(value);
+        } else if (line.startsWith('\t\t')) {
+          if (items instanceof Set) {
+            items.add(value);
           }
-          field.choices.push(currentSubcategory);
-        }
-      } else {
-        if (
-          currentSubcategory &&
-          !validateChoices(hierarchyChoices.fields[0].fields[0].choices, value)
-        ) {
-          const field = hierarchyChoices.fields[0].fields[0];
-          if (!field.id) {
-            field.id = createUUID();
-          }
-          const item = {
-            id: createUUID(),
-            value: value,
-            dependent_ids: { choice: [], field: [] },
-          };
-          currentSubcategory.dependent_ids.choice.push(item.id);
-          if (!currentSubcategory.dependent_ids.field.length) {
-            currentSubcategory.dependent_ids.field.push(field.id);
-          }
-          hierarchyChoices.fields[0].fields[0].choices.push(item);
         }
       }
+    });
+  } catch (error) {
+    console.error(
+      'Encountered an error while generating field mapping: ',
+      error
+    );
+    return new Map();
+  }
+
+  return mapping;
+}
+
+export function buildChoicesFromText(text, dataProvider) {
+  const fieldMapping = generateFieldMapping(text);
+  const dependentField = dataProvider.fields[0];
+
+  const dependentFieldLevels = [
+    dependentField,
+    dependentField.fields[0],
+    dependentField.fields[0].fields[0],
+  ];
+
+  // Generate unique Ids for each of the field levels
+  dependentFieldLevels.forEach((level) => {
+    if (!level.id) {
+      level.id = createUUID();
     }
   });
 
-  return { ...dataProvider, fields: [hierarchyChoices] };
+  // Iterating through the following structure
+  // { category: { subcategory: items(Array) } }
+  fieldMapping.forEach((subCategories, category) => {
+    const newCategoryValue = {
+      id: createUUID(),
+      value: category,
+      dependent_ids: { field: [], choice: [] },
+    };
+
+    // Add category as a choice in the dependent field's first level.
+    dependentFieldLevels[0].choices.push(newCategoryValue);
+
+    // Process subcategories and add their ids to the newCategory's choice value.
+    if (subCategories?.size) {
+      subCategories.forEach((items, subCategory) => {
+        const newSubCategory = {
+          id: createUUID(),
+          value: subCategory,
+          dependent_ids: { field: [], choice: [] },
+        };
+
+        newCategoryValue.dependent_ids.choice.push(newSubCategory.id);
+
+        // Update the category's field value with the second level field's id.
+        if (!newCategoryValue.dependent_ids.field.length) {
+          newCategoryValue.dependent_ids.field.push(dependentFieldLevels[1].id);
+        }
+
+        // Add Subcategory as a choice in the dependent field's second level.
+        dependentFieldLevels[1].choices.push(newSubCategory);
+
+        items.forEach((item) => {
+          const newItem = {
+            id: createUUID(),
+            value: item,
+            dependent_ids: { field: [], choice: [] },
+          };
+
+          newSubCategory.dependent_ids.choice.push(newItem.id);
+
+          // Update the sub category's field value with the third level field's id.
+          if (!newSubCategory.dependent_ids.field.length) {
+            newSubCategory.dependent_ids.field.push(dependentFieldLevels[2].id);
+          }
+
+          // Add new item as a choice in the dependent field's third level.
+          dependentFieldLevels[2].choices.push(newItem);
+        });
+      });
+    }
+  });
+
+  return { ...dataProvider, fields: [dependentField] };
 }
 
 export function hasStringDuplicates(stringObj, i18nText) {

--- a/packages/crayons-extended/custom-objects/src/components/form-builder/utils/form-builder-utils.ts
+++ b/packages/crayons-extended/custom-objects/src/components/form-builder/utils/form-builder-utils.ts
@@ -425,14 +425,12 @@ export function buildChoicesFromText(text, dataProvider) {
   const fieldMapping = generateFieldMapping(text);
   const dependentField = dataProvider.fields[0];
 
-  const dependentFieldLevels = [
-    dependentField,
-    dependentField.fields[0],
-    dependentField.fields[0].fields[0],
-  ];
+  const level1 = dependentField;
+  const level2 = dependentField.fields[0];
+  const level3 = dependentField.fields[0].fields[0];
 
   // Generate unique Ids for each of the field levels
-  dependentFieldLevels.forEach((level) => {
+  [level1, level2, level3].forEach((level) => {
     if (!level.id) {
       level.id = createUUID();
     }
@@ -448,7 +446,7 @@ export function buildChoicesFromText(text, dataProvider) {
     };
 
     // Add category as a choice in the dependent field's first level.
-    dependentFieldLevels[0].choices.push(newCategoryValue);
+    level1.choices.push(newCategoryValue);
 
     // Process subcategories and add their ids to the newCategory's choice value.
     if (subCategories?.size) {
@@ -463,11 +461,11 @@ export function buildChoicesFromText(text, dataProvider) {
 
         // Update the category's field value with the second level field's id.
         if (!newCategoryValue.dependent_ids.field.length) {
-          newCategoryValue.dependent_ids.field.push(dependentFieldLevels[1].id);
+          newCategoryValue.dependent_ids.field.push(level2.id);
         }
 
         // Add Subcategory as a choice in the dependent field's second level.
-        dependentFieldLevels[1].choices.push(newSubCategory);
+        level2.choices.push(newSubCategory);
 
         items.forEach((item) => {
           const newItem = {
@@ -480,11 +478,11 @@ export function buildChoicesFromText(text, dataProvider) {
 
           // Update the sub category's field value with the third level field's id.
           if (!newSubCategory.dependent_ids.field.length) {
-            newSubCategory.dependent_ids.field.push(dependentFieldLevels[2].id);
+            newSubCategory.dependent_ids.field.push(level3.id);
           }
 
           // Add new item as a choice in the dependent field's third level.
-          dependentFieldLevels[2].choices.push(newItem);
+          level3.choices.push(newItem);
         });
       });
     }


### PR DESCRIPTION
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
 ## What's the change?

Currently, while bulk importing options in dependent fields, if "category 1" has "subcategory 1", including the same subcategory in "category 2" would not work.

Payload:

```
Category 1
        Sub Category 1
                Item 1
                Item 2
Category 2
        Sub Category 1
                Item 3
                Item 4
```

After processing:

```
Category 1
        Sub Category 1
                Item 1
                Item 2
Category 2
```

This has been flagged as a bug and has been fixed to accommodate such values.

Update behaviour after bug fix would result in:

```
Category 1
        Sub Category 1
                Item 1
                Item 2
Category 2
        Sub Category 1
                Item 3
                Item 4
```
 
## How Has This Been Tested?

This change affects the bulk import functionality in dependent fields. So. testing was done using different payloads simulating the edge cases and checking how the output was.

<!--- Include details of your testing environment, and the tests you ran to -->

1. Checked with payload which started with `\t`. This isn't supported currently and should return an empty Map without failing hard.
2.  Checked with a valid payload where two categories had the same sub categories and items. This was not supported earlier but works now.

Payload:

```
Category 1
        Sub Category 1
                Item 1
                Item 2
        Sub Category 2
                Item 1
                Item 2
```

Current Behaviour:

```
Category 1
        Sub Category 1
                Item 1
                Item 2
        Sub Category 2
```

Updated Behaviour:

```
Category 1
        Sub Category 1
                Item 1
                Item 2
        Sub Category 2
                Item 1
                Item 2
```


3. Checked with a valid payload where a category had sub categories which are of the same value but with different items. 

Payload:

```
Category 1
        Sub Category 1
                Item 1
                Item 2
        Sub Category 1
                Item 1
                Item 3
                Item 4
```

Expected output:

```
Category 1
        Sub Category 1
                Item 1
                Item 2
                Item 3
                Item 4
```
<!--- see how your change affects other areas of the code, etc. -->
