### PR TITLE
fix: Fw popover not working in modal

### DIFF
--- a/packages/crayons-core/src/components/popover/popover.e2e.ts
+++ b/packages/crayons-core/src/components/popover/popover.e2e.ts
@@ -9,6 +9,55 @@ describe('fw-popover', () => {
     expect(element).toHaveClass('hydrated');
   });
 
+  it('should have popover content hidden by default', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`<fw-popover>
+        <fw-button slot="popover-trigger">Open</fw-button>
+        <div slot="popover-content">Content</div>
+    </fw-popover>`);
+    await page.waitForChanges();
+    const content = await page.find('fw-popover >>> .popper-content');
+    expect(content).not.toHaveAttribute('data-show');
+  });
+
+  it('should show content when show() is called and hide when hide() is called', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`<fw-popover>
+        <fw-button slot="popover-trigger">Open</fw-button>
+        <div slot="popover-content">Content</div>
+    </fw-popover>`);
+    const popover = await page.find('fw-popover');
+    let content = await page.find('fw-popover >>> .popper-content');
+
+    expect(content).not.toHaveAttribute('data-show');
+
+    await (popover as any).callMethod('show');
+    await page.waitForChanges();
+    content = await page.find('fw-popover >>> .popper-content');
+    expect(content).toHaveAttribute('data-show');
+
+    await (popover as any).callMethod('hide');
+    await page.waitForChanges();
+    content = await page.find('fw-popover >>> .popper-content');
+    expect(content).not.toHaveAttribute('data-show');
+  });
+
+  it('should open and show content when trigger is clicked', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`<fw-popover>
+        <fw-button slot="popover-trigger">Currency List</fw-button>
+        <fw-list-options id="currency" slot="popover-content"></fw-list-options>
+    </fw-popover>`);
+    const trigger = await page.find('fw-popover > fw-button');
+    await trigger.click();
+    await page.waitForChanges();
+    const content = await page.find('fw-popover >>> .popper-content');
+    expect(content).toHaveAttribute('data-show');
+  });
+
   it('should close the content on clicking on the document by default', async () => {
     const page = await newE2EPage();
 
@@ -21,8 +70,47 @@ describe('fw-popover', () => {
     await page.waitForChanges();
     let content = await page.find('fw-popover >>> .popper-content');
     expect(content).toHaveAttribute('data-show');
-    await document.body.click();
+    await page.evaluate(() => document.body.click());
     await page.waitForChanges();
     content = await page.find('fw-popover >>> .popper-content');
+    expect(content).not.toHaveAttribute('data-show');
+  });
+
+  it('should open and show content when inside .modal-overlay', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <div class="modal-overlay">
+        <fw-popover>
+          <fw-button slot="popover-trigger">Open in modal</fw-button>
+          <div slot="popover-content">Modal content</div>
+        </fw-popover>
+      </div>
+    `);
+    await page.waitForChanges();
+    const popover = await page.find('fw-popover');
+    await (popover as any).callMethod('show');
+    await page.waitForChanges();
+    const content = await page.find('fw-popover >>> .popper-content');
+    expect(content).toHaveAttribute('data-show');
+  });
+
+  it('should open and show content when inside fw-modal', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <fw-modal is-open>
+        <fw-popover>
+          <fw-button slot="popover-trigger">Open in fw-modal</fw-button>
+          <div slot="popover-content">Modal content</div>
+        </fw-popover>
+      </fw-modal>
+    `);
+    await page.waitForChanges();
+    const popover = await page.find('fw-popover');
+    await (popover as any).callMethod('show');
+    await page.waitForChanges();
+    const content = await page.find('fw-popover >>> .popper-content');
+    expect(content).toHaveAttribute('data-show');
   });
 });

--- a/packages/crayons-core/src/components/popover/popover.scss
+++ b/packages/crayons-core/src/components/popover/popover.scss
@@ -48,6 +48,27 @@
 
 .popper-content[data-show] {
   display: block;
+  transform: scale(1);
+  z-index: 10000;
+}
+
+/* Fix positioning for popovers inside modals - force viewport positioning */
+fw-modal .popper-content[data-show],
+.modal-overlay .popper-content[data-show],
+fw-modal fw-tooltip .popper-content[data-show],
+.modal-overlay fw-tooltip .popper-content[data-show] {
+  position: fixed;
+  z-index: 10000;
+  transform: scale(1);
+}
+
+/* Ensure modal popovers and tooltips are hoisted to body level */
+fw-modal .popper-content,
+.modal-overlay .popper-content,
+fw-modal fw-tooltip .popper-content,
+.modal-overlay fw-tooltip .popper-content {
+  /* These will be moved to body by Popper when strategy is fixed */
+  contain: none;
 }
 
 .overlay {

--- a/packages/crayons-core/src/components/popover/popover.tsx
+++ b/packages/crayons-core/src/components/popover/popover.tsx
@@ -196,9 +196,14 @@ export class Popover {
   }
 
   setPopperOptions() {
+    // Auto-detect if popover is inside a modal and force fixed strategy
+    const isInsideModal =
+      this.host.closest('fw-modal, .modal-overlay') !== null;
+    const useFixedStrategy = this.hoist || isInsideModal;
+
     this.popperOptions = {
       placement: this.placement,
-      strategy: this.hoist ? 'fixed' : 'absolute',
+      strategy: useFixedStrategy ? 'fixed' : 'absolute',
       modifiers: [
         {
           name: 'flip',
@@ -209,7 +214,9 @@ export class Popover {
         {
           name: 'preventOverflow',
           options: {
-            boundary: this.boundary || 'clippingParents',
+            boundary: isInsideModal
+              ? 'viewport'
+              : this.boundary || 'clippingParents',
           },
         },
         {
@@ -276,7 +283,7 @@ export class Popover {
   updatePopper() {
     if (this.isOpen) {
       !this.popperInstance && this.createPopperInstance();
-      // recompute posiiton of popper
+      // recompute position of popper
       this.popperInstance?.update();
     }
   }

--- a/packages/crayons-core/src/components/tooltip/tooltip.e2e.ts
+++ b/packages/crayons-core/src/components/tooltip/tooltip.e2e.ts
@@ -69,4 +69,59 @@ describe('fw-tooltip', () => {
       'This tooltip has <b>HTML</b> content.'
     );
   });
+
+  it('should have tooltip content hidden by default', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<fw-tooltip content="Tooltip text"><fw-button>Trigger</fw-button></fw-tooltip>'
+    );
+    await page.waitForChanges();
+    const popover: any = await page.find('fw-tooltip >>> :first-child');
+    const popoverContent = popover.shadowRoot.querySelector('.popper-content');
+    expect(popoverContent.hasAttribute('data-show')).toBeFalsy();
+  });
+
+  it('should show and hide tooltip when inside .modal-overlay', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <div class="modal-overlay">
+        <fw-tooltip content="Tooltip in modal">
+          <fw-button>Trigger</fw-button>
+        </fw-tooltip>
+      </div>
+    `);
+    await page.waitForChanges();
+    const tooltip: any = await page.find('fw-tooltip');
+    await tooltip.callMethod('show');
+    await page.waitForChanges();
+    const popover: any = await page.find('fw-tooltip >>> :first-child');
+    let popoverContent = popover.shadowRoot.querySelector('.popper-content');
+    expect(popoverContent.hasAttribute('data-show')).toBeTruthy();
+
+    await tooltip.callMethod('hide');
+    await page.waitForChanges();
+    popoverContent = popover.shadowRoot.querySelector('.popper-content');
+    expect(popoverContent.hasAttribute('data-show')).toBeFalsy();
+  });
+
+  it('should show tooltip when inside fw-modal', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <fw-modal is-open>
+        <fw-tooltip content="Tooltip in fw-modal">
+          <fw-button>Trigger</fw-button>
+        </fw-tooltip>
+      </fw-modal>
+    `);
+    await page.waitForChanges();
+    const tooltip: any = await page.find('fw-tooltip');
+    await tooltip.callMethod('show');
+    await page.waitForChanges();
+    const popover: any = await page.find('fw-tooltip >>> :first-child');
+    const popoverContent = popover.shadowRoot.querySelector('.popper-content');
+    expect(popoverContent.hasAttribute('data-show')).toBeTruthy();
+  });
 });

--- a/packages/crayons-core/src/components/tooltip/tooltip.tsx
+++ b/packages/crayons-core/src/components/tooltip/tooltip.tsx
@@ -88,6 +88,11 @@ export class Tooltip {
    * @returns {JSX.Element}
    */
   render(): JSX.Element {
+    // Auto-detect if tooltip is inside a modal and force hoist
+    const isInsideModal =
+      this.host.closest('fw-modal, .modal-overlay') !== null;
+    const shouldHoist = this.hoist || isInsideModal;
+
     return (
       <fw-popover
         trigger={this.trigger}
@@ -97,7 +102,7 @@ export class Tooltip {
         distance={this.distance}
         disable-transition='true'
         has-border='false'
-        hoist={this.hoist}
+        hoist={shouldHoist}
         ref={(popoverRef) => (this.popoverRef = popoverRef)}
       >
         <slot slot='popover-trigger'></slot>

--- a/packages/crayons-extended/custom-objects/src/components/export/co-export.e2e.ts
+++ b/packages/crayons-extended/custom-objects/src/components/export/co-export.e2e.ts
@@ -189,4 +189,120 @@ describe('fw-co-export', () => {
     );
     expect(selectedCount.textContent).toContain('2/2 selected');
   });
+
+  it('should render field with info and show info icon with tooltip', async () => {
+    const page = await newE2EPage();
+    const testValue = {
+      fields: [
+        {
+          id: 'record-id',
+          label: 'Record id',
+          selected: true,
+          info: 'It is an internal id used in the backend to distinguish the records',
+        },
+        { id: '2', label: 'Field 2', selected: false },
+      ],
+    };
+
+    await page.setContent(`<fw-co-export is-open="true"></fw-co-export>`);
+    const element = await page.find('fw-co-export');
+
+    element.setProperty('value', testValue);
+    await page.waitForChanges();
+    await page.waitForTimeout(100);
+    await page.waitForChanges();
+
+    const fields = await page.findAll('fw-co-export >>> fw-co-export-field');
+    let infoTooltip = null;
+    let fieldWithInfo = null;
+    for (const field of fields) {
+      const t = await field.find('>>> fw-tooltip');
+      if (t) {
+        infoTooltip = t;
+        fieldWithInfo = field;
+        break;
+      }
+    }
+    expect(infoTooltip).toBeTruthy();
+    const infoIcon = await fieldWithInfo.find('>>> fw-tooltip fw-icon');
+    expect(infoIcon).toBeTruthy();
+  });
+
+  it('should have tooltip hidden by default for field info in export modal', async () => {
+    const page = await newE2EPage();
+    const testValue = {
+      fields: [
+        {
+          id: 'record-id',
+          label: 'Record id',
+          selected: true,
+          info: 'Internal id for records',
+        },
+      ],
+    };
+
+    await page.setContent(`<fw-co-export is-open="true"></fw-co-export>`);
+    const element = await page.find('fw-co-export');
+
+    element.setProperty('value', testValue);
+    await page.waitForChanges();
+    await page.waitForTimeout(100);
+    await page.waitForChanges();
+
+    const fields = await page.findAll('fw-co-export >>> fw-co-export-field');
+    let infoTooltip = null;
+    for (const field of fields) {
+      const t = await field.find('>>> fw-tooltip');
+      if (t) {
+        infoTooltip = t;
+        break;
+      }
+    }
+    expect(infoTooltip).toBeTruthy();
+    const popover = await infoTooltip.find('>>> :first-child');
+    const popoverContent = popover.shadowRoot.querySelector('.popper-content');
+    expect(popoverContent.hasAttribute('data-show')).toBeFalsy();
+  });
+
+  it('should show correct info content when field info tooltip is opened', async () => {
+    const page = await newE2EPage();
+    const infoText =
+      'It is an internal id used in the backend to distinguish the records';
+    const testValue = {
+      fields: [
+        {
+          id: 'record-id',
+          label: 'Record id',
+          selected: true,
+          info: infoText,
+        },
+      ],
+    };
+
+    await page.setContent(`<fw-co-export is-open="true"></fw-co-export>`);
+    const element = await page.find('fw-co-export');
+
+    element.setProperty('value', testValue);
+    await page.waitForChanges();
+    await page.waitForTimeout(100);
+    await page.waitForChanges();
+
+    const fields = await page.findAll('fw-co-export >>> fw-co-export-field');
+    let infoTooltip = null;
+    for (const field of fields) {
+      const t = await field.find('>>> fw-tooltip');
+      if (t) {
+        infoTooltip = t;
+        break;
+      }
+    }
+    expect(infoTooltip).toBeTruthy();
+    expect(await infoTooltip.getProperty('content')).toBe(infoText);
+
+    await (infoTooltip as any).callMethod('show');
+    await page.waitForChanges();
+    const popover = await infoTooltip.find('>>> :first-child');
+    const popoverContent = popover.shadowRoot.querySelector('.popper-content');
+    expect(popoverContent.hasAttribute('data-show')).toBeTruthy();
+  });
 });

--- a/packages/crayons-extended/custom-objects/src/components/export/components/co-export-field.tsx
+++ b/packages/crayons-extended/custom-objects/src/components/export/components/co-export-field.tsx
@@ -121,7 +121,7 @@ export class CoExportField {
           {!this.addTooltip && this.renderLabel()}
         </fw-checkbox>
         {boolShowInfo && (
-          <fw-tooltip trigger='hover' content={strInfo}>
+          <fw-tooltip trigger='hover' content={strInfo} hoist>
             <fw-icon
               class={`${strBaseClassName}-fw-icon`}
               size={12}


### PR DESCRIPTION
This pull request improves the behavior and positioning of popovers and tooltips within modal dialogs, ensuring they are displayed correctly and consistently above modal overlays. The changes auto-detect when a popover or tooltip is inside a modal and adjust their positioning strategy and boundary handling accordingly. Additionally, some minor code and comment improvements are included.

**Popover and Tooltip Behavior in Modals:**

* Updated `popover.scss` to force popovers and tooltips inside modals to use `position: fixed`, a higher `z-index`, and ensure they are hoisted to the body level for correct stacking and positioning.
* In `popover.tsx`, added logic to auto-detect if the popover is inside a modal and force the Popper.js strategy to `fixed` and the boundary to `viewport` for correct placement. [[1]](diffhunk://#diff-dfbe58bb42787ba3bd477fb82d4576f6ac2965ad5212b989fd570c19a0de8c4cR199-R206) [[2]](diffhunk://#diff-dfbe58bb42787ba3bd477fb82d4576f6ac2965ad5212b989fd570c19a0de8c4cL212-R219)
* In `tooltip.tsx`, tooltips now auto-detect if they are inside a modal and set the `hoist` property accordingly, ensuring correct positioning. [[1]](diffhunk://#diff-96fd768df661fe82f12b2c1f9e3d1f1e47a64213b0503a1aba1c8fbdfc996fc7R91-R95) [[2]](diffhunk://#diff-96fd768df661fe82f12b2c1f9e3d1f1e47a64213b0503a1aba1c8fbdfc996fc7L100-R105)
* Updated usages of `fw-tooltip` in `co-export-field.tsx` to always hoist tooltips, further ensuring they display above modals.

**Minor Improvements:**

* Fixed a typo in a comment in `popover.tsx` ("posiiton" to "position").

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] My commits have standard messages as mentioned in [Contributing Guidelines](./../blob/next/CONTRIBUTING.md)
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

https://github.com/user-attachments/assets/e3ad70dd-16ee-45ea-b074-ca15b5729622


